### PR TITLE
test: 添加分级管控UT代码

### DIFF
--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -908,7 +908,7 @@ void DebListModel::showNoDigitalErrWindowInDdimProcess(void (DebListModel::*fail
 
     auto fullPath = m_packagesManager->package(m_operatingIndex);
     QFileInfo info(fullPath);
-    Ddialog->setMessage(QString(tr("Failed to install %1: no valid digital singature").arg(info.fileName())));
+    Ddialog->setMessage(QString(tr("Failed to install %1: no valid digital singature").arg(info.fileName())) + QString("!"));
 
     //消息框reject后的操作，包括点击取消按钮、关闭图标、按ESC退出
     std::function<void(void)> rejectOperate = [this, Ddialog, failedFunction]() {
@@ -1004,7 +1004,7 @@ void DebListModel::showDigitalErrWindow(bool recordError)
 
     // 设置弹出窗口显示的信息
     Ddialog->setTitle(tr("Unable to install"));
-    Ddialog->setMessage(QString(tr("This package does not have a valid digital signature")));
+    Ddialog->setMessage(QString(tr("This package does not have a valid digital signature")) + QString("!"));
     Ddialog->setIcon(QIcon::fromTheme("di_popwarning"));
     Ddialog->addButton(QString(tr("OK", "button")), true, DDialog::ButtonNormal);
     Ddialog->show();

--- a/tests/src/manager/ut_packagemanager.cpp
+++ b/tests/src/manager/ut_packagemanager.cpp
@@ -329,11 +329,6 @@ void UT_packagesManager::TearDown()
 {
     stub.set(ADDR(PackagesManager, rmTempDir), stub_is_open_false);
 
-    for (auto pkg : PackageAnalyzer::instance().backendPtr()->availablePackages()) {
-        delete pkg;
-        pkg =  nullptr;
-    }
-
     delete m_packageManager;
 }
 

--- a/tests/src/ut_singleInstallerApplication.cpp
+++ b/tests/src/ut_singleInstallerApplication.cpp
@@ -5,6 +5,7 @@
 #include "../deb-installer/singleInstallerApplication.h"
 #include "../deb-installer/utils/utils.h"
 #include "../deb-installer/view/pages/debinstaller.h"
+#include "../deb-installer/utils/hierarchicalverify.h"
 
 #include <stub.h>
 #include <ut_Head.h>
@@ -18,6 +19,11 @@
 void stud_singleaAppProcess(const QCoreApplication &app)
 {
     Q_UNUSED(app);
+}
+
+bool stub_SingleInstallerApplication_HierarchicalVerify_Invalid()
+{
+    return false;
 }
 
 class SingleInstallerApplication_UT : public UT_HEAD
@@ -81,11 +87,16 @@ TEST_F(SingleInstallerApplication_UT, UT_SingleInstallerApplication_checkDepends
     singleInstaller->activateWindow();
     EXPECT_EQ(2, singleInstaller->checkDependsStatus("test.db"));
 }
+
 TEST_F(SingleInstallerApplication_UT, UT_SingleInstallerApplication_checkDigitalSignature)
 {
+    Stub stub;
+    stub.set(ADDR(HierarchicalVerify, isValid), stub_SingleInstallerApplication_HierarchicalVerify_Invalid);
+
     singleInstaller->activateWindow();
     EXPECT_EQ(0, singleInstaller->checkDigitalSignature("test.db"));
 }
+
 TEST_F(SingleInstallerApplication_UT, UT_SingleInstallerApplication_getPackageInfo)
 {
     singleInstaller->activateWindow();

--- a/tests/src/utils/ut_hierarchicalverify.cpp
+++ b/tests/src/utils/ut_hierarchicalverify.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../deb-installer/utils/hierarchicalverify.h"
+
+#include <QSignalSpy>
+#include <QDBusInterface>
+
+#include <stub.h>
+
+#include <gtest/gtest.h>
+
+class ut_HierarchicalVerify_TEST : public ::testing::Test
+{
+protected:
+    void SetUp();
+    void TearDown();
+};
+
+void ut_HierarchicalVerify_TEST::SetUp() {}
+
+void ut_HierarchicalVerify_TEST::TearDown()
+{
+    HierarchicalVerify::instance()->invalidPackages.clear();
+}
+
+// Stub functions.
+bool stub_checkHierarchicalInterface_true()
+{
+    return true;
+}
+
+bool stub_dbus_isValid_false()
+{
+    return false;
+}
+
+static bool stub_switchValid = true;
+bool stub_checkHierarchicalInterface_switch()
+{
+    return stub_switchValid;
+}
+
+TEST_F(ut_HierarchicalVerify_TEST, isValid_WithInterface_True)
+{
+    Stub stub;
+    stub.set(ADDR(HierarchicalVerify, checkHierarchicalInterface), stub_checkHierarchicalInterface_true);
+
+    ASSERT_TRUE(HierarchicalVerify::instance()->isValid());
+}
+
+TEST_F(ut_HierarchicalVerify_TEST, isValid_NoInterface_False)
+{
+    Stub stub;
+    stub.set(ADDR(QDBusAbstractInterface, isValid), stub_dbus_isValid_false);
+
+    ASSERT_FALSE(HierarchicalVerify::instance()->isValid());
+    ASSERT_TRUE(HierarchicalVerify::instance()->interfaceInvalid);
+}
+
+TEST_F(ut_HierarchicalVerify_TEST, checkTransactionError_TestRegExp_True)
+{
+    auto hVerify = HierarchicalVerify::instance();
+    ASSERT_TRUE(hVerify->checkTransactionError("pkg", "deepinhook65280"));
+    ASSERT_TRUE(hVerify->checkTransactionError("pkg", "\r\ndeepindeehook+++65280\n"));
+    ASSERT_TRUE(hVerify->checkTransactionError("pkg2", "deepinhookhook65280"));
+    ASSERT_TRUE(hVerify->checkTransactionError("pkg2", "Error:deepin hook exit code 65280"));
+
+    QSet<QString> pkgSet{"pkg", "pkg2"};
+    ASSERT_EQ(hVerify->invalidPackages, pkgSet);
+}
+
+TEST_F(ut_HierarchicalVerify_TEST, checkTransactionError_TestRegExp_False)
+{
+    auto hVerify = HierarchicalVerify::instance();
+    ASSERT_FALSE(hVerify->checkTransactionError("pkg", ""));
+    ASSERT_FALSE(hVerify->checkTransactionError("pkg", "deepihoo65280"));
+    ASSERT_FALSE(hVerify->checkTransactionError("pkg", "\r\ndeepin\ndeehook+++65280\n"));
+    ASSERT_FALSE(hVerify->checkTransactionError("pkg2", "deepinh-ookh-ook65280"));
+    ASSERT_FALSE(hVerify->checkTransactionError("pkg2", "Error:deepin hook \n exit code 65280"));
+
+    ASSERT_TRUE(hVerify->invalidPackages.isEmpty());
+}
+
+TEST_F(ut_HierarchicalVerify_TEST, validChanged_Notify_Count)
+{
+    auto hVerify = HierarchicalVerify::instance();
+    QSignalSpy spy(hVerify, SIGNAL(validChanged(bool)));
+
+    Stub stub;
+    stub.set(ADDR(HierarchicalVerify, checkHierarchicalInterface), stub_checkHierarchicalInterface_switch);
+    hVerify->valid = false;
+    hVerify->interfaceInvalid = false;
+    stub_switchValid = true;
+
+    ASSERT_TRUE(hVerify->isValid());
+    stub_switchValid = false;
+    ASSERT_FALSE(hVerify->isValid());
+
+    ASSERT_EQ(spy.count(), 2);
+}
+
+TEST_F(ut_HierarchicalVerify_TEST, verifyResult_Store_True)
+{
+    auto hVerify = HierarchicalVerify::instance();
+    hVerify->invalidPackages.insert("deb");
+
+    // Passed when not contains invalid package name.
+    ASSERT_TRUE(hVerify->pkgVerifyPassed(""));
+    ASSERT_FALSE(hVerify->pkgVerifyPassed("deb"));
+
+    hVerify->clearVerifyResult();
+    ASSERT_TRUE(hVerify->pkgVerifyPassed("deb"));
+}


### PR DESCRIPTION
添加分级管控UT代码，覆盖分级管控接口，
直接调用接口部分代码，并对可能影响其它
功能的分级管控接口在测试时进行关闭处理

Log: 添加分级管控UT代码
Influence: UT