### PR TITLE
fix: update hierarchical verify code

### DIFF
--- a/tests/src/utils/ut_hierarchicalverify.cpp
+++ b/tests/src/utils/ut_hierarchicalverify.cpp
@@ -70,7 +70,14 @@ TEST_F(ut_HierarchicalVerify_TEST, checkTransactionError_TestRegExp_True)
     ASSERT_TRUE(hVerify->checkTransactionError("pkg2", "deepinhookhook65280"));
     ASSERT_TRUE(hVerify->checkTransactionError("pkg2", "Error:deepin hook exit code 65280"));
 
-    QSet<QString> pkgSet{"pkg", "pkg2"};
+    // 1071 调整错误码为 256
+    ASSERT_TRUE(hVerify->checkTransactionError("pkg2", "deepinhookhook256"));
+    ASSERT_TRUE(hVerify->checkTransactionError("pkg2", "Error:deepin hook exit code 256"));
+    ASSERT_TRUE(hVerify->checkTransactionError("pkg2",
+                                               "执行钩子 if test -x /usr/sbin/deepin-pkg-install-hook;then /usr/sbin/deepin-pkg "
+                                               "install-hook -e hc-verifysign;fi 出错，退出状态为 256"));
+
+    QSet<QString> pkgSet { "pkg", "pkg2" };
     ASSERT_EQ(hVerify->invalidPackages, pkgSet);
 }
 
@@ -82,6 +89,16 @@ TEST_F(ut_HierarchicalVerify_TEST, checkTransactionError_TestRegExp_False)
     ASSERT_FALSE(hVerify->checkTransactionError("pkg", "\r\ndeepin\ndeehook+++65280\n"));
     ASSERT_FALSE(hVerify->checkTransactionError("pkg2", "deepinh-ookh-ook65280"));
     ASSERT_FALSE(hVerify->checkTransactionError("pkg2", "Error:deepin hook \n exit code 65280"));
+
+    // 1071 调整错误码为 256
+    ASSERT_FALSE(hVerify->checkTransactionError("pkg2", "deepinhookhook25"));
+    ASSERT_FALSE(hVerify->checkTransactionError("pkg2", "Error:deepin hook exit code 255"));
+    ASSERT_FALSE(hVerify->checkTransactionError("pkg2",
+                                               "执行钩子 if test -x /usr/sbin/deepin-pkg-install-hook;then /usr/sbin/deepin-pkg "
+                                               "install-hook -e hc-verifysign;fi 出错，退出状态为 \n测试代码"));
+    ASSERT_FALSE(hVerify->checkTransactionError("pkg2",
+                                               "执行钩子 if test -x /usr/sbin/deepin-pkg-install-hook;then /usr/sbin/deepin-pkg "
+                                               "install-hook -e hc-verifysign;fi 出错，退出状态为 xxx"));
 
     ASSERT_TRUE(hVerify->invalidPackages.isEmpty());
 }


### PR DESCRIPTION
Update hierarchical verify code from
65280 to 256, both error codes are available.

Log: Update hierarchical verify code.
Bug: https://pms.uniontech.com/bug-view-269341.html