### PR TITLE
chore: Bump version to 6.0.21

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+deepin-deb-installer (6.0.21) unstable; urgency=medium
+
+  * fix: Set default focus widget on each page(Bug: 247435)(Influence: FocusWidget)
+  * fix: UI init wrong when load large package(Bug: 247435)(Influence: FocusWidget)
+  * fix: Change default focus widget(Bug: 247435, 248153, 248161)(Influence: FocusWidget)
+  * fix: Remove clear focus code(Bug: 247435)(Influence: FocusWidget)
+  * fix: Button focus not work in wayland(Bug: 247435)
+  * fix: The effect of checkbox is not fully displayed(Bug: 248145)(Influence: UI)
+  * fix: App cannot start when apt is configure error(Bug: 224605)
+
+ -- renbin <renbin@uniontech.com>  Wed, 27 Mar 2024 15:55:30 +0800
+
 deepin-deb-installer (6.0.20) unstable; urgency=medium
 
   * fix: Print useless log after install failed.(Bug: 225161)


### PR DESCRIPTION
Bump version to 6.0.21
PR:
* https://github.com/linuxdeepin/deepin-deb-installer/pull/244
* https://github.com/linuxdeepin/deepin-deb-installer/pull/245
* https://github.com/linuxdeepin/deepin-deb-installer/pull/246
* https://github.com/linuxdeepin/deepin-deb-installer/pull/247
* https://github.com/linuxdeepin/deepin-deb-installer/pull/248
* https://github.com/linuxdeepin/deepin-deb-installer/pull/249

Log: Bump version to 6.0.21