### PR TITLE
feat: 添加应用安装分级验签处理策略

### DIFF
--- a/assets/data/deepin-deb-installer.json
+++ b/assets/data/deepin-deb-installer.json
@@ -9,7 +9,7 @@
                     {
                         "key": "",
                         "name": "",
-                        "type": "checkbox",
+                        "type": "verifycheckbox",
                         "text": "Check digital signatures if the developer mode is enabled",
                         "default": false
                     }

--- a/src/deb-installer/utils/hierarchicalverify.cpp
+++ b/src/deb-installer/utils/hierarchicalverify.cpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "hierarchicalverify.h"
+
+#include <QDBusInterface>
+#include <QDBusReply>
+#include <QDBusError>
+#include <QDebug>
+
+// 分级管控DBus接口信息
+const char DBUS_HIERARCHICAL_BUS[] = "com.deepin.daemon.ACL";
+const char DBUS_HIERARCHICAL_PATH[] = "/org/deepin/security/hierarchical/Control";
+const char DBUS_HIERARCHICAL_INTERFACE[] = "org.deepin.security.hierarchical.Control";
+const char DBUS_HIERARCHICAL_METHOD[] = "Availabled";
+
+// 匹配正则,%1为错误码
+const char VERIFY_ERROR_REGEXP[] = "(deepin)+[^\\n]*(hook)+[^\\n]*%1";
+
+/**
+   @brief dpkg校验错误码，当前仅验签错误
+ */
+enum HierarchicalError {
+    VerifyError = 65280,  ///< dpkg hook 签名校验错误码
+};
+
+/**
+   @class HierarchicalVerify
+   @brief 分级管控签名校验辅助类
+   @details 配合【安全中心】分级管控，实现不同的安装包管理策略，进行签名验证
+    1. 当分级管控接口不可用时，使用安装器校验，@sa `Utils::Digital_Verify`
+    2. 当分级管控控件可用时，采用dpkg hook方式调用验签工具，错误码信息通过命令行输出，
+       安装器接收输出信息并判断是否为验签错误。
+ */
+
+HierarchicalVerify::HierarchicalVerify() {}
+
+HierarchicalVerify::~HierarchicalVerify() {}
+
+/**
+   @return 返回分级管控签名校验辅助类实例
+ */
+HierarchicalVerify *HierarchicalVerify::instance()
+{
+    static HierarchicalVerify ins;
+    return &ins;
+}
+
+/**
+   @return 返回当前分级管控签名验证是否可用，此信息通过查询DBus接口属性值取得。
+ */
+bool HierarchicalVerify::isValid()
+{
+    if (interfaceInvalid) {
+        return false;
+    }
+
+    bool availabled = checkHierarchicalInterface();
+    if (valid != availabled) {
+        valid = availabled;
+
+        // 分级验签不可用时，清理当前缓存数据
+        if (!valid) {
+            clearVerifyResult();
+        }
+
+        Q_EMIT validChanged(valid);
+    }
+
+    return valid;
+}
+
+/**
+   @brief 检测软件包 \a pkgName 安装失败时的错误信息 \a errorString 中是否包含验签不通过的错误信息。
+
+   @warning 通过正则表达式匹配输出，当前通过 hook 标志和错误码 65280 匹配，需注意命令行输出信息更新未正常匹配的情况
+ */
+bool HierarchicalVerify::checkTransactionError(const QString &pkgName, const QString &errorString)
+{
+    static QRegExp s_ErrorReg(QString(VERIFY_ERROR_REGEXP).arg(VerifyError));
+    if (errorString.contains(s_ErrorReg)) {
+        invalidPackages.insert(pkgName);
+        return true;
+    }
+
+    return false;
+}
+
+/**
+   @return 返回软件包 \a pkgName 是否通过校验，这个信息从校验缓存中获取，
+    通过 `clearVerifyResult` 移除
+ */
+bool HierarchicalVerify::pkgVerifyPassed(const QString &pkgName)
+{
+    return !invalidPackages.contains(pkgName);
+}
+
+/**
+   @brief 移除缓存中的校验结果
+ */
+void HierarchicalVerify::clearVerifyResult()
+{
+    invalidPackages.clear();
+}
+
+/**
+   @brief 检测当前系统环境下是否包含分级管控接口，并取值判断接口是否可用。
+ */
+bool HierarchicalVerify::checkHierarchicalInterface()
+{
+    bool availabled = false;
+    QDBusInterface interface(
+        DBUS_HIERARCHICAL_BUS, DBUS_HIERARCHICAL_PATH, DBUS_HIERARCHICAL_INTERFACE, QDBusConnection::systemBus());
+
+    if (interface.isValid()) {
+        QDBusMessage message = interface.call(DBUS_HIERARCHICAL_METHOD);
+        QDBusError error = interface.lastError();
+        if (QDBusError::NoError != error.type()) {
+            qWarning() << QString("[Hierarchical] DBus %1 read property %2 error: type(%2) [%3] %4")
+                              .arg(DBUS_HIERARCHICAL_BUS)
+                              .arg(DBUS_HIERARCHICAL_METHOD)
+                              .arg(error.type())
+                              .arg(error.name())
+                              .arg(error.message());
+
+            // QDBusInterface 在构造时不一定能判断接口是否有效，调用后二次判断
+            if (!interface.isValid() || QDBusError::UnknownInterface == error.type() ||
+                QDBusError::InvalidInterface == error.type()) {
+                interfaceInvalid = true;
+                qWarning() << QString("[Hierarchical] Interface %1 is not valid! Disable check hierarchical control interface.")
+                                  .arg(DBUS_HIERARCHICAL_INTERFACE);
+            }
+        } else {
+            QDBusReply<bool> reply(message);
+            availabled = reply.value();
+
+            qInfo() << QString("[Hierarchical] Get %1 property %2 value: %3")
+                           .arg(DBUS_HIERARCHICAL_BUS)
+                           .arg(DBUS_HIERARCHICAL_METHOD)
+                           .arg(availabled);
+        }
+    } else {
+        interfaceInvalid = true;
+        qWarning() << QString("[Hierarchical] DBus interface %1 invalid! error: [%2] %3")
+                          .arg(DBUS_HIERARCHICAL_INTERFACE)
+                          .arg(interface.lastError().name())
+                          .arg(interface.lastError().message());
+    }
+
+    return availabled;
+}

