### PR TITLE
fix: 移除对 deepin-elf-sign-tool 的强依赖

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://www.deepin.com/
 
 Package: deepin-deb-installer
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libqapt3-runtime, libqapt3, deepin-elf-verify, deepin-elf-sign-tool
+Depends: ${shlibs:Depends}, ${misc:Depends}, libqapt3-runtime, libqapt3, deepin-elf-verify
 Description: Package Installer helps users install and remove local packages.
  Package Installer is an easy-to-use .deb package management tool 
  with a simple interface for users to quickly install customized applications


### PR DESCRIPTION
master 分支不应强依赖 deepin-elf-sign-tool 工具，
移除对应配置。

Log: 移除对 deepin-elf-sign-tool 的强依赖
Influence: 安装依赖