### PR TITLE
fix: 降低启动后内存占用

### DIFF
--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -43,12 +43,6 @@ class DebListModel;
 class DealDependThread;
 class AddPackageThread;
 
-/**
- * @brief init_backend 初始化后端
- * @return 初始化完成的后端指针
- */
-Backend *init_backend();
-
 struct DependInfo {
     QString packageName; //依赖的包名称
     QString version; //依赖的包的版本
@@ -193,22 +187,10 @@ signals:
 public:
 
     /**
-     * @brief isBackendReady 判断安装程序后端是否加载完成
-     * @return 安装程序后端加载的结果
-     *
-     * true: 加载完成
-     * false: 未加载完成
-     */
-    bool isBackendReady();
-
-    /**
      * @brief backend 获取后端指针
      * @return  后端的指针
      */
-    QApt::Backend *backend() const
-    {
-        return m_backendFuture.result();
-    }
+    QApt::Backend *backend();
 
 //// 包状态相关函数
 public:
@@ -516,7 +498,7 @@ private:
 private:
 
     //安装程序后端指针(异步加载)
-    QFuture<QApt::Backend *> m_backendFuture;           
+    QApt::Backend *m_backendFuture;
 
     //存放包路径的列表
     QList<QString> m_preparedPackages       = {};   
@@ -607,6 +589,8 @@ private:
     QMap<QString, PackageDependsStatus> m_checkedOrDependsStatus; //存储检测完成的或依赖包及其依赖状态
 
     QMap<QString, DependencyInfo> m_dependsInfo; //所有依赖的信息
+
+    std::once_flag backendLoadFlag; //后端加载标记
 };
 
 #endif  // PACKAGESMANAGER_H

--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -245,11 +245,6 @@ void DebListModel::slotDealDependResult(int authType, int dependIndex, QString d
     emit signalDependResult(authType, dependName);                //发送信号，由debinstaller处理界面状态。
 }
 
