### PR TITLE
fix: 修复部分机型无法正确安装带deepin-wine依赖的软件包

### DIFF
--- a/src/AptInstallDepend/installDebThread.cpp
+++ b/src/AptInstallDepend/installDebThread.cpp
@@ -101,16 +101,9 @@ void InstallDebThread::run()
             }
 
             system("echo 'libc6 libraries/restart-without-asking boolean true' | sudo debconf-set-selections\n");
-//            m_proc->start("sudo", QStringList() << "apt-get"
-//                          << "install"
-//                          << depends
-//                          << "deepin-wine-helper"
-//                          << "--fix-missing"
-//                          << "-y");
             m_proc->setProgram("sudo", QStringList() << "apt-get"
                                << "install"
                                << depends
-                               << "deepin-wine-helper"
                                << "--fix-missing"
                                << "-y");
             m_proc->start();


### PR DESCRIPTION
原因是代码中写死了必须安装deepin-wine-helper，而部分机型并无此软件包
与相关负责人沟通后，直接从代码中移除此项，完全根据软件包本身的依赖配置进行安装

Log: 修复部分机型无法正确安装带deepin-wine依赖的软件包
Bug: https://pms.uniontech.com/bug-view-145897.html