### PR TITLE
fix: 修复apt初始化界面的文本不是活动色，无法跟随控制中心设置变化

### DIFF
--- a/src/deb-installer/view/widgets/noprocesswidget.cpp
+++ b/src/deb-installer/view/widgets/noprocesswidget.cpp
@@ -20,12 +20,21 @@ NoProcessWidget::NoProcessWidget(QWidget *parent)
 
     actionTextLabel = new Dtk::Widget::DLabel;
     Dtk::Widget::DFontSizeManager::instance()->bind(actionTextLabel, Dtk::Widget::DFontSizeManager::T6, QFont::Medium);
-    actionTextLabel->setForegroundRole(Dtk::Gui::DPalette::LightLively);
+
+    Dtk::Gui::DPalette pe;
+    pe.setColor(QPalette::WindowText, Dtk::Gui::DGuiApplicationHelper::instance()->applicationPalette().highlight().color());
+    actionTextLabel->setPalette(pe);
 
     auto allLayer = new QVBoxLayout;
     allLayer->addWidget(spinner, 0, Qt::AlignHCenter | Qt::AlignBottom);
     allLayer->addWidget(actionTextLabel, 0, Qt::AlignHCenter | Qt::AlignTop);
     setLayout(allLayer);
+
+    connect(Dtk::Gui::DGuiApplicationHelper::instance(), &Dtk::Gui::DGuiApplicationHelper::applicationPaletteChanged, [this]() {
+        Dtk::Gui::DPalette pe;
+        pe.setColor(QPalette::WindowText, Dtk::Gui::DGuiApplicationHelper::instance()->applicationPalette().highlight().color());
+        actionTextLabel->setPalette(pe);
+    });
 }
 
 void NoProcessWidget::start()


### PR DESCRIPTION
原因是直接设置的固定颜色
解决方法是添加自动变色机制

Log: 修复apt初始化界面的文本不是活动色，无法跟随控制中心设置变化
Bug: https://pms.uniontech.com/bug-view-187389.html