### PR TITLE
fix: The effect of checkbox is not fully displayed

### DIFF
--- a/src/deb-installer/view/pages/packageselectview.cpp
+++ b/src/deb-installer/view/pages/packageselectview.cpp
@@ -13,6 +13,9 @@
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 
+// 选中框最低高度（低字号下可能使得选中框显示不全）
+static const int s_MinimumBoxHeight = 32;
+
 PackageSelectView::PackageSelectView(QWidget *parent)
     : QWidget(parent)
     , packageListWidget(new QListWidget)
@@ -23,6 +26,8 @@ PackageSelectView::PackageSelectView(QWidget *parent)
     selectAllBox->setFocusPolicy(Qt::StrongFocus);
     installButton->setFocusPolicy(Qt::StrongFocus);
     installButton->setDefault(true);
+
+    selectAllBox->setMinimumHeight(s_MinimumBoxHeight);
 
     //全选+安装
     auto bottomLayout = new QHBoxLayout;


### PR DESCRIPTION
勾选框高度以文本高度计算，低字号下导致选中
效果无法完全展示，设置最小高度避免此问题

Log: 修复勾选框在低字号下选中效果显示不全
Bug: https://pms.uniontech.com/bug-view-248145.html
Influence: UI