### PR TITLE
fix: Install wine package depends detection error.

### DIFF
--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -513,6 +513,11 @@ private:
      */
     void getBlackApplications();
 
+    /**
+       @brief 过滤已安装或无需更新的Wine软件包
+     */
+    void filterNeedInstallWinePackage(QStringList &dependList, const DebFile &debFile, const QHash<QString, DependencyInfo>& dependInfoMap);
+
 private:
     QMap<QByteArray, int> m_errorIndex;        //wine依赖错误的包的下标 QMap<MD5, DebListModel::DependsAuthStatus>
 


### PR DESCRIPTION
Wine包升降级依赖中i386、amd64架构混用，和安装包
架构不同，使用主线基于包架构的版本存在识别错误。
修改Wine包依赖识别逻辑，未标识架构的将使用默认
包顺序，并判断安装包版本。

Log: 修复安装、升降级Wine应用依赖冲突的问题
Influence: Wine
Change-Id: I1b0b571133cfca62e3ab44887ce7492a7ad170d8