### PR TITLE
fix: Fix wine depends detect error.

### DIFF
--- a/src/deb-installer/main.cpp
+++ b/src/deb-installer/main.cpp
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
 
     QAccessible::installFactory(accessibleFactory);//自动化测试
 
-    qDebug() << qApp->applicationName() << "started, version = " << qApp->applicationVersion();
+    qInfo() << qApp->applicationName() << "started, version = " << qApp->applicationVersion();
 
     QDBusConnection dbus = QDBusConnection::sessionBus();
     if (app.parseCmdLine()) {

--- a/src/deb-installer/manager/DealDependThread.cpp
+++ b/src/deb-installer/manager/DealDependThread.cpp
@@ -86,4 +86,6 @@ void DealDependThread::slotInstallFinished(int num = -1)
         emit signalDependResult(DebListModel::AuthDependsErr, m_index, m_brokenDepend);
     }
     emit signalEnableCloseButton(true);
+
+    qInfo() << qPrintable("Process(apt) install finished, num: ") << num << qPrintable("Depends list:") << m_dependsList;
 }

--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -341,11 +341,12 @@ private:
      * @param choosed_set   包的依赖候选的集合
      * @param debArch       包的架构
      * @param dependsList   依赖列表
+       @param levelInfo     提供用于打印的软件包查找层级依赖信息
      */
     void packageCandidateChoose(QSet<QString> &choosed_set, const QString &debArch,
-                                const QList<QApt::DependencyItem> &dependsList);
+                                const QList<QApt::DependencyItem> &dependsList, const QString& levelInfo);
     void packageCandidateChoose(QSet<QString> &choosed_set, const QString &debArch,
-                                const QApt::DependencyItem &candidateItem);
+                                const QApt::DependencyItem &candidateItem, const QString &levelInfo);
 
     /**
      * @brief isInstalledConflict 是否存在下载冲突

--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -394,6 +394,16 @@ private:
     QApt::Package *packageWithArch(const QString &packageName, const QString &sysArch,
                                    const QString &annotation = QString());
 
+    /**
+     * @brief checkPackageArchValid 检测通过包名 \a packageName 获取的软件包 \a package 架构
+     *      是否支持建议架构 \a suggestArch
+     * @param package       软件包
+     * @param packageName   软件包名称
+     * @param resloveArch   解析建议的软件包名称
+     * @return 软件包 \a package 支持 \a suggestArch 架构
+     */
+    bool checkPackageArchValid(const QApt::Package *package, const QString &packageName, const QString &suggestArch);
+
 private:
 
     // 卸载deepin-wine-plugin-virture 时无法卸载deepin-wine-helper. Temporary solution：Special treatment for these package

--- a/src/deb-installer/model/deblistmodel.h
+++ b/src/deb-installer/model/deblistmodel.h
@@ -747,6 +747,11 @@ private:
      */
     void initRefreshPageConnecions();
 
+    /**
+       @brief printDependsChanges 打印安装的依赖包变更
+     */
+    void printDependsChanges();
+
 private:
     //当前工作状态
     int m_workerStatus                  = 0;

--- a/tests/src/manager/ut_packagemanager.cpp
+++ b/tests/src/manager/ut_packagemanager.cpp
@@ -2028,7 +2028,7 @@ TEST_F(UT_packagesManager, PackageManager_UT_packageCandidateChoose)
                                                              const QList<QApt::DependencyItem> &))
              ADDR(PackagesManager, checkDependsPackageStatus), stub_checkDependsPackageStatus);
 
-    m_packageManager->packageCandidateChoose(choosed_set, debArch, cadicateList);
+    m_packageManager->packageCandidateChoose(choosed_set, debArch, cadicateList, QString());
     EXPECT_EQ("", debArch);
     EXPECT_EQ(1, choosed_set.size());
     EXPECT_EQ(1, cadicateList.size());
@@ -2063,7 +2063,7 @@ TEST_F(UT_packagesManager, PackageManager_UT_packageCandidateChoose_1)
                                                              const QList<QApt::DependencyItem> &))
              ADDR(PackagesManager, checkDependsPackageStatus), stub_checkDependsPackageStatus);
 
-    m_packageManager->packageCandidateChoose(choosed_set, debArch, cadicateList);
+    m_packageManager->packageCandidateChoose(choosed_set, debArch, cadicateList, QString());
     EXPECT_EQ("", debArch);
     EXPECT_EQ(1, choosed_set.size());
     EXPECT_EQ(1, cadicateList.size());
@@ -2098,7 +2098,7 @@ TEST_F(UT_packagesManager, PackageManager_UT_packageCandidateChoose_2)
                                                              const QList<QApt::DependencyItem> &))
              ADDR(PackagesManager, checkDependsPackageStatus), stub_checkDependsPackageStatus_ok);
 
-    m_packageManager->packageCandidateChoose(choosed_set, debArch, cadicateList);
+    m_packageManager->packageCandidateChoose(choosed_set, debArch, cadicateList, QString());
     EXPECT_EQ("", debArch);
     EXPECT_EQ(2, choosed_set.size());
     EXPECT_EQ(1, cadicateList.size());
@@ -2132,7 +2132,7 @@ TEST_F(UT_packagesManager, PackageManager_UT_packageCandidateChoose_3)
                                                              const QList<QApt::DependencyItem> &))
              ADDR(PackagesManager, checkDependsPackageStatus), stub_checkDependsPackageStatus_ok);
 
-    m_packageManager->packageCandidateChoose(choosed_set, debArch, cadicateList);
+    m_packageManager->packageCandidateChoose(choosed_set, debArch, cadicateList, QString());
     EXPECT_EQ("", debArch);
     EXPECT_EQ(0, choosed_set.size());
     EXPECT_EQ(1, cadicateList.size());
@@ -2167,7 +2167,7 @@ TEST_F(UT_packagesManager, PackageManager_UT_packageCandidateChoose_4)
                                                              const QList<QApt::DependencyItem> &))
              ADDR(PackagesManager, checkDependsPackageStatus), stub_checkDependsPackageStatus_ok);
 
-    m_packageManager->packageCandidateChoose(choosed_set, debArch, cadicateList);
+    m_packageManager->packageCandidateChoose(choosed_set, debArch, cadicateList, QString());
     EXPECT_EQ("", debArch);
     EXPECT_EQ(1, choosed_set.size());
     EXPECT_EQ(1, cadicateList.size());


### PR DESCRIPTION
在递归解析软件包依赖时，统一使用了安装包架构而不是
指向的软件包架构，修改为基于依赖包架构继续解析。
例如：i386软件包可能依赖amd64软件包，对amd64软件包
的依赖将以amd64架构解析，而不是统一使用i386架构。

添加判断是否指定安装包架构类型，未指定的依赖包
将按照安装包架构进行判断。
部分软件包提供多架构支持，例如部分 amd64 软件包
同样提供 i386 支持。

Bug: https://pms.uniontech.com/bug-view-220943.html
Bug: https://pms.uniontech.com/bug-view-220019.html