### PR TITLE
fix: 修复UOS专用设备系统下不校验软件包签名和开发者模式

### DIFF
--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -987,9 +987,11 @@ void DebListModel::checkSystemVersion()
     // 修改获取系统版本的方式 此前为  DSysInfo::deepinType()
 
 #if (DTK_VERSION >= DTK_VERSION_CHECK(5, 2, 2, 2))
+    qInfo() << "system code(UOS): " << Dtk::Core::DSysInfo::uosEditionType();
     switch (Dtk::Core::DSysInfo::uosEditionType()) {            //获取系统的类型
 #if (DTK_VERSION > DTK_VERSION_CHECK(5, 4, 10, 0))
     case Dtk::Core::DSysInfo::UosEducation:                     //教育版
+    case Dtk::Core::DSysInfo::UosDeviceEdition:                 //专用设备版
 #endif
     case Dtk::Core::DSysInfo::UosProfessional: //专业版
     case Dtk::Core::DSysInfo::UosHome: {                     //个人版
@@ -1010,6 +1012,7 @@ void DebListModel::checkSystemVersion()
         break;
     }
 #else
+    qInfo() << "system code(Deepin): " << Dtk::Core::DSysInfo::deepinType();
     switch (Dtk::Core::DSysInfo::deepinType()) {
     case Dtk::Core::DSysInfo::DeepinDesktop:
         m_isDevelopMode = true;


### PR DESCRIPTION
原因推测是DTK新增了专用设备系统的代号，而软件内部没有增加相关的判断
解决方法是额外增加判断，判断依据和UOS专业版保持一致

Log: 修复UOS专用设备系统下不校验软件包签名和开发者模式
Bug: https://pms.uniontech.com/bug-view-148343.html