### PR TITLE
fix: 修复单个deb包安装时可以用alt+f4退出

### DIFF
--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -374,7 +374,6 @@ void DebInstaller::disableCloseAndExit()
     if (tbar) {
         tbar->setQuitMenuDisabled(true);
     }
-
 }
 
 void DebInstaller::enableCloseAndExit()
@@ -909,6 +908,12 @@ void DebInstaller::slotShowHiddenButton()
 
 void DebInstaller::closeEvent(QCloseEvent *event)
 {
+    DTitlebar *tbar = this->titlebar();
+    if (tbar && tbar->quitMenuIsDisabled()) {
+        event->ignore();
+        return;
+    }
+
     PackageAnalyzer::instance().setUiExit();
     DMainWindow::closeEvent(event);
 }


### PR DESCRIPTION
原因是没有对close event做处理，导致可以使用alt+f4进入
解决方法是在close event里监控外部控件的状态，当无法使用控件按钮退出时，同时不允许相关事件通过

Log: 修复单个deb包安装时可以用alt+f4退出
Bug: https://pms.uniontech.com/bug-view-192353.html