### PR TITLE
fix: cherry-pick from master and update depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,12 @@ Homepage: https://www.deepin.com/
 
 Package: deepin-deb-installer
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libqapt3-runtime, libqapt3, deepin-elf-verify, deepin-elf-sign-tool
+Depends: ${shlibs:Depends}, ${misc:Depends}, 
+ libqapt3-runtime, 
+ libqapt3, 
+# deepin-app-store-runtime is available in the community edition.
+ deepin-elf-verify | deepin-app-store-runtime, 
+ deepin-elf-sign-tool | deepin-app-store-runtime
 Description: Package Installer helps users install and remove local packages.
  Package Installer is an easy-to-use .deb package management tool 
  with a simple interface for users to quickly install customized applications

--- a/src/deb-installer/manager/AddPackageThread.cpp
+++ b/src/deb-installer/manager/AddPackageThread.cpp
@@ -43,10 +43,24 @@ void AddPackageThread::setSamePackageMd5(const QMap<QString, QByteArray> &packag
 bool AddPackageThread::dealInvalidPackage(const QString &packagePath)
 {
     if (!Utils::checkPackageReadable(packagePath)) {
-        emit signalNotLocalPackage();
-        return false;
-    }
+        QFileInfo debFileIfo(packagePath);
+        // 查看包是否能够打开，无法打开说明包不在本地或无权限。
+        QFile outfile(packagePath.toUtf8());
+        outfile.open(QFile::ReadOnly);
 
+        if (!outfile.isOpen()) { // 打不开，文件不在本地或无安装权限
+            QFile::FileError error = outfile.error();
+            if (error == QFile::FileError::NoError) {
+                // 文件不存在或路径错误
+                emit signalNotLocalPackage();
+                return false;
+            } else {
+                //无安装权限
+                emit signalNotInstallablePackage();
+                return false;
+            }
+        }
+    }
     return true;
 }
 

--- a/src/deb-installer/manager/AddPackageThread.h
+++ b/src/deb-installer/manager/AddPackageThread.h
@@ -75,6 +75,13 @@ signals:
     void signalNotLocalPackage();
 
     /**
+     * @brief notInstallablePackage 包无安装权限的信号
+     *
+     * 包无安装权限无法安装
+     */
+    void signalNotInstallablePackage();
+
+    /**
      * @brief packageAlreadyExists 当前包已经被添加到应用中
      */
     void signalPackageAlreadyExists();

--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -144,6 +144,13 @@ signals:
     void signalNotLocalPackage();
 
     /**
+     * @brief notInstallablePackage 包无安装权限的信号
+     *
+     * 包无安装权限无法安装
+     */
+    void signalNotInstallablePackage();
+
+    /**
      * @brief packageAlreadyExists 包重复添加的信号
      */
     void signalPackageAlreadyExists();

--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -139,6 +139,9 @@ void DebListModel::initAppendConnection()
     //添加的包不在本地
     connect(m_packagesManager, &PackagesManager::signalNotLocalPackage, this, &DebListModel::signalNotLocalPackage);
 
+    //添加的包无安装权限
+    connect(m_packagesManager, &PackagesManager::signalNotInstallablePackage, this, &DebListModel::signalNotInstallablePackage);
+
     //要添加的包早就已经被添加到程序中
     connect(m_packagesManager, &PackagesManager::signalPackageAlreadyExists, this, &DebListModel::signalPackageAlreadyExists);
 

--- a/src/deb-installer/model/deblistmodel.h
+++ b/src/deb-installer/model/deblistmodel.h
@@ -384,6 +384,14 @@ signals:
     void signalNotLocalPackage();
 
     /**
+     * @brief notInstallablePackage 包无安装权限的信号
+     *
+     * 包无安装权限无法安装
+     */
+    void signalNotInstallablePackage();
+
+
+    /**
      * @brief signalPackageCannotFind 包已经被移动的信号 通知前端发送浮动消息
      * @param packageName 被移动的文件名
      */

--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -130,8 +130,11 @@ void DebInstaller::initConnections()
         slotShowDdimFloatingMessage(tr("Installing other packages... Please open it later."));
     });
 
