### PR TITLE
fix: Segmentation fault

### DIFF
--- a/src/deb-installer/model/packageslistdelegate.cpp
+++ b/src/deb-installer/model/packageslistdelegate.cpp
@@ -291,8 +291,6 @@ void PackagesListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         painter->drawText(info_rect, info_str, Qt::AlignLeft | Qt::AlignTop);       //将提示绘制到item上
 
         painter->restore();
-    } else {
-        DStyledItemDelegate::paint(painter, option, index);
     }
 }
 


### PR DESCRIPTION
#40 的 check 炸了，翻了下记录，炸的这一段是在 https://github.com/linuxdeepin/deepin-deb-installer/commit/d4f1265d8f077eb43415fc2d92dce66c8b4758b5#diff-38d5486f28b01c4cfb157e50444ee18fac8fede6a681d9795b18c244f24ffeae 次添加的，但是单看 commit msg 没有理解具体添加这行的原因（我不太懂哈哈哈哈 :joy: ）。check 里 https://github.com/linuxdeepin/deepin-deb-installer/runs/6771987972?check_suite_focus=true#step:6:4828 这一段，报了 Segmentation fault，一路追下来就到这行了～不过这是 19 年就进仓库的代码啊，check 应该不太可能是从 19 年 fail 到现在吧？fail 是因为后来 lib-dtk 改动过吗？

也不知道我这么就删了这行对不对 :joy_cat: 

Log: fix `Segmentation fault`