--- a/src/deb-installer/utils/hierarchicalverify.h
+++ b/src/deb-installer/utils/hierarchicalverify.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef HIERARCHICALVERIFY_H
+#define HIERARCHICALVERIFY_H
+
+#include <QObject>
+#include <QSet>
+
+class HierarchicalVerify : public QObject
+{
+    Q_OBJECT
+    explicit HierarchicalVerify();
+    ~HierarchicalVerify() override;
+
+public:
+    static HierarchicalVerify *instance();
+
+    bool isValid();
+    bool checkTransactionError(const QString &pkgName, const QString &errorString);
+    bool pkgVerifyPassed(const QString &pkgName);
+    void clearVerifyResult();
+
+    Q_SIGNAL void validChanged(bool valid);
+
+private:
+    bool checkHierarchicalInterface();
+
+private:
+    bool valid = false;                 ///< 分级管控是否开启
+    bool interfaceInvalid = false;      ///< DBus接口是否有效
+    QSet<QString> invalidPackages;      ///< 验签失败的包集合
+
+    Q_DISABLE_COPY(HierarchicalVerify)
+};
+
+#endif  // HIERARCHICALVERIFY_H

--- a/src/deb-installer/view/pages/settingdialog.cpp
+++ b/src/deb-installer/view/pages/settingdialog.cpp
@@ -3,10 +3,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "settingdialog.h"
+#include "utils/hierarchicalverify.h"
+
 #include <DSettingsWidgetFactory>
 #include <DStandardPaths>
 #include <DCheckBox>
 
+#include <QApplication>
 #include <QDir>
 #include <qsettingbackend.h>
 #include <QDebug>