-    //接收到添加无效包的信号则弹出无效包的弹窗
+    //接收到添加非本地包的信号则弹出无效包的弹窗
     connect(m_fileListModel, &DebListModel::signalNotLocalPackage, this, &DebInstaller::slotShowNotLocalPackageMessage);
+
+    //接收到添加无安装权限包的信号则弹出无效包的弹窗
+    connect(m_fileListModel, &DebListModel::signalNotInstallablePackage, this, &DebInstaller::slotShowNotInstallablePackageMessage);
 
     //接收到包已经添加的信号则弹出已添加的弹窗
     connect(m_fileListModel, &DebListModel::signalPackageAlreadyExists, this, &DebInstaller::slotShowPkgExistMessage);
@@ -640,6 +643,14 @@ void DebInstaller::slotShowNotLocalPackageMessage()
 {
     DFloatingMessage *floatingMsg = new DFloatingMessage;
     floatingMsg->setMessage(tr("You can only install local deb packages"));
+    floatingMsg->setIcon(QIcon::fromTheme("di_warning"));
+    DMessageManager::instance()->sendMessage(this, floatingMsg);                        //如果损坏，提示
+}
+
+void DebInstaller::slotShowNotInstallablePackageMessage()
+{
+    DFloatingMessage *floatingMsg = new DFloatingMessage;
+    floatingMsg->setMessage(tr("No permission to access this folder"));
     floatingMsg->setIcon(QIcon::fromTheme("di_warning"));
     DMessageManager::instance()->sendMessage(this, floatingMsg);                        //如果损坏，提示
 }

--- a/src/deb-installer/view/pages/debinstaller.h
+++ b/src/deb-installer/view/pages/debinstaller.h
@@ -79,6 +79,11 @@ private slots:
     void slotShowNotLocalPackageMessage();
 
     /**
+     * @brief slotShowNotInstallablePackageMessage 弹出无安装权限的消息通知
+     */
+    void slotShowNotInstallablePackageMessage();
+
+    /**
      * @brief slotShowPkgExistMessage 弹出包已存在的消息通知
      */
     void slotShowPkgExistMessage();

--- a/translations/deepin-deb-installer_zh_CN.ts
+++ b/translations/deepin-deb-installer_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>AptConfigMessage</name>
     <message>
@@ -53,49 +55,54 @@
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="130"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="537"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="540"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>正在执行安装流程，无法打开</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="544"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>软件包解析失败，软件包清单包含非法的文件结构！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="543"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="546"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>软件包解析失败，软件包清单包含非法版本号！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="545"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="548"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>未检测到安装包，请检查安装目录！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="631"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="634"/>
         <source>The deb package may be broken</source>
         <translation>请检查deb包是否损坏</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="639"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="642"/>
         <source>You can only install local deb packages</source>
         <translation>只能安装本地的deb包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="653"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="650"/>
+        <source>No permission to access this folder</source>
+        <translation>没有权限访问文件夹</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="664"/>
         <source>Already Added</source>
         <translation>已添加</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="662"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="673"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1文件不存在，请重新选择文件</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="330"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="669"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="799"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="333"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="680"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="810"/>
         <source>Bulk Install</source>
         <translation>批量安装</translation>
     </message>
@@ -127,14 +134,14 @@
     </message>
     <message>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="632"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="637"/>
         <source>Invalid digital signature</source>
         <translation>数字签名无效</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="124"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="625"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1576"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="630"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1591"/>
         <source>The administrator has set policies to prevent installation of this package</source>
         <translation>管理员已限制，该软件禁止安装</translation>
     </message>
@@ -144,88 +151,84 @@
         <translation>安装失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="634"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="639"/>
         <source>Failed to install %1</source>
         <translation>%1安装失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1617"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1634"/>
         <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
         <translation>安装包没有有效的数字签名，已被禁止安装/运行，请前往安全中心-安全工具-应用安全进行调整。</translation>
     </message>
     <message>
