### PR TITLE
fix: not responding to template settings input.

### DIFF
--- a/src/AptInstallDepend/installDebThread.cpp
+++ b/src/AptInstallDepend/installDebThread.cpp
@@ -8,6 +8,12 @@
 InstallDebThread::InstallDebThread()
 {
     m_proc = new KProcess;
+
+    // Note: 目前 deepin-deb-installer 使用 KPty 捕获所有通道进行设置，因此旧版的
+    // installDebThread 手动捕获输入流程不再响应。
+    // 修改输入模式为响应主进程输入，而不是手动管理。
+    m_proc->setInputChannelMode(QProcess::ForwardedInputChannel);
+
     connect(m_proc, SIGNAL(finished(int)), this, SLOT(onFinished(int)));
     connect(m_proc, SIGNAL(readyReadStandardOutput()), this, SLOT(on_readoutput()));
 }

--- a/tests/src/manager/ut_packagemanager.cpp
+++ b/tests/src/manager/ut_packagemanager.cpp
@@ -2015,6 +2015,7 @@ TEST_F(UT_packagesManager, PackageManager_UT_packageCandidateChoose)
 
     stub.set(ADDR(PackagesManager, packageWithArch), stub_avaialbe_packageWithArch);
 
+    stub.set(ADDR(Package, version), package_version);
     stub.set(ADDR(Package, installedVersion), package_installedVersion);
     stub.set(ADDR(Package, compareVersion), ut_packagesManager_compareVersion);
     stub.set(ADDR(Package, name), package_name);
@@ -2050,6 +2051,7 @@ TEST_F(UT_packagesManager, PackageManager_UT_packageCandidateChoose_1)
 
     stub.set(ADDR(PackagesManager, packageWithArch), stub_avaialbe_packageWithArch);
 
+    stub.set(ADDR(Package, version), package_version);
     stub.set(ADDR(Package, installedVersion), package_version);
     stub.set(ADDR(Package, compareVersion), package_compareVersion1);
     stub.set(ADDR(Package, name), package_name);
@@ -2085,6 +2087,7 @@ TEST_F(UT_packagesManager, PackageManager_UT_packageCandidateChoose_2)
 
     stub.set(ADDR(PackagesManager, packageWithArch), stub_avaialbe_packageWithArch);
 
+    stub.set(ADDR(Package, version), package_version);
     stub.set(ADDR(Package, installedVersion), package_version);
     stub.set(ADDR(Package, compareVersion), package_compareVersion1);
     stub.set(ADDR(Package, name), package_name);
@@ -2120,6 +2123,7 @@ TEST_F(UT_packagesManager, PackageManager_UT_packageCandidateChoose_3)
 
     stub.set(ADDR(PackagesManager, packageWithArch), stub_avaialbe_packageWithArch);
 
+    stub.set(ADDR(Package, version), package_version);
     stub.set(ADDR(Package, installedVersion), package_version);
     stub.set(ADDR(Package, compareVersion), package_compareVersion2);
     stub.set(ADDR(Package, name), package_name);
@@ -2154,6 +2158,7 @@ TEST_F(UT_packagesManager, PackageManager_UT_packageCandidateChoose_4)
 
     stub.set(ADDR(PackagesManager, packageWithArch), stub_avaialbe_packageWithArch);
 
+    stub.set(ADDR(Package, version), package_version);
     stub.set(ADDR(Package, installedVersion), package_version);
     stub.set(ADDR(Package, compareVersion), package_compareVersion1);
     stub.set(ADDR(Package, name), package_name);


### PR DESCRIPTION
目前 deepin-deb-installer 使用 KPty 捕获所有通道
进行设置，因此旧版的 installDebThread 手动捕获
输入流程不再响应。
修改输入模式为响应主进程输入，而不是手动管理。

Log: 修复未响应模板设置输入.
Influence: Templates