### PR TITLE
fix: Detect Provides/Or dependencies error.

### DIFF
--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -578,6 +578,13 @@ private:
     QMap<QByteArray, QPair<QList<DependInfo>, QList<DependInfo>>> m_dependsPackages;
     DependInfo m_dinfo; //依赖包的包名及版本
 
+    /**
+       @brief m_loopErrorDeepends 循环判断依赖时缓存非 Ok 的前置包状态
+        用于对 OR 或依赖及 Provides 虚包依赖在循环中依赖中返回前置已检测的包状态，
+        而不是直接返回 Ok .
+     */
+    QHash<QString, int> m_loopErrorDeepends;
+
     // wine应用处理的下标
     int m_DealDependIndex = -1;
 


### PR DESCRIPTION
修复同时存在虚包依赖/或依赖时检测错误,
旧版流程基于包不会重复给出ok结果,
引入考虑虚包场景,检测包和实际包名不一致,
导致依赖包未能正常安装.

含虚包依赖/或依赖检测过程:
1. 检测前清理缓存状态;
2. 顺序遍历(后续依赖可能已安装)或依赖;
3. 依赖中存在非ok依赖,缓存包依赖状态;
4. 检测到重复包,返回缓存状态,而不是直接返回ok.

Issue: https://pms.uniontech.com/bug-view-212307.html
Influence: ProvidesDepends OrDepends