-        <source>Failed to install %1: no valid digital singature</source>
-        <translation type="vanished">无法安装%1，安装包无有效的数字签名</translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="961"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="968"/>
         <source>Unable to install - no digital signature</source>
         <translation>无法安装，安装包无数字签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="969"/>
         <source>Please go to Control Center to enable developer mode and try again. Proceed?</source>
         <translation>请进入控制中心，开启开发者模式后，再尝试继续安装。是否前往？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="965"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1620"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="972"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1637"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="966"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1621"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="973"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1638"/>
         <source>Proceed</source>
         <comment>button</comment>
         <translation>前 往</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="919"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1021"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1578"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="926"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1028"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1593"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="923"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="930"/>
         <source>Failed to install %1: no valid digital signature</source>
         <translation>无法安装%1，安装包无有效的数字签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1059"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1066"/>
         <source>This package does not have a valid digital signature. Continue with the installation?</source>
         <translation>此安装包没有有效的数字签名，是否继续安装？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1061"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1068"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1062"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1069"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>继续</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="917"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1018"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1575"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1616"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="924"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1025"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1590"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1633"/>
         <source>Unable to install</source>
         <translation>无法安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1019"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1026"/>
         <source>This package does not have a valid digital signature</source>
         <translation>此安装包没有有效的数字签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="637"/>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="642"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="647"/>
         <source>Broken dependencies: %1</source>
         <translation>依赖关系不满足：%1</translation>
     </message>
@@ -235,7 +238,7 @@
         <translation>配置授权失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="623"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="628"/>
         <source>Unmatched package architecture</source>
         <translation>软件包架构不匹配</translation>
     </message>
@@ -267,35 +270,35 @@
         <translation>收 起</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="171"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="168"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="172"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="169"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="174"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="171"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="468"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="473"/>
         <source>Dependencies in the repository</source>
         <translation>仓库中存在的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="474"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="479"/>
         <source>Missing dependencies</source>
         <translation>仓库中缺失的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="523"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="528"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安装依赖：%1</translation>
     </message>
@@ -407,12 +410,12 @@
         <translation>开发者模式下，检测安装包的签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="77"/>
+        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="82"/>
         <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
         <translation>如需安装未签名应用，前往安全中心-安全工具-应用安全设置允许安装的应用类型。</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="79"/>
+        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="84"/>
         <source>Security Center &gt; Tools &gt; App Security</source>
         <translation>安全中心-安全工具-应用安全</translation>
     </message>
@@ -420,125 +423,125 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="707"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="333"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="803"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="966"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="341"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="826"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="992"/>
         <source>Reinstall</source>
         <translation>重新安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="806"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="969"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="829"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="995"/>
         <source>Later version installed: %1</source>
         <translation>已安装较新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="808"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="971"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="831"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="997"/>
         <source>Downgrade</source>
         <translation>安装旧版本</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="811"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="974"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="834"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1000"/>
         <source>Earlier version installed: %1</source>
         <translation>已安装较早的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="876"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="900"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安装依赖：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1011"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1037"/>
         <source>Failed to install %1</source>
         <translation>%1安装失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="178"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="181"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="325"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="333"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="329"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="337"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>卸 载</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="337"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="345"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="341"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="349"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="345"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="353"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="679"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="702"/>
         <source>Installed successfully</source>
         <translation>安装成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="684"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="707"/>
         <source>Uninstalled successfully</source>
         <translation>卸载成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="698"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="721"/>
         <source>Uninstall Failed</source>
         <translation>卸载失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="727"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
         <source>Dependencies in the repository</source>
         <translation>仓库中存在的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="733"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="756"/>
         <source>Missing dependencies</source>
         <translation>仓库中缺失的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="813"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="976"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="836"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1002"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1042"/>
         <source>Invalid digital signature</source>
         <translation>数字签名无效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="166"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="169"/>
         <source>Name: </source>
         <translation>名称：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="802"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="965"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="825"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="991"/>
         <source>Same version installed</source>
         <translation>已安装相同版本</translation>
     </message>
@@ -547,9 +550,9 @@
     <name>SingleInstallPage_Install</name>
     <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="45"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="551"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="678"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="536"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="562"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="701"/>
         <source>Show details</source>
         <translation>显示详细信息</translation>
     </message>
