### PR TITLE
fix: 修复无法正确安装同时为可配置的包和需要安装依赖的包

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -883,7 +883,7 @@ void PackagesManager::resetPackageDependsStatus(const int index)
     }
     // reload backend cache
     //reloadCache必须要加
-    m_backendFuture.result()->reloadCache();;
+    m_backendFuture.result()->reloadCache();
     m_packageMd5DependsStatus.remove(currentPackageMd5);  //删除当前包的依赖状态（之后会重新获取此包的依赖状态）
 }
 
@@ -1446,7 +1446,7 @@ const PackageDependsStatus PackagesManager::checkDependsPackageStatus(QSet<QStri
             return PackageDependsStatus::_break(package->name());
         }
 
-        qInfo() << "PackagesManager:" << "Check finshed for package" << package->name();
+        qInfo() << "PackagesManager:" << "Check finished for package" << package->name();
         // 修复卸载p7zip导致deepin-wine-helper被卸载的问题，Available 添加packageName
         m_dinfo.packageName = package_name;
         m_dinfo.version = package->availableVersion();


### PR DESCRIPTION
原因是软件主干流程直接进入了可配置包的安装流程，导致没有安装对应的依赖就直接进入报错流程
解决方法是先判断包是否存在依赖，优先解决依赖问题，随后再走配置安装流程

Log: 修复无法正确安装同时为可配置的包和需要安装依赖的包
Bug: https://pms.uniontech.com/bug-view-149885.html,https://pms.uniontech.com/bug-view-149635.html