### PR TITLE
fix: 移除安装依赖 deepin-elf-verify

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://www.deepin.com/
 
 Package: deepin-deb-installer
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libqapt3-runtime, libqapt3, deepin-elf-verify
+Depends: ${shlibs:Depends}, ${misc:Depends}, libqapt3-runtime, libqapt3
 Description: Package Installer helps users install and remove local packages.
  Package Installer is an easy-to-use .deb package management tool 
  with a simple interface for users to quickly install customized applications


### PR DESCRIPTION
移除安装依赖 deepin-elf-verify , control 文件移除对应配置。
master 分支不提供签名校验。

Log: 移除安装依赖 deepin-elf-verify
Bug: https://pms.uniontech.com/bug-view-195557.html
Influence: 安装依赖