@@ -563,8 +566,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="576"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="683"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="588"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="706"/>
         <source>Show details</source>
         <translation>显示卸载进程</translation>
     </message>

--- a/translations/deepin-deb-installer_zh_HK.ts
+++ b/translations/deepin-deb-installer_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>AptConfigMessage</name>
     <message>
@@ -53,49 +55,54 @@
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="130"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="537"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="540"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>正在執行安裝流程，無法打開</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="544"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>軟件包解析失敗，軟件包清單包含非法的文件結構！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="543"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="546"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>軟件包解析失敗，軟件包清單包含非法版本號！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="545"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="548"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>未檢測到安裝包，請檢查安裝目錄！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="631"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="634"/>
         <source>The deb package may be broken</source>
         <translation>請檢查deb包是否損壞</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="639"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="642"/>
         <source>You can only install local deb packages</source>
         <translation>只能安裝本地的deb包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="653"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="650"/>
+        <source>No permission to access this folder</source>
+        <translation>沒有權限訪問此資料夾</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="664"/>
         <source>Already Added</source>
         <translation>已添加</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="662"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="673"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1文件不存在，請重新選擇文件</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="330"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="669"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="799"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="333"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="680"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="810"/>
         <source>Bulk Install</source>
         <translation>批量安裝</translation>
     </message>
@@ -127,14 +134,14 @@
     </message>
     <message>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="632"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="637"/>
         <source>Invalid digital signature</source>
         <translation>數字簽名無效</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="124"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="625"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1576"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="630"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1591"/>
         <source>The administrator has set policies to prevent installation of this package</source>
         <translation>管理員已限制，該軟件禁止安裝</translation>
     </message>
@@ -144,88 +151,84 @@
         <translation>安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="634"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="639"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1617"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1634"/>
         <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
         <translation>安裝包沒有有效的數字簽名，已被禁止安裝/運行，請前往安全中心-安全工具-應用安全進行調整。</translation>
     </message>
     <message>
-        <source>Failed to install %1: no valid digital singature</source>
-        <translation type="vanished">無法安裝%1，安裝包無有效的數字簽名</translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="961"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="968"/>
         <source>Unable to install - no digital signature</source>
         <translation>無法安裝，安裝包無數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="969"/>
         <source>Please go to Control Center to enable developer mode and try again. Proceed?</source>
         <translation>請進入控制中心，開啟開發者模式後，再嘗試繼續安裝。是否前往？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="965"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1620"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="972"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1637"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="966"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1621"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="973"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1638"/>
         <source>Proceed</source>
         <comment>button</comment>
         <translation>前 往</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="919"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1021"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1578"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="926"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1028"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1593"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="923"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="930"/>
         <source>Failed to install %1: no valid digital signature</source>
         <translation>無法安裝%1，安裝包無有效的數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1059"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1066"/>
         <source>This package does not have a valid digital signature. Continue with the installation?</source>
         <translation>此安裝包沒有有效的數字簽名，是否繼續安裝？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1061"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1068"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1062"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1069"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>繼續</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="917"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1018"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1575"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1616"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="924"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1025"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1590"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1633"/>
         <source>Unable to install</source>
         <translation>無法安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1019"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1026"/>
         <source>This package does not have a valid digital signature</source>
         <translation>此安裝包沒有有效的數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="637"/>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="642"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="647"/>
         <source>Broken dependencies: %1</source>
         <translation>依賴關係不滿足：%1</translation>
     </message>
@@ -235,7 +238,7 @@
         <translation>配置授權失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="623"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="628"/>
         <source>Unmatched package architecture</source>
         <translation>軟件包架構不匹配</translation>
     </message>
@@ -267,35 +270,35 @@
         <translation>收 起</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="171"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="168"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="172"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="169"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="174"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="171"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="468"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="473"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="474"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="479"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="523"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="528"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
@@ -407,12 +410,12 @@
         <translation>開發者模式下，檢測安裝包的簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="77"/>
+        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="82"/>
         <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
         <translation>如需安裝未簽名應用，前往安全中心-安全工具-應用安全設定允許安裝的應用類型。</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="79"/>
