### PR TITLE
fix: Conflicts contain pkg name install failed.

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -454,6 +454,16 @@ const ConflictResult PackagesManager::isInstalledConflict(const QString &package
         if (pkgName != packageName)
             continue;
 
+        /* 部分特殊软件包 conflicts 包名和当前包名一致，若一致，则认为无效
+           e.g.:
+            Pakcage: ImageEnhance
+            Conflicts: ImageEnhance
+            Replaces: ImageEnhnace
+        */
+        if (pkg->name() == info.first) {
+            continue;
+        }
+
         // pass if arch not match
         if (!pkgArch.isEmpty() && pkgArch != packageArch && pkgArch != "any" && pkgArch != "native")
             continue;


### PR DESCRIPTION
在包冲突包名中含当前包名时，包安装过滤了这类场景，
但已安装包冲突检测没有，导致后续包升降级时，已安装
包冲突项和当前包一致，出现依赖冲突。
调整安装策略和apt一致，允许安装冲突包名和当前包名
一致的包。

Log: 修复特殊依赖安装冲突
Bug: https://pms.uniontech.com/bug-view-233895.html
Influence: Conflicts