### PR TITLE
fix: 修复tab切出安装包列表后，快捷键任然可以操作安装包列表

### DIFF
--- a/src/deb-installer/model/packagelistview.cpp
+++ b/src/deb-installer/model/packagelistview.cpp
@@ -298,5 +298,14 @@ bool PackagesListView::event(QEvent *event)
             emit signalChangeItemHeight(52 + 2 * (DFontSizeManager::fontPixelSize(qGuiApp->font()) - 13));
         }
     }
+
+    //焦点切出事件
+    if(event->type() == QEvent::FocusOut) {
+        this->clearSelection();
+        m_currentIndex = -1;
+        m_currModelIndex = this->model()->index(-1, -1);
+        emit signalCurrentIndexRow(-1);
+    }
+
     return DListView::event(event);
 }


### PR DESCRIPTION
原因是没有处理焦点切出事件
解决方法是添加对应的处理代码

Log: 修复tab切出安装包列表后，快捷键任然可以操作安装包列表
Bug: https://pms.uniontech.com/bug-view-139853.html