+        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="84"/>
         <source>Security Center &gt; Tools &gt; App Security</source>
         <translation>安全中心-安全工具-應用安全</translation>
     </message>
@@ -420,125 +423,125 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="707"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="333"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="803"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="966"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="341"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="826"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="992"/>
         <source>Reinstall</source>
         <translation>重新安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="806"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="969"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="829"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="995"/>
         <source>Later version installed: %1</source>
         <translation>已安裝較新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="808"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="971"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="831"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="997"/>
         <source>Downgrade</source>
         <translation>安裝舊版本</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="811"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="974"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="834"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1000"/>
         <source>Earlier version installed: %1</source>
         <translation>已安裝較早的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="876"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="900"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1011"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1037"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="178"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="181"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="325"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="333"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="329"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="337"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>卸 載</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="337"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="345"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="341"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="349"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="345"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="353"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="679"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="702"/>
         <source>Installed successfully</source>
         <translation>安裝成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="684"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="707"/>
         <source>Uninstalled successfully</source>
         <translation>卸載成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="698"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="721"/>
         <source>Uninstall Failed</source>
         <translation>卸載失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="727"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="733"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="756"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="813"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="976"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="836"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1002"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1042"/>
         <source>Invalid digital signature</source>
         <translation>數字簽名無效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="166"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="169"/>
         <source>Name: </source>
         <translation>名稱：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="802"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="965"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="825"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="991"/>
         <source>Same version installed</source>
         <translation>已安裝相同版本</translation>
     </message>
@@ -547,9 +550,9 @@
     <name>SingleInstallPage_Install</name>
     <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="45"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="551"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="678"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="536"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="562"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="701"/>
         <source>Show details</source>
         <translation>顯示詳細訊息</translation>
     </message>
@@ -563,8 +566,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="576"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="683"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="588"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="706"/>
         <source>Show details</source>
         <translation>顯示卸載進程</translation>
     </message>

--- a/translations/deepin-deb-installer_zh_TW.ts
+++ b/translations/deepin-deb-installer_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>AptConfigMessage</name>
     <message>
@@ -53,49 +55,54 @@
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="130"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="537"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="540"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>正在執行安裝流程，無法打開</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="544"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>套裝軟體解析失敗，套裝軟體清單包含非法的文件結構！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="543"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="546"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>套裝軟體解析失敗，套裝軟體清單包含非法版本號！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="545"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="548"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>未檢測到安裝包，請檢查安裝目錄！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="631"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="634"/>
         <source>The deb package may be broken</source>
         <translation>請檢查deb包是否損壞</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="639"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="642"/>
         <source>You can only install local deb packages</source>
         <translation>只能安裝本機的deb包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="653"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="650"/>
+        <source>No permission to access this folder</source>
+        <translation>沒有權限訪問此資料夾</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="664"/>
         <source>Already Added</source>
         <translation>已添加</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="662"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="673"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1文件不存在，請重新選擇文件</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="330"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="669"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="799"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="333"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="680"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="810"/>
         <source>Bulk Install</source>
         <translation>批次安裝</translation>
     </message>
@@ -127,14 +134,14 @@
     </message>
     <message>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="632"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="637"/>
         <source>Invalid digital signature</source>
         <translation>數位簽章無效</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="124"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="625"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1576"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="630"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1591"/>
         <source>The administrator has set policies to prevent installation of this package</source>
         <translation>管理員已限制，該軟體禁止安裝</translation>
     </message>
@@ -144,88 +151,84 @@
         <translation>安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="634"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="639"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1617"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1634"/>
         <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
         <translation>安裝包沒有有效的數位簽章，已被禁止安裝/執行，請前往安全中心-安全工具-應用安全進行調整。</translation>
     </message>
     <message>