@@ -26,9 +29,14 @@ SettingDialog::~SettingDialog()
 
 void SettingDialog::init()
 {
+    // 设置默认的校验勾选框
+    if (widgetFactory()) {
+        widgetFactory()->registerWidget("verifycheckbox", &SettingDialog::createVerifyCheckBox);
+    }
+
     m_setting = DSettings::fromJsonFile(":/data/deepin-deb-installer.json");
     setFocus(Qt::PopupFocusReason);
-    const QString confDir = DStandardPaths::writableLocation(QStandardPaths::AppConfigLocation); // 换了枚举值，待验证
+    const QString confDir = DStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);  // 换了枚举值，待验证
 
     const QString confPath = confDir + QDir::separator() + "deepin-deb-installer.conf";
     QDir dir;
@@ -51,10 +59,55 @@ void SettingDialog::init()
         m_isDigital = m_setting->value("basic.develop_digital_verify.").toBool();
     });
     m_isDigital = m_setting->value("basic.develop_digital_verify.").toBool();
-
 }
 
 bool SettingDialog::isDigitalVerified()
 {
     return m_setting->value("basic.develop_digital_verify.").toBool();
+}
+
+/**
+   @return 根据传入的设置参数 \a obj 创建用于配置校验信息的勾选框，
+    存在分级管控接口时，静止配置验签功能，选项置灰。
+ */
+QWidget *SettingDialog::createVerifyCheckBox(QObject *obj)
+{
+    auto translateContext = obj->property("_d_DSettingsWidgetFactory_translateContext").toByteArray();
+    auto option = qobject_cast<DTK_CORE_NAMESPACE::DSettingsOption *>(obj);
+    auto value = option->data("text").toString();
+    QString trName;
+    if (translateContext.isEmpty()) {
+        trName = QObject::tr(value.toStdString().c_str());
+    } else {
+        trName = qApp->translate(translateContext, value.toStdString().c_str());
+    }
+    DCheckBox *checkBox = new DCheckBox(trName);
+
+    checkBox->setObjectName("OptionVerifyCheckbox");
+    checkBox->setAccessibleName("OptionVerifyCheckbox");
+
+    // 分级管控模式下，不允许设置安装器验签
+    checkBox->setEnabled(!HierarchicalVerify::instance()->isValid());
+    QObject::connect(HierarchicalVerify::instance(), &HierarchicalVerify::validChanged, checkBox, [=](bool valid) {
+        checkBox->setEnabled(!valid);
+    });
+
+    checkBox->setChecked(option->value().toBool());
+    option->connect(checkBox, &QCheckBox::stateChanged, option, [=](int status) { option->setValue(status == Qt::Checked); });
+    option->connect(option, &DTK_CORE_NAMESPACE::DSettingsOption::valueChanged, checkBox, [=](const QVariant &value) {
+        checkBox->setChecked(value.toBool());
+        checkBox->update();
+    });
+
+    return checkBox;
+}
+
+/**
+   @brief 处理显示事件，此处用于展示前刷新分级管控接口状态
+ */
+void SettingDialog::showEvent(QShowEvent *e)
+{
+    // 刷新分级管控接口状态
+    (void)HierarchicalVerify::instance()->isValid();
+    DSettingsDialog::showEvent(e);
 }

--- a/src/deb-installer/view/pages/settingdialog.h
+++ b/src/deb-installer/view/pages/settingdialog.h
@@ -22,12 +22,14 @@ public:
     void init();
     bool isDigitalVerified();
 
-signals:
+    static QWidget *createVerifyCheckBox(QObject *obj);
 
-public slots:
+protected:
+    void showEvent(QShowEvent *e) override;
+
 private:
     DSettings *m_setting;
     bool m_isDigital = false;
 };
 
-#endif // SETTINGDIALOG_H
+#endif  // SETTINGDIALOG_H


### PR DESCRIPTION
新版系统引入分级管控进行应用安装分级验签，
添加HierarchicalVerify用于获取分级管控接口，
判断是否进入分级管控流程。根据错误返回值判断
是否为分级管控验签失败错误。

Log: 添加应用安装分级验签处理策略
Influence: 签名校验