### PR TITLE
fix: 修复收起图标与信息的间距过近

### DIFF
--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -81,6 +81,7 @@ void DebInstaller::initUI()
 
     //初始化 加载文件选择widget
     m_centralLayout->addWidget(m_fileChooseWidget);
+    m_lastPage = m_fileChooseWidget;
     m_centralLayout->setContentsMargins(0, 0, 0, 0);
     m_centralLayout->setSpacing(0);
 
@@ -738,10 +739,9 @@ void DebInstaller::slotReset()
     m_fileListModel->reset();                                               // 重置model
 
     // 删除所有的页面
-    if (!m_lastPage.isNull()) {
+    if (!m_lastPage.isNull() && m_lastPage != m_fileChooseWidget) {
         m_lastPage->deleteLater();
     }
-    //m_centralLayout->setCurrentIndex(0);
     m_centralLayout->setCurrentWidget(m_fileChooseWidget);
 
     this->setAcceptDrops(true);
@@ -783,7 +783,9 @@ void DebInstaller::single2Multi()
     // 刷新文件的状态，初始化包的状态为准备状态
     m_fileListModel->resetFileStatus();
     m_fileListModel->initPrepareStatus();
-    if (!m_lastPage.isNull()) m_lastPage->deleteLater();                    //清除widgets缓存
+    if (!m_lastPage.isNull() && m_lastPage != m_fileChooseWidget) {
+        m_lastPage->deleteLater();                    //清除widgets缓存
+    }
 
     // multiple packages install
     titlebar()->setTitle(tr("Bulk Install"));
@@ -817,7 +819,9 @@ void DebInstaller::refreshSingle()
     m_fileListModel->resetFileStatus();
     m_fileListModel->initPrepareStatus();
     // clear widgets if needed
-    if (!m_lastPage.isNull()) m_lastPage->deleteLater();                    //清除widgets缓存
+    if (!m_lastPage.isNull() && m_lastPage != m_fileChooseWidget) {
+        m_lastPage->deleteLater();                    //清除widgets缓存
+    }
     //安装器中只有一个包，刷新单包安装页面
     //刷新成单包安装界面时，删除标题
     titlebar()->setTitle(QString());

--- a/src/deb-installer/view/pages/multipleinstallpage.cpp
+++ b/src/deb-installer/view/pages/multipleinstallpage.cpp
@@ -35,7 +35,7 @@ MultipleInstallPage::MultipleInstallPage(DebListModel *model, QWidget *parent)
     , m_backButton(new DPushButton(this))
     , m_acceptButton(new DPushButton(this))
 
-    // fix bug:33999 change DButton to DCommandLinkButton for Activity color
+      // fix bug:33999 change DButton to DCommandLinkButton for Activity color
     , m_tipsLabel(new DCommandLinkButton("", this))
     , m_dSpinner(new DSpinner(this))
 {
@@ -153,7 +153,7 @@ void MultipleInstallPage::initUI()
     m_appsListView->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     //监听字体大小变化,设置高度
-    connect(m_appsListView, &PackagesListView::signalChangeItemHeight,delegate, &PackagesListDelegate::getItemHeight);
+    connect(m_appsListView, &PackagesListView::signalChangeItemHeight, delegate, &PackagesListDelegate::getItemHeight);
 
     //使用代理重绘listView
     m_appsListView->setItemDelegate(delegate);
@@ -337,7 +337,7 @@ void MultipleInstallPage::initConnections()
     connect(m_debListModel, &DebListModel::signalChangeOperateIndex, this, &MultipleInstallPage::slotAutoScrollInstallList);
 
     //点击安装包列表时，向后端传递当前选中行
-    connect(m_appsListView, &PackagesListView::signalCurrentIndexRow, this, [=](int row) {
+    connect(m_appsListView, &PackagesListView::signalCurrentIndexRow, this, [ = ](int row) {
         m_debListModel->selectedIndexRow(row);
     });
 
@@ -410,6 +410,10 @@ void MultipleInstallPage::slotShowInfo()
     m_appsListViewBgFrame->setVisible(false);               //隐藏applistView
     m_appsListView->setVisible(false);
     m_installProcessInfoView->setVisible(true);             //显示相关安装进度信息
+
+    auto contentsMargins = m_infoControlButton->contentsMargins();
+    contentsMargins.setBottom(5);
+    m_infoControlButton->setContentsMargins(contentsMargins);
 }
 
 void MultipleInstallPage::slotHideInfo()


### PR DESCRIPTION
修复收起图标与信息的间距过近
补充修复pr#178引起的无法从启动器或者双击图标进入软件包安装器问题（卡初始化apt界面）

Log: 修复收起图标与信息的间距过近
Bug: https://pms.uniontech.com/bug-view-157601.html