### PR TITLE
fix: UI init wrong when load large package

### DIFF
--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -459,6 +459,9 @@ void DebInstaller::slotPackagesSelected(const QStringList &packagesPathList)
             || DebListModel::AuthConfirm == m_wineAuthStatus
             || DebListModel::AuthDependsErr == m_wineAuthStatus) {
     } else {
+        // 下一指令第1个包大小较大时，解析操作会阻塞当前线程，导致界面设置的逻辑顺序出现混乱，优先处理界面交互，然后再执行加载
+        qApp->processEvents();
+
         //开始添加包，将要添加的包传递到后端，添加包由后端处理
         m_fileListModel->slotAppendPackage(packagesPathList);
     }


### PR DESCRIPTION
修复加载较大软件包可能导致界面焦点错误
传入包过大可能阻塞线程, 导致界面设置顺序异常,
在解析包前先进行界面设置.

Log: 修复加载较大软件包可能导致界面焦点错误
Bug: https://pms.uniontech.com/bug-view-247435.html
Influence: FocusWidget