-bool DebListModel::isReady() const
-{
-    return m_packagesManager->isBackendReady();
-}
-
 bool DebListModel::isWorkerPrepare() const
 {
     return m_workerStatus == WorkerPrepare;
@@ -381,7 +376,7 @@ void DebListModel::slotUninstallPackage(const int index)
     if (!debFile.isValid())
         return;
     const QStringList rdepends = m_packagesManager->packageReverseDependsList(debFile.packageName(), debFile.architecture()); //检查是否有应用依赖到该包
-    Backend *backend = m_packagesManager->m_backendFuture.result();
+    Backend *backend = m_packagesManager->backend();
     for (const auto &r : rdepends) {                                        // 卸载所有依赖该包的应用（二者的依赖关系为depends）
         if (backend->package(r)) {
             // 更换卸载包的方式，remove卸载不卸载完全会在影响下次安装的依赖判断。
@@ -693,7 +688,7 @@ void DebListModel::checkBoxStatus()
 {
     QTime startTime = QTime::currentTime();                                      //获取弹出的时间
     Transaction *transation = nullptr;
-    auto *const backend = m_packagesManager->m_backendFuture.result();
+    auto *const backend = m_packagesManager->backend();
     transation = backend->commitChanges();
 
     QTime stopTime = QTime::currentTime();
@@ -726,7 +721,7 @@ void DebListModel::installDebs()
     emit signalStartInstall();
 
     // fetch next deb
-    auto *const backend = m_packagesManager->m_backendFuture.result();
+    auto *const backend = m_packagesManager->backend();
     if (!backend)
         return;
 

--- a/src/deb-installer/model/deblistmodel.h
+++ b/src/deb-installer/model/deblistmodel.h
@@ -196,12 +196,6 @@ public:
     bool isWorkerPrepare() const;
 
     /**
-     * @brief isReady 查看后端初始化的状态
-     * @return 后端是否准备就绪
-     */
-    bool isReady() const;
-
-    /**
      * @brief preparedPackages 获取当前已经添加的包的列表
      * @return 添加的包的列表
      */

--- a/tests/src/manager/ut_packagemanager.cpp
+++ b/tests/src/manager/ut_packagemanager.cpp
@@ -322,7 +322,7 @@ void UT_packagesManager::TearDown()
 {
     stub.set(ADDR(PackagesManager, rmTempDir), stub_is_open_false);
 
-    for (auto pkg : m_packageManager->m_backendFuture.result()->availablePackages()) {
+    for (auto pkg : m_packageManager->backend()->availablePackages()) {
         delete pkg;
         pkg =  nullptr;
     }
@@ -337,11 +337,6 @@ Package *packagesManager_package(const QString &)
     pkgCache::PkgIterator packageIter;
     QScopedPointer<Package> package(new Package(bac, packageIter));
     return package.get();
-}
-
-TEST_F(UT_packagesManager, PackageManager_UT_isBackendReady)
-{
-    ASSERT_TRUE(m_packageManager->isBackendReady());
 }
 
 TEST_F(UT_packagesManager, PackageManager_UT_selectedIndexRow)

--- a/tests/src/model/ut_deblistmodel.cpp
+++ b/tests/src/model/ut_deblistmodel.cpp
@@ -401,7 +401,6 @@ void ut_DebListModel_test::stubFunction()
     stub.set(ADDR(PackagesManager, getPackageMd5), model_package_getPackageMd5);
     stub.set(ADDR(PackagesManager, isArchError), model_package_isArchError);
     stub.set(ADDR(PackagesManager, getPackageDependsStatus), model_getPackageDependsStatus);
-    stub.set(ADDR(PackagesManager, isBackendReady), model_BackendReady);
     stub.set(ADDR(PackagesManager, packageWithArch), model_packageWithArch);
     stub.set(ADDR(PackagesManager, package), model_packageManager_package);
     stub.set(ADDR(PackagesManager, dealInvalidPackage), model_stub_dealInvalidPackage);
@@ -441,12 +440,6 @@ TEST_F(ut_DebListModel_test, deblistmodel_UT_reset_filestatus)
     EXPECT_TRUE(m_debListModel->m_packageOperateStatus.isEmpty());
     EXPECT_TRUE(m_debListModel->m_packageFailReason.isEmpty());
     EXPECT_TRUE(m_debListModel->m_packageFailCode.isEmpty());
-}
-
-
-TEST_F(ut_DebListModel_test, deblistmodel_UT_isReady)
-{
-    EXPECT_TRUE(m_debListModel->isReady());
 }
 
 TEST_F(ut_DebListModel_test, deblistmodel_UT_isWorkerPrepare)

--- a/tests/src/model/ut_packageslistdelegate.cpp
+++ b/tests/src/model/ut_packageslistdelegate.cpp
@@ -151,7 +151,6 @@ TEST_F(ut_packageslistdelegate_Test, packageslistdelegate_UT_paint)
     QPainter painter(m_listview);
     QStyleOptionViewItem option;
     stub.set(ADDR(Backend, init), delegate_backend_init);
-    stub.set(ADDR(PackagesManager, isBackendReady), delegate_backendReady);
     stub.set(ADDR(DebListModel, checkSystemVersion), delegate_checkSystemVersion);
 
     stub.set(ADDR(DebFile, architecture), delegate_deb_arch_i386);
@@ -187,7 +186,6 @@ TEST_F(ut_packageslistdelegate_Test, packageslistdelegate_UT_sizeHint)
     QStyleOptionViewItem option;
 
     stub.set(ADDR(Backend, init), delegate_backend_init);
-    stub.set(ADDR(PackagesManager, isBackendReady), delegate_backendReady);
     stub.set(ADDR(DebListModel, checkSystemVersion), delegate_checkSystemVersion);
 
     stub.set(ADDR(DebFile, architecture), delegate_deb_arch_i386);


### PR DESCRIPTION
原因是启动后即加载依赖解析库，导致初始内存占用较高
解决方法是延迟加载该解析库

Log: 降低启动后内存占用
Bug: https://pms.uniontech.com/bug-view-111333.html