### PR TITLE
feat: 添加分级验签时DDIM流程界面逻辑处理

### DIFF
--- a/src/deb-installer/model/deblistmodel.h
+++ b/src/deb-installer/model/deblistmodel.h
@@ -634,8 +634,10 @@ private:
 
     /**
      * @brief showNoDigitalErrWindow 弹出数字签名校验错误的错误弹窗
+     * @param recordError 是否记录错误信息，引入分级验签后，允许只提示验签错误信息，
+     *  不涉及状态切换及更新记录
      */
-    void showDigitalErrWindow();
+    void showDigitalErrWindow(bool recordError = true);
 
     /**
      * @brief showDevelopDigitalErrWindow 开发者模式下弹出数字签名无效的弹窗

--- a/src/deb-installer/utils/hierarchicalverify.cpp
+++ b/src/deb-installer/utils/hierarchicalverify.cpp
@@ -81,6 +81,7 @@ bool HierarchicalVerify::checkTransactionError(const QString &pkgName, const QSt
     static QRegExp s_ErrorReg(QString(VERIFY_ERROR_REGEXP).arg(VerifyError));
     if (errorString.contains(s_ErrorReg)) {
         invalidPackages.insert(pkgName);
+        qWarning() << QString("[Hierarchical] Package %1 detected hierarchical error!").arg(pkgName);
         return true;
     }
 


### PR DESCRIPTION
添加分级验签DDIM流程时，安装失败弹出DDIM签名验证失败弹窗时，
不在弹窗处触发状态切换，以正确切换状态。

Log: 添加分级验签时DDIM流程界面逻辑处理
Influence: 分级验签 DDIM