### PR TITLE
fix: 修复卸载包过程中进度条可能会归零

### DIFF
--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -618,7 +618,6 @@ void SingleInstallPage::slotShowInfo()
     m_infoControlButton->setVisible(true);
     m_showDependsButton->setVisible(false);
     m_progressFrame->setVisible(true);
-    m_progress->setValue(0);
 
     //清空提示  此处可优化 m_tipsLabel->setVisiable(true);
     m_tipsLabel->clear();


### PR DESCRIPTION
原因是当可以读取中间信息时，将进度条置为零
解决方法是去除对应代码

Log: 修复卸载包过程中进度条可能会归零
Bug: https://pms.uniontech.com/bug-view-192377.html