### PR TITLE
fix: 修复超大安装包校验签名失败

### DIFF
--- a/src/deb-installer/utils/utils.cpp
+++ b/src/deb-installer/utils/utils.cpp
@@ -166,7 +166,7 @@ Utils::VerifyResultCode Utils::Digital_Verify(QString filepath_name)
         filepath_name = "\"" + filepath_name + "\"";
         program = program + filepath_name;
         proc.start(program);
-        proc.waitForFinished();
+        proc.waitForFinished(-1);
         const QString output = proc.readAllStandardOutput();
         const QString output1 = proc.readAllStandardError();
         qInfo() << "签名校验结果：" << output1;

--- a/src/deepin-deb-installer-dev/status/PackageSigntureStatus.cpp
+++ b/src/deepin-deb-installer-dev/status/PackageSigntureStatus.cpp
@@ -53,7 +53,7 @@ SigntureStatus PackageSigntureStatus::checkPackageSignture(QString packagePath)
         packagePath = "\"" + packagePath + "\"";
         program = program + packagePath;
         m_pCheckSignProc->start(program);
-        m_pCheckSignProc->waitForFinished();
+        m_pCheckSignProc->waitForFinished(-1);
         const QString output = m_pCheckSignProc->readAllStandardOutput();
         const QString output1 = m_pCheckSignProc->readAllStandardError();
         qInfo() << "签名校验结果：" << output1;


### PR DESCRIPTION
原因是校验签名只给了30秒时间，超时后会强制杀死进程
修改方法是去除时间限制

Log: 修复超大安装包校验签名失败