### PR TITLE
fix: Dialog text disappear when using large font size.

### DIFF
--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -1633,6 +1633,17 @@ void DebListModel::showHierarchicalVerifyWindow()
     dialog->addButton(QString(tr("Proceed", "button")), true, DDialog::ButtonRecommend);
     dialog->show();
 
+    // 拷贝自 ddialog.cpp 用于设置默认对话框高度，避免在大字号/高缩放比下显示不全，在 show() 之后调用。
+    QLabel *msgLabel = dialog->findChild<QLabel *>("MessageLabel");
+    if (msgLabel) {
+        auto dialogStyle = dialog->style();
+        if (dialogStyle) {
+            QSize sz = dialogStyle->itemTextRect(msgLabel->fontMetrics(), msgLabel->rect(),
+                                                 Qt::TextWordWrap, false, msgLabel->text()).size();
+            msgLabel->setMinimumHeight(qMax(sz.height(), msgLabel->sizeHint().height()));
+        }
+    }
+
     QPushButton *btnPorceed = qobject_cast<QPushButton *>(dialog->getButton(1));
     btnPorceed->setFocusPolicy(Qt::TabFocus);
     btnPorceed->setFocus();


### PR DESCRIPTION
对话框默认布局过宽,仅限制默认宽度,欠考虑大字号下
默认对话框高度,在初始化时调整内容最低高度.

Log: 对话框字体在大字号下显示不全
Bug: https://pms.uniontech.com/bug-view-201611.html
Influence: DialogText