### PR TITLE
fix: 拖拽较多包到软件包安装器中后，右键逐个删除包会使软件包安装器崩溃

### DIFF
--- a/src/deb-installer/model/dependgraph.cpp
+++ b/src/deb-installer/model/dependgraph.cpp
@@ -18,13 +18,13 @@ void DependGraph::addNode(const QString &packagePath, const QByteArray &md5, con
     node->md5 = md5;
 
     //建立依赖关系图
-    std::vector<DependGraphNode*> dependsInGraph;
+    std::vector<DependGraphNode *> dependsInGraph;
 
     //1.搜索当前节点的潜在依赖关系
-    for(auto &eachDepend : depends) {
-        for(auto &eachOrDepend : eachDepend) {
-            for(auto &eachNode : nodes) {
-                if(eachNode->packageName == eachOrDepend.packageName()) {
+    for (auto &eachDepend : depends) {
+        for (auto &eachOrDepend : eachDepend) {
+            for (auto &eachNode : nodes) {
+                if (eachNode->packageName == eachOrDepend.packageName()) {
                     dependsInGraph.push_back(eachNode);
                     break;
                 }
@@ -33,16 +33,16 @@ void DependGraph::addNode(const QString &packagePath, const QByteArray &md5, con
     }
 
     //2.为其他节点添加潜在依赖关系
-    for(auto &eachNode : nodes) {
+    for (auto &eachNode : nodes) {
         bool finded = false;
-        for(auto &eachDepends : eachNode->depends) {
-            for(auto &eachOrDepend : eachDepends) {
-                if(eachOrDepend.packageName() == packageName) {
+        for (auto &eachDepends : eachNode->depends) {
+            for (auto &eachOrDepend : eachDepends) {
+                if (eachOrDepend.packageName() == packageName) {
                     eachNode->dependsInGraph.push_back(node);
                     break;
                 }
             }
-            if(finded) {
+            if (finded) {
                 break;
             }
         }
@@ -54,13 +54,13 @@ void DependGraph::addNode(const QString &packagePath, const QByteArray &md5, con
 
 void addDepend(QList<QString> &paths, QList<QByteArray> &md5s, QStringList &result, DependGraphNode *node)
 {
-    if(result.contains(node->packageName)) {
+    if (result.contains(node->packageName)) {
         return;
     }
 
-    for(auto &eachDependNode : node->dependsInGraph) {
-        if(eachDependNode->dependsInGraph.empty()) {
-            if(result.contains(eachDependNode->packageName)) {
+    for (auto &eachDependNode : node->dependsInGraph) {
+        if (eachDependNode->dependsInGraph.empty()) {
+            if (result.contains(eachDependNode->packageName)) {
                 continue;
             }
             result.push_back(eachDependNode->packageName);
@@ -68,7 +68,7 @@ void addDepend(QList<QString> &paths, QList<QByteArray> &md5s, QStringList &resu
             md5s.push_back(eachDependNode->md5);
         } else {
             addDepend(paths, md5s, result, eachDependNode);
-            if(result.contains(eachDependNode->packageName)) {
+            if (result.contains(eachDependNode->packageName)) {
                 continue;
             }
             result.push_back(eachDependNode->packageName);
@@ -83,14 +83,14 @@ std::pair<QList<QString>, QList<QByteArray>> DependGraph::getBestInstallQueue() 
     QStringList result;
     QList<QString> paths;
     QList<QByteArray> md5s;
-    for(size_t i = 0;i != nodes.size();++i) {
-        if(result.contains(nodes[i]->packageName)) {
+    for (size_t i = 0; i != nodes.size(); ++i) {
+        if (result.contains(nodes[i]->packageName)) {
             continue;
         }
         //添加前置依赖
         addDepend(paths, md5s, result, nodes[i]);
         //添加本体
-        if(result.contains(nodes[i]->packageName)) {
+        if (result.contains(nodes[i]->packageName)) {
             continue;
         }
         result.push_back(nodes[i]->packageName);
@@ -102,7 +102,7 @@ std::pair<QList<QString>, QList<QByteArray>> DependGraph::getBestInstallQueue() 
 
 void DependGraph::reset()
 {
-    for(auto &node : nodes) {
+    for (auto &node : nodes) {
         delete node;
     }
     nodes.clear();
@@ -110,11 +110,26 @@ void DependGraph::reset()
 
 void DependGraph::remove(const QByteArray &md5)
 {
-    for(size_t i = 0;i != nodes.size();++i) {
-        if(nodes[i]->md5 == md5) {
+    for (size_t i = 0; i != nodes.size(); ++i) {
+        if (nodes[i]->md5 == md5) {
+            //删除包需要更新依赖图(bug 179891)
+            removeInGraph(nodes[i]);
             delete nodes[i];
             nodes.erase(nodes.begin() + static_cast<int>(i));
             break;
+        }
+    }
+}
+
+void DependGraph::removeInGraph(const DependGraphNode *dependnode)
+{
+    //清除当前节点潜在依赖
+    for (auto eachNode : nodes) {
+        for (size_t i = 0; i != eachNode->dependsInGraph.size(); ++i) {
+            if (eachNode->dependsInGraph[i] == dependnode) {
+                eachNode->dependsInGraph.erase(eachNode->dependsInGraph.begin() + static_cast<int>(i));
+                break;
+            }
         }
     }
 }

--- a/src/deb-installer/model/dependgraph.h
+++ b/src/deb-installer/model/dependgraph.h
@@ -10,13 +10,12 @@
 
 #include <vector>
 
-struct DependGraphNode
-{
+struct DependGraphNode {
     QString packageName;
     QString packagePath;
     QByteArray md5;
     QList<QApt::DependencyItem> depends;
-    std::vector<DependGraphNode*> dependsInGraph;
+    std::vector<DependGraphNode *> dependsInGraph;
 };
 
 class DependGraph
@@ -30,7 +29,9 @@ public:
 
     void reset();
     void remove(const QByteArray &md5);
+protected:
+    void removeInGraph(const DependGraphNode *dependnode);
 
 private:
-    std::vector<DependGraphNode*> nodes;
+    std::vector<DependGraphNode *> nodes;
 };


### PR DESCRIPTION
Description: 删除包指针释放，但是依赖图表里面存放的包指针没有删除，导致访问野指针程序崩溃。在删除包的时候，需要同步删除依赖图表里面 的包指针。

Log: 拖拽较多包到软件包安装器中后，右键逐个删除包会使软件包安装器崩溃

Bug: https://pms.uniontech.com/bug-view-179891.html