### PR TITLE
feat: 添加分级验签正确处理wine依赖应用提示

### DIFF
--- a/src/deb-installer/manager/DealDependThread.h
+++ b/src/deb-installer/manager/DealDependThread.h
@@ -68,6 +68,8 @@ private:
 
     //依赖安装状态是否错误的标识
     bool bDependsStatusErr      = false;
+    // 分级管控验签失败的标识
+    bool bVerifyStatusErr       = false;
 
     //下载失败的依赖的名称
     QString m_brokenDepend      ="";

--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -668,11 +668,11 @@ void PackagesManager::slotDealDependResult(int iAuthRes, int iIndex, const QStri
         }
         emit signalEnableCloseButton(true);
     }
-    if (iAuthRes == DebListModel::AuthDependsErr || iAuthRes == DebListModel::AnalysisErr) {
+    if (iAuthRes == DebListModel::AuthDependsErr || iAuthRes == DebListModel::AnalysisErr || iAuthRes == DebListModel::VerifyDependsErr) {
         for (int num = 0; num < m_dependInstallMark.size(); num++) {
             m_packageMd5DependsStatus[m_dependInstallMark.at(num)].status = DebListModel::DependsBreak;//更换依赖的存储结构
             if (!m_errorIndex.contains(m_dependInstallMark[num]))
-                m_errorIndex.push_back(m_dependInstallMark[num]);
+                m_errorIndex.insert(m_dependInstallMark[num], iAuthRes);
         }
         if (installWineDepends) { //下载wine依赖失败时，考虑出现依赖缺失的情况
             qInfo() << "check wine depends again !" << iIndex;

--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -320,10 +320,6 @@ public:
      */
     void resetPackageDependsStatus(const int index);
 
-public:
-
-    QList<QByteArray> m_errorIndex;        //wine依赖错误的包的下标
-
 //// 依赖查找 获取等相关函数
 private:
 
@@ -506,6 +502,8 @@ private:
     void getBlackApplications();
 
 private:
+    QMap<QByteArray, int> m_errorIndex;        //wine依赖错误的包的下标 QMap<MD5, DebListModel::DependsAuthStatus>
+
     //存放包路径的列表
     QList<QString> m_preparedPackages       = {};
 

--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -614,8 +614,15 @@ QString DebListModel::packageFailedReason(const int idx) const
         return tr("The administrator has set policies to prevent installation of this package");
     if (dependStatus.isBreak() || dependStatus.isAuthCancel()) {                                            //依赖状态错误
         if (!dependStatus.package.isEmpty() || !m_brokenDepend.isEmpty()) {
-            if (m_packagesManager->m_errorIndex.contains(md5))     //修改wine依赖的标记方式
-                return tr("Failed to install %1").arg(m_brokenDepend); //wine依赖安装失败
+            if (m_packagesManager->m_errorIndex.contains(md5)) {    //修改wine依赖的标记方式
+                auto ret = static_cast<DebListModel::DependsAuthStatus>(m_packagesManager->m_errorIndex.value(md5));
+                switch (ret) {
+                   case DebListModel::VerifyDependsErr:
+                       return m_brokenDepend + tr("Invalid digital signature");
+                    default:
+                        return tr("Failed to install %1").arg(m_brokenDepend); //wine依赖安装失败
+                }
+            }
             return tr("Broken dependencies: %1").arg(dependStatus.package);                         //依赖不满足
         }
 

--- a/src/deb-installer/model/deblistmodel.h
+++ b/src/deb-installer/model/deblistmodel.h
@@ -150,6 +150,7 @@ public:
         AuthDependsSuccess, //安装成功
         AuthDependsErr,     //安装失败
         AnalysisErr,        //解析错误
+        VerifyDependsErr,   //验证签名失败(分级管控)
     };
 
     enum ErrorCode {

--- a/src/deb-installer/view/pages/multipleinstallpage.cpp
+++ b/src/deb-installer/view/pages/multipleinstallpage.cpp
@@ -529,6 +529,7 @@ void MultipleInstallPage::DealDependResult(int authStatus, QString dependName)
     case DebListModel::AuthDependsSuccess:      //依赖安装成功
     case DebListModel::AuthDependsErr:          //依赖安装错误
     case DebListModel::AnalysisErr:             //解析错误
+    case DebListModel::VerifyDependsErr:        //依赖验签失败
         m_appsListView->setEnabled(true);       //listView可以操作
         m_installButton->setVisible(true);      //显示安装按钮
         m_installButton->setEnabled(true);      //安装按钮可用

--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -1011,6 +1011,11 @@ void SingleInstallPage::DealDependResult(int authStatus, QString dependName)
         m_tipsLabel->setText(tr("Failed to install %1").arg(dependName));
         m_tipsLabel->setCustomDPalette(DPalette::TextWarning);
         break;
+    case DebListModel::VerifyDependsErr:
+        setCancelAuthOrAuthDependsErr();
+        m_tipsLabel->setText(dependName + tr("Invalid digital signature"));
+        m_tipsLabel->setCustomDPalette(DPalette::TextWarning);
+        break;
     default:
         break;
     }


### PR DESCRIPTION
安装wine添加正确校验分级验证输出错误信息，
并在单页/批量安装展示页正确显示错误信息。

Log: 添加分级验签正确处理wine依赖应用提示
Influence: wine依赖安装包签名验证