### PR TITLE
fix: 修复签名校验失败

### DIFF
--- a/src/deb-installer/utils/utils.cpp
+++ b/src/deb-installer/utils/utils.cpp
@@ -149,7 +149,7 @@ Utils::VerifyResultCode Utils::Digital_Verify(const QString &filepath_name)
     if (result_verify_file) {
         QProcess proc;
         QString program = "/usr/bin/deepin-deb-verify";
-        proc.start(program, {"\"" + filepath_name + "\""});
+        proc.start(program, {filepath_name});
         proc.waitForFinished(-1);
         const QString output1 = proc.readAllStandardError();
         qInfo() << "签名校验结果：" << output1;


### PR DESCRIPTION
原因是之前在V23分支上修cppcheck问题时，修改了对验签工具的调用参数，导致传入的路径前后多了两个冒号
解决方法是去掉冒号

Log: 修复签名校验失败
Bug: https://pms.uniontech.com/bug-view-186037.html