### PR TITLE
chore: Update version to 6.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deb-installer (6.0.8) unstable; urgency=medium
+
+  * fix: 移除对 deepin-elf-sign-tool 的强依赖(Influence: 安装依赖)
+
+ -- Deepin Packages Builder <packages@deepin.org>  Fri, 07 Apr 2023 15:59:52 +0800
+
 deepin-deb-installer (6.0.5) unstable; urgency=medium
 
   * Update version


### PR DESCRIPTION
Update version to 6.0.8
修复：
1. 移除对 deepin-elf-sign-tool 的强依赖，
    * https://github.com/linuxdeepin/deepin-deb-installer/pull/186
 
Log: Update version to 6.0.8