### PR TITLE
fix: Fix package conflicts and replaces depends error.

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -376,7 +376,7 @@ const ConflictResult PackagesManager::packageConflictStat(const int index)
     DebFile debfile(m_preparedPackages[index]);
     if (!debfile.isValid())
         return ConflictResult::err("");
-    ConflictResult ConflictResult = isConflictSatisfy(debfile.architecture(), debfile.conflicts());
+    ConflictResult ConflictResult = isConflictSatisfy(debfile.architecture(), debfile.conflicts(), debfile.replaces());
     return ConflictResult;
 }
 
@@ -394,7 +394,7 @@ const ConflictResult PackagesManager::isConflictSatisfy(const QString &arch, Pac
         return ret_installed;
     }
 
-    const auto conflictStatus = isConflictSatisfy(arch, package->conflicts());
+    const auto conflictStatus = isConflictSatisfy(arch, package->conflicts(), package->replaces());
 
     return conflictStatus;
 }
@@ -755,7 +755,7 @@ PackageDependsStatus PackagesManager::getPackageDependsStatus(const int index)
     }
 
     // conflicts
-    const ConflictResult debConflitsResult = isConflictSatisfy(architecture, debFile.conflicts());
+    const ConflictResult debConflitsResult = isConflictSatisfy(architecture, debFile.conflicts(), debFile.replaces());
 
     if (!debConflitsResult.is_ok()) {
         qWarning() << "PackagesManager:" << "depends break because conflict" << debFile.packageName();
@@ -1054,7 +1054,7 @@ void PackagesManager::packageCandidateChoose(QSet<QString> &choosed_set, const Q
             }
         }
 
-        if (!isConflictSatisfy(debArch, package->conflicts()).is_ok())
+        if (!isConflictSatisfy(debArch, package->conflicts(), package->replaces()).is_ok())
             continue;
 
         QSet<QString> upgradeDependsSet = choosed_set;

--- a/src/deepin-deb-installer-dev/status/PackageStatus.h
+++ b/src/deepin-deb-installer-dev/status/PackageStatus.h
@@ -146,7 +146,7 @@ private:
      * @return     冲突的结果
      */
     const ConflictResult isConflictSatisfy(const QString &arch, QApt::Package *package);
-    const ConflictResult isConflictSatisfy(const QString &arch, const QList<QApt::DependencyItem> &conflicts);
+    const ConflictResult isConflictSatisfy(const QString &arch, const QList<QApt::DependencyItem> &conflicts, const QList<QApt::DependencyItem> &replaces = {});
 
 
     /**


### PR DESCRIPTION
在判断冲突包标识时,仅考虑conflicts,未处理conflicts和
replaces结合使用的场景,更新判断replaces标识.
* 更新了 PackagesManager 的UT.

Log: 修复conflicts和replaces结合使用报告冲突的问题
Bug: https://pms.uniontech.com/bug-view-214693.html
Influence: PackageInstall