### PR TITLE
fix: Set default focus widget on each page

### DIFF
--- a/src/deb-installer/view/pages/multipleinstallpage.cpp
+++ b/src/deb-installer/view/pages/multipleinstallpage.cpp
@@ -347,6 +347,8 @@ void MultipleInstallPage::slotWorkerFinshed()
     //安装结束显示返回和确认按钮
     m_acceptButton->setVisible(true);
     m_backButton->setVisible(true);
+    m_acceptButton->setFocus();
+
     m_processFrame->setVisible(false);                  //隐藏进度条
     //当前安装结束后，不允许调出右键菜单
     m_appsListView->setRightMenuShowStatus(false);      //安装结束不允许删除包
@@ -486,6 +488,7 @@ void MultipleInstallPage::slotDependPackages(DependsPair dependPackages, bool in
 void MultipleInstallPage::setEnableButton(bool bEnable)
 {
     m_installButton->setEnabled(bEnable);//设置按钮是否可用
+    m_installButton->setFocus();
     if (bEnable) {                     //按钮可用时刷新一次model 保证所有的包都能显示出来
         m_appsListView->reset();
     }
@@ -496,6 +499,7 @@ void MultipleInstallPage::afterGetAutherFalse()
     m_processFrame->setVisible(false);          //隐藏进度条
     m_infoControlButton->setVisible(false);     //隐藏infoControlButton
     m_installButton->setVisible(true);          //显示安装按钮
+    m_installButton->setFocus();
     m_infoControlButton->shrink();              //收缩安装信息，下次出现时是收缩的
 
     //授权取消或授权失败后，允许右键菜单弹出
@@ -522,6 +526,7 @@ void MultipleInstallPage::DealDependResult(int authStatus, QString dependName)
         m_appsListView->setEnabled(true);       //appListView可用
         m_installButton->setVisible(true);      //安装按钮可见并可用
         m_installButton->setEnabled(true);
+        m_installButton->setFocus();
         break;
     case DebListModel::AuthConfirm:             //确认授权
         m_appsListView->setEnabled(false);      //listView不可用
@@ -538,6 +543,7 @@ void MultipleInstallPage::DealDependResult(int authStatus, QString dependName)
         m_appsListView->setEnabled(true);       //listView可以操作
         m_installButton->setVisible(true);      //显示安装按钮
         m_installButton->setEnabled(true);      //安装按钮可用
+        m_installButton->setFocus();
         m_dSpinner->stop();                     //隐藏并停止安装动画
         m_dSpinner->hide();
         m_tipsLabel->setVisible(false);         //隐藏依赖安装提示

--- a/src/deb-installer/view/pages/packageselectview.cpp
+++ b/src/deb-installer/view/pages/packageselectview.cpp
@@ -19,6 +19,11 @@ PackageSelectView::PackageSelectView(QWidget *parent)
     , selectAllBox(new QCheckBox(tr("Select all")))
     , installButton(new QPushButton(tr("Install", "button")))
 {
+    this->setFocusPolicy(Qt::NoFocus);
+    selectAllBox->setFocusPolicy(Qt::StrongFocus);
+    installButton->setFocusPolicy(Qt::StrongFocus);
+    installButton->setDefault(true);
+
     //全选+安装
     auto bottomLayout = new QHBoxLayout;
     bottomLayout->addWidget(selectAllBox);
@@ -53,6 +58,14 @@ void PackageSelectView::onInstallClicked()
         }
     }
     emit packageInstallConfim(selectIndexes);
+}
+
+void PackageSelectView::showEvent(QShowEvent *e)
+{
+    QWidget::showEvent(e);
+
+    // 首次展示焦点在全选(默认安装是被禁用的)
+    selectAllBox->setFocus();
 }
 
 void PackageSelectView::selectAll(bool select)

--- a/src/deb-installer/view/pages/packageselectview.h
+++ b/src/deb-installer/view/pages/packageselectview.h
@@ -31,6 +31,9 @@ signals:
 public slots:
     void onInstallClicked();
 
+protected:
+    void showEvent(QShowEvent *e) override;
+
 private:
     void clearDebList();
 

--- a/src/deb-installer/view/pages/singleinstallpage.h
+++ b/src/deb-installer/view/pages/singleinstallpage.h
@@ -62,6 +62,10 @@ public slots:
     void slotUninstallCurrentPackage();
 
 protected:
+    /**
+       @brief 每次切换展示当前页面，复位焦点状态
+     */
+    void showEvent(QShowEvent *e) override;
     void paintEvent(QPaintEvent *event) override;
 
 signals:
@@ -287,6 +291,8 @@ private:
     // fix bug:33999 change DebInfoLabel to DCommandLinkButton for Activity color
     DCommandLinkButton *m_pLoadingLabel = nullptr; //依赖安装提示信息
     int dependAuthStatu = -1; //存储依赖授权状态
+
+    bool resetButtonFocus = true; // 展示包信息前，复位焦点状态，切换后第一次显示有效
 };
 
 #endif  // SINGLEINSTALLPAGE_H

--- a/src/deb-installer/view/widgets/filechoosewidget.cpp
+++ b/src/deb-installer/view/widgets/filechoosewidget.cpp
@@ -144,6 +144,13 @@ FileChooseWidget::FileChooseWidget(QWidget *parent)
                      this, &FileChooseWidget::themeChanged);
 }
 
+void FileChooseWidget::showEvent(QShowEvent *e)
+{
+    QWidget::showEvent(e);
+
+    m_chooseFileBtn->setFocus();
+}
+
 void FileChooseWidget::chooseFiles()
 {
     QString historyDir = m_settings.value("history_dir").toString();        //获取保存的文件路径
@@ -160,7 +167,10 @@ void FileChooseWidget::chooseFiles()
 
     QString currentPackageDir = dialog.directoryUrl().toLocalFile();    //获取当前打开的文件夹路径
 
-    if (mode != QDialog::Accepted) return;
+    if (mode != QDialog::Accepted) {
+        m_chooseFileBtn->setFocus();
+        return;
+    }
 
     const QStringList selected_files = dialog.selectedFiles();              //获取选中的文件
     emit packagesSelected(selected_files);                                  //发送信号

--- a/src/deb-installer/view/widgets/filechoosewidget.h
+++ b/src/deb-installer/view/widgets/filechoosewidget.h
@@ -47,6 +47,12 @@ signals:
      */
     void packagesSelected(const QStringList &files) const;
 
+protected:
+    /**
+       @brief 展示控件时设置默认焦点
+     */
+    void showEvent(QShowEvent *e);
+
 private slots:
     /**
      * @brief chooseFiles 打开文件选择窗口，选择文件后将文件保存


### PR DESCRIPTION
在每个安装界面设置默认焦点控件
涉及单包/批量/DDIM, 操作中断也会将焦点还原

Log: 在每个安装界面设置默认焦点控件
Bug: https://pms.uniontech.com/bug-view-247435.html
Influence: FocusWidget