### PR TITLE
fix: 修复卸载包的时候会卡apt初始化界面

### DIFF
--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -850,13 +850,13 @@ void DebInstaller::refreshSingle()
 SingleInstallPage *DebInstaller::backToSinglePage()
 {
     // 获取当前的页面并删除
-    QWidget *confirmPage = m_centralLayout->widget(2);
+    QWidget *confirmPage = m_centralLayout->widget(3);
     if (nullptr == confirmPage)
         return nullptr;
     m_centralLayout->removeWidget(confirmPage);
     confirmPage->deleteLater();
 
-    SingleInstallPage *singleInstallPage = qobject_cast<SingleInstallPage *>(m_centralLayout->widget(1));           //获取单包安装widget
+    SingleInstallPage *singleInstallPage = qobject_cast<SingleInstallPage *>(m_centralLayout->widget(2));           //获取单包安装widget
     if (!singleInstallPage) {
         return nullptr;
     }


### PR DESCRIPTION
原因是原始代码中的界面层级是使用数字进行硬编码，导致删除了错误的层级
解决方法是修正编码的数值

Log: 修复卸载包的时候会卡apt初始化界面
Bug: https://pms.uniontech.com/bug-view-192377.html