### PR TITLE
fix: Button focus not work in wayland

### DIFF
--- a/src/deb-installer/view/pages/ddimerrorpage.cpp
+++ b/src/deb-installer/view/pages/ddimerrorpage.cpp
@@ -40,6 +40,7 @@ DdimErrorPage::DdimErrorPage(QWidget *parent)
     allLayout->setContentsMargins(allContentsMargins);
     allLayout->setSpacing(0);
 
+    confimButton->setFocusPolicy(Qt::StrongFocus);
     confimButton->setFixedSize(120, 36);
     confimButton->setDefault(true);
     connect(confimButton, &QPushButton::clicked, this, &DdimErrorPage::comfimPressed);


### PR DESCRIPTION
修复在wayland下焦点未成功设置

Log: 修复在wayland下焦点未成功设置
Bug: https://pms.uniontech.com/bug-view-247435.html