### PR TITLE
fix: 修复重复添加同一deb包，无toast提示

### DIFF
--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -636,7 +636,7 @@ void DebInstaller::slotShowNotLocalPackageMessage()
 
 void DebInstaller::slotShowPkgExistMessage()
 {
-    if (m_ddimView == nullptr) { //如果选择界面未创建，则表示是第一次进入且只有必装包和依赖包
+    if (SingleInstallerApplication::mode == SingleInstallerApplication::DdimChannel && m_ddimView == nullptr) { //如果选择界面未创建，则表示是第一次进入且只有必装包和依赖包
         slotShowSelectInstallPage({});
         return;
     }


### PR DESCRIPTION
原因是被DDIM流程的特殊处理覆盖了
解决方法是加上额外判断，防止被DDIM流程覆盖

Log: 修复重复添加同一deb包，无toast提示
Bug: https://pms.uniontech.com/bug-view-192371.html