### PR TITLE
fix: Change default focus widget

### DIFF
--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -596,9 +596,9 @@ void DebListModel::slotTransactionErrorOccurred()
         QTimer::singleShot(100 * 1, this, &DebListModel::checkBoxStatus);           //检查授权弹窗的状态 如果弹窗仍然在只是超时，则底层窗口按钮不可用
         qWarning() << "DebListModel:" << "Authorization error";
 
-        // reset env
-        emit signalAuthCancel();                                                          //发送授权被取消的信号
+        // 复位，注意先取消锁定状态再设置界面，否则焦点设置丢失
         emit signalLockForAuth(false);                                                    //取消授权锁定，设置按钮可用
+        emit signalAuthCancel();                                                          //发送授权被取消的信号
         emit signalEnableCloseButton(true);
         m_workerStatus = WorkerPrepare;                                             // 重置工作状态为准备态
         return;

--- a/src/deb-installer/view/pages/ddimerrorpage.cpp
+++ b/src/deb-installer/view/pages/ddimerrorpage.cpp
@@ -16,6 +16,7 @@ DdimErrorPage::DdimErrorPage(QWidget *parent)
     , errorPicLabel(new Dtk::Widget::DLabel)
     , confimButton(new QPushButton(tr("OK")))
 {
+    setFocusPolicy(Qt::NoFocus);
     auto allLayout = new QVBoxLayout;
     allLayout->addWidget(errorPicLabel, 0, Qt::AlignCenter | Qt::AlignBottom);
     allLayout->addWidget(errorMessageLabel, 0, Qt::AlignCenter | Qt::AlignBottom);
@@ -40,10 +41,18 @@ DdimErrorPage::DdimErrorPage(QWidget *parent)
     allLayout->setSpacing(0);
 
     confimButton->setFixedSize(120, 36);
+    confimButton->setDefault(true);
     connect(confimButton, &QPushButton::clicked, this, &DdimErrorPage::comfimPressed);
 }
 
 void DdimErrorPage::setErrorMessage(const QString &message)
 {
     errorMessageLabel->setText(message);
+}
+
+void DdimErrorPage::showEvent(QShowEvent *event)
+{
+    // 每次展示时固定默认焦点，缩放后弹出也是
+    confimButton->setFocus();
+    QWidget::showEvent(event);
 }

--- a/src/deb-installer/view/pages/ddimerrorpage.h
+++ b/src/deb-installer/view/pages/ddimerrorpage.h
@@ -25,6 +25,9 @@ public:
 signals:
     void comfimPressed();
 
+protected:
+    void showEvent(QShowEvent *event) override;
+
 private:
     Dtk::Widget::DLabel *errorMessageLabel;
     Dtk::Widget::DLabel *errorPicLabel;

--- a/src/deb-installer/view/pages/uninstallconfirmpage.cpp
+++ b/src/deb-installer/view/pages/uninstallconfirmpage.cpp
@@ -131,6 +131,13 @@ void UninstallConfirmPage::setRequiredList(const QStringList &requiredList)
     m_dependsInfomation->appendText(requiredList.join(", "));
 }
 
+void UninstallConfirmPage::showEvent(QShowEvent *e)
+{
+    // 每次展示时设置默认焦点
+    m_confirmBtn->setFocus();
+    QWidget::showEvent(e);
+}
+
 void UninstallConfirmPage::slotShowDetail()
 {
     // Show dependency information

--- a/src/deb-installer/view/pages/uninstallconfirmpage.h
+++ b/src/deb-installer/view/pages/uninstallconfirmpage.h
@@ -43,6 +43,11 @@ signals:
      */
     void signalUninstallCanceled() const;
 
+protected:
+    /**
+       @brief 展示时设置默认焦点
+     */
+    void showEvent(QShowEvent *e) override;
 
 private slots:
 


### PR DESCRIPTION
调整默认焦点位置,对话框退出后恢复焦点

Log: 调整默认焦点设置
Bug: https://pms.uniontech.com/bug-view-247435.html
Bug: https://pms.uniontech.com/bug-view-248153.html
Bug: https://pms.uniontech.com/bug-view-248161.html
Influence: FocusWidget