### PR TITLE
chore: [Community] Bump version to 6.0.19

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-deb-installer (6.0.19) unstable; urgency=medium
+
+  * fix: Update qapt version check.
+  * fix: Conflicts contain pkg name install failed.(Bug: 233895)
+
+ -- renbin <renbin@uniontech.com> Tue, 12 Dec 2023 16:54:52 +0800
+
 deepin-deb-installer (6.0.18) unstable; urgency=medium
 
   * fix: Fix package conflicts and replaces depends error.(Bug: 214693)(Influence: PackageInstall)


### PR DESCRIPTION
[Community] Bump version to 6.0.19
PR:
* https://github.com/linuxdeepin/deepin-deb-installer/pull/237
* https://github.com/linuxdeepin/deepin-deb-installer/pull/239

Log: [Community] Bump version to 6.0.19