### PR TITLE
feat: deepin-elf-verify or depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,12 @@ Homepage: https://www.deepin.com/
 
 Package: deepin-deb-installer
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libqapt3-runtime, libqapt3
+Depends: ${shlibs:Depends}, ${misc:Depends}, 
+ libqapt3-runtime, 
+ libqapt3, 
+# deepin-app-store-runtime is available in the community edition.
+ deepin-elf-verify | deepin-app-store-runtime, 
+ deepin-elf-sign-tool | deepin-app-store-runtime
 Description: Package Installer helps users install and remove local packages.
  Package Installer is an easy-to-use .deb package management tool 
  with a simple interface for users to quickly install customized applications


### PR DESCRIPTION
Add deepin-elf-verfiy / deepin-elf-sign-tool or depends,
deepin-app-store-runtime is available in community edition.

Log: Add or depends on deepin-elf-verify.
Influence: debian/control