### PR TITLE
fix: or/provides depends error when first pkg fails.

### DIFF
--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -335,7 +335,7 @@ private:
     const PackageDependsStatus checkDependsPackageStatus(QSet<QString> &choosed_set, const QString &architecture,
                                                          const QApt::DependencyItem &candicate);
     const PackageDependsStatus checkDependsPackageStatus(QSet<QString> &choosed_set, const QString &architecture,
-                                                         const QApt::DependencyInfo &dependencyInfo);
+                                                         const QApt::DependencyInfo &dependencyInfo, const QString &providesName = QString::null);
     /**
      * @brief packageCandidateChoose   查找包的依赖候选
      * @param choosed_set   包的依赖候选的集合

--- a/tests/src/manager/ut_packagemanager.cpp
+++ b/tests/src/manager/ut_packagemanager.cpp
@@ -1190,7 +1190,8 @@ const PackageDependsStatus stub_checkDependsPackageStatus_ok(QSet<QString> &, co
 
 const PackageDependsStatus stub_checkDependsPackageStatus_DI(QSet<QString> &,
                                                              const QString &,
-                                                             const DependencyInfo &)
+                                                             const DependencyInfo &,
+                                                             const QString &)
 {
     return PackageDependsStatus::_break("1");
 }
@@ -1232,7 +1233,8 @@ TEST_F(UT_packagesManager, PackageManager_UT_getPackageDependsStatus_06)
 
     stub.set((const PackageDependsStatus(PackagesManager::*)(QSet<QString> &,
                                                              const QString &,
-                                                             const DependencyInfo &))
+                                                             const DependencyInfo &,
+                                                             const QString &))
              ADDR(PackagesManager, checkDependsPackageStatus), stub_checkDependsPackageStatus_DI);
 
 
@@ -1293,7 +1295,8 @@ TEST_F(UT_packagesManager, PackageManager_UT_getPackageDependsStatus_07)
 
     stub.set((const PackageDependsStatus(PackagesManager::*)(QSet<QString> &,
                                                              const QString &,
-                                                             const DependencyInfo &))
+                                                             const DependencyInfo &,
+                                                             const QString &))
              ADDR(PackagesManager, checkDependsPackageStatus), stub_checkDependsPackageStatus_DI);
 
     stub.set(ADDR(QThread, isRunning), stub_isRunning);


### PR DESCRIPTION
或包中包含虚包时，仅匹配了第一个虚包提供包,
不能自动切换到其它提供包，调整或包依赖解析，
将续保所有实现包添加到或包依赖列表中，满足遍历。

Log: 修复虚包、或包共用依赖满足问题
Influence: ProvidesDepends