### PR TITLE
fix: 修复或依赖的判断逻辑

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -1277,8 +1277,9 @@ const PackageDependsStatus PackagesManager::checkDependsPackageStatus(QSet<QStri
             }
         }
 
-        if (!dependsStatus.isBreak())
+        if (dependsStatus.status == DebListModel::DependsOk) {
             break;
+        }
     }
     return dependsStatus;
 }


### PR DESCRIPTION
原来是只要多个或关系的依赖有一个可以解决，就不继续判断后续的依赖
目前修改为多个或关系的依赖有一个是已经就绪，就不继续判断后续的依赖

Log: 修复或依赖的判断逻辑
Bug: https://pms.uniontech.com/bug-view-139517.html