-        <source>Failed to install %1: no valid digital singature</source>
-        <translation type="vanished">無法安裝%1，安裝包無有效的數位簽章</translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="961"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="968"/>
         <source>Unable to install - no digital signature</source>
         <translation>無法安裝，安裝包無數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="969"/>
         <source>Please go to Control Center to enable developer mode and try again. Proceed?</source>
         <translation>請進入控制中心，開啟開發者模式後，再嘗試繼續安裝。是否前往？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="965"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1620"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="972"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1637"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="966"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1621"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="973"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1638"/>
         <source>Proceed</source>
         <comment>button</comment>
         <translation>前 往</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="919"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1021"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1578"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="926"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1028"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1593"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="923"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="930"/>
         <source>Failed to install %1: no valid digital signature</source>
         <translation>無法安裝%1，安裝包無有效的數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1059"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1066"/>
         <source>This package does not have a valid digital signature. Continue with the installation?</source>
         <translation>此安裝包沒有有效的數位簽章，是否繼續安裝？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1061"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1068"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1062"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1069"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>繼續</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="917"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1018"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1575"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1616"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="924"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1025"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1590"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1633"/>
         <source>Unable to install</source>
         <translation>無法安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1019"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1026"/>
         <source>This package does not have a valid digital signature</source>
         <translation>此安裝包沒有有效的數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="637"/>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="642"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="647"/>
         <source>Broken dependencies: %1</source>
         <translation>缺少依賴軟體：%1</translation>
     </message>
@@ -235,7 +238,7 @@
         <translation>配置授權失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="623"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="628"/>
         <source>Unmatched package architecture</source>
         <translation>軟體套件結構不符合規範</translation>
     </message>
@@ -267,35 +270,35 @@
         <translation>隱 藏</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="171"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="168"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="172"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="169"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="174"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="171"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="468"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="473"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="474"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="479"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="523"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="528"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
@@ -407,12 +410,12 @@
         <translation>開發者模式下，檢測安裝包的簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="77"/>
+        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="82"/>
         <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
         <translation>如需安裝未簽名應用，前往安全中心-安全工具-應用安全設定允許安裝的應用類型。</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="79"/>
+        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="84"/>
         <source>Security Center &gt; Tools &gt; App Security</source>
         <translation>安全中心-安全工具-應用安全</translation>
     </message>
@@ -420,125 +423,125 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="707"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
         <source>Collapse</source>
         <translation>隱藏</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="333"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="803"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="966"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="341"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="826"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="992"/>
         <source>Reinstall</source>
         <translation>重 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="806"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="969"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="829"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="995"/>
         <source>Later version installed: %1</source>
         <translation>已安裝較新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="808"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="971"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="831"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="997"/>
         <source>Downgrade</source>
         <translation>安裝舊版本</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="811"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="974"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="834"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1000"/>
         <source>Earlier version installed: %1</source>
         <translation>已安裝舊版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="876"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="900"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1011"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1037"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="178"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="181"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="325"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="333"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="329"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="337"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>移 除</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="337"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="345"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="341"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="349"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="345"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="353"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="679"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="702"/>
         <source>Installed successfully</source>
         <translation>安裝成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="684"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="707"/>
         <source>Uninstalled successfully</source>
         <translation>解除安裝成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="698"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="721"/>
         <source>Uninstall Failed</source>
         <translation>解除安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="727"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="733"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="756"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="813"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="976"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="836"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1002"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1042"/>
         <source>Invalid digital signature</source>
         <translation>數位簽章無效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="166"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="169"/>
         <source>Name: </source>
         <translation>名稱：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="802"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="965"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="825"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="991"/>
         <source>Same version installed</source>
         <translation>已安裝相同版本</translation>
     </message>
@@ -547,9 +550,9 @@
     <name>SingleInstallPage_Install</name>
     <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="45"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="551"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="678"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="536"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="562"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="701"/>
         <source>Show details</source>
         <translation>顯示詳細訊息</translation>
     </message>
@@ -563,8 +566,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="576"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="683"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="588"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="706"/>
         <source>Show details</source>
         <translation>顯示卸載進程</translation>
     </message>


### PR DESCRIPTION
cherry-pick from master  c092f495db0e078342f07bd1d8101d7763a83eb3
sync branch master and release/eagle

Add deepin-elf-verfiy / deepin-elf-sign-tool or depends,
deepin-app-store-runtime is available in community edition.
