### PR TITLE
fix: Remove package will remove "breaks" reverse depends.

### DIFF
--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -370,6 +370,18 @@ private:
                                            const QList<DependencyItem> &conflicts,
                                            const QList<DependencyItem> &replaces);
 
+//// 依赖查找 获取查找包是否为消极的反向依赖
+private:
+    /**
+     * @brief isNegativeReverseDepend 判断软件包 `reverseDepend` 是否是 `packageName` 的消极依赖包，
+     *      例如 冲突(Conflict)/替换(Replace)/破坏(Breaks) 这些包在卸载时将被跳过，
+     *      在 依赖(Depends) 字段设置包将不会被视为消极包。
+     * @param packageName   当前处理的软件包
+     * @param reverseDepend `packageName` 的反向依赖包
+     * @return `reverseDepend` 是否为 `packageName` 的消极依赖
+     */
+    bool isNegativeReverseDepend(const QString &packageName, const QApt::Package *reverseDepend);
+
 private:
     /**
      * @brief packageWithArch 从指定的架构上打包

--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -376,6 +376,8 @@ void DebListModel::slotUninstallPackage(const int index)
     if (!debFile.isValid())
         return;
     const QStringList rdepends = m_packagesManager->packageReverseDependsList(debFile.packageName(), debFile.architecture()); //检查是否有应用依赖到该包
+    qInfo() << QString("Will remove reverse depends before remove %1 , Lists:").arg(debFile.packageName()) << rdepends;
+    
     Backend *backend = PackageAnalyzer::instance().backendPtr();
     for (const auto &r : rdepends) {                                        // 卸载所有依赖该包的应用（二者的依赖关系为depends）
         if (backend->package(r)) {


### PR DESCRIPTION
卸载软件包时过滤标记为 Conflict/Replace/Break 的反向依赖包,
这些依赖包并非直接依赖待卸载的软件包,仅移除标记为 Depends 的包.

Log: 修复卸载软件包时卸载了标记"破坏"的反向依赖包
Bug: https://pms.uniontech.com/bug-view-208617.html
Influence: UninstallPcakge