### PR TITLE
fix: debian build missing header

### DIFF
--- a/src/deepin-deb-installer-dev/status/PackageStatus.cpp
+++ b/src/deepin-deb-installer-dev/status/PackageStatus.cpp
@@ -4,6 +4,8 @@
 
 #include "PackageStatus.h"
 
+#include <unistd.h>
+
 #include <QtConcurrent>
 #include <QDebug>
 #include <QSet>


### PR DESCRIPTION
usleep function need header

Log: