### PR TITLE
chore: Update version to 6.0.15

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deb-installer (6.0.15) unstable; urgency=medium
+
+  * fix: Fix package conflicts and replaces depends error.(Bug: 214693)(Influence: PackageInstall)
+
+ -- renbin <renbin@uniontech.com>  Wed, 30 Aug 2023 16:30:14 +0800
+
 deepin-deb-installer (6.0.13) unstable; urgency=medium
 
   * test: Add hierarchical notify unit test case.(Influence: UnitTest)


### PR DESCRIPTION
Update version to 6.0.15
相关PR：
* https://github.com/linuxdeepin/deepin-deb-installer/pull/220

Log: Update version to 6.0.15