### PR TITLE
fix: when installing deb from tmpfs such as /dev/shm/, `You can only install local deb packages` is thrown.

### DIFF
--- a/src/deb-installer/manager/AddPackageThread.cpp
+++ b/src/deb-installer/manager/AddPackageThread.cpp
@@ -59,7 +59,8 @@ bool AddPackageThread::dealInvalidPackage(QString packagePath)
     QStorageInfo info(packagePath);
 
     //判断路径信息是不是本地路径
-    if (!info.device().startsWith("/dev/")) {
+    QString device = info.device();     //获取设备信息
+    if (!device.startsWith("/dev/") && device != QString::fromLocal8Bit("tmpfs")) {
         emit signalNotLocalPackage();
         return false;
     }

--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -1013,7 +1013,8 @@ bool PackagesManager::dealInvalidPackage(QString packagePath)
 {
     QStorageInfo info(packagePath);                               //获取路径信息
 
-    if (!info.device().startsWith("/dev/")) {                            //判断路径信息是不是本地路径
+    QString device = info.device();                               //获取设备信息
+    if (!device.startsWith("/dev/") && device != QString::fromLocal8Bit("tmpfs")) {  //判断路径信息是不是本地路径
         emit signalNotLocalPackage();
         return false;
     }

--- a/src/deb-installer/view/widgets/filechoosewidget.cpp
+++ b/src/deb-installer/view/widgets/filechoosewidget.cpp
@@ -162,7 +162,8 @@ void FileChooseWidget::chooseFiles()
     // save the directory string to config file.
     QStorageInfo info(currentPackageDir);                               //获取路径信息
 
-    if (info.device().startsWith("/dev/")) {                            //判断路径信息是不是本地路径
+    QString device = info.device();                                     //获取设备信息
+    if (device.startsWith("/dev/") || device == QString::fromLocal8Bit("tmpfs")) {  //判断路径信息是不是本地路径
         m_settings.setValue("history_dir", currentPackageDir);          //本地路径，保存当前文件路径
     }
     if (mode != QDialog::Accepted) return;


### PR DESCRIPTION
变化：安装存在于诸如 /dev/shm 等 tmpfs 中的 deb 时，不再提示`只能安装本地的deb包`，而是允许安装。

注：在 V15 以及早期的 V20 中我记得都是可以直接通过 __软件包安装器__ 安装被下载到 /dev/shm 中的 deb 包的，后续是因为安全原因还是疏漏了或是其它原因不支持了呢～