### PR TITLE
feat: linglnog output parser and dbus interface

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -104,7 +104,7 @@ bool PackagesManager::dependencyVersionMatch(const int result, const RelationTyp
     }
 }
 
-int PackagesManager::checkInstallStatus(const QString &package_path)
+Pkg::PackageInstallStatus PackagesManager::checkInstallStatus(const QString &package_path)
 {
     DebFile debFile(package_path);
     if (!debFile.isValid())
@@ -129,7 +129,7 @@ int PackagesManager::checkInstallStatus(const QString &package_path)
     const QString packageVersion = debFile.version();
     const int result = Package::compareVersion(packageVersion, installedVersion);
 
-    int ret;
+    Pkg::PackageInstallStatus ret;
     if (result == 0)
         ret = Pkg::PackageInstallStatus::InstalledSameVersion;
     else if (result < 0)

--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -75,7 +75,7 @@ public:
      * @brief searchPackageInstallInfo 查找指定包安装状态
      * @param package_path 路径
      */
-    int checkInstallStatus(const QString &package_path);
+    Pkg::PackageInstallStatus checkInstallStatus(const QString &package_path);
     /**
      * @brief searchPackageInstallInfo 查找指定包依赖
      * @param package_path 包名字

--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -550,8 +550,6 @@ private:
 private:
     AddPackageThread *m_pAddPackageThread = nullptr;  // 添加包的线程
 
-    bool installWineDepends = false;
-
     bool isDependsExists = false;
 
     int m_validPackageCount = 0;

--- a/src/deb-installer/model/abstract_package_list_model.h
+++ b/src/deb-installer/model/abstract_package_list_model.h
@@ -56,14 +56,6 @@ public:
         VerifyDependsErr,    // signature verification failed (hierarchical verify)
     };
 
-    // Signature fail error code
-    enum ErrorCode {
-        NoDigitalSignature = 101,
-        DigitalSignatureError,
-        ConfigAuthCancel = 127,     // Authentication failed
-        ApplocationProhibit = 404,  // the current package is in the blacklist and is prohibited from installation
-    };
-
     explicit AbstractPackageListModel(QObject *parent = nullptr);
 
     [[nodiscard]] inline Pkg::PackageType supportPackage() const { return m_supportPackageType; }
@@ -76,9 +68,17 @@ public:
     virtual void removePackage(int index) = 0;
     virtual QString checkPackageValid(const QString &packagePath) = 0;
 
+    // package base info
+    virtual Pkg::PackageInstallStatus checkInstallStatus(const QString &packagePath) = 0;
+    virtual Pkg::DependsStatus checkDependsStatus(const QString &packagePath) = 0;
+    virtual QStringList getPackageInfo(const QString &packagePath) = 0;
+
+    // raw output of install/uninstall failures
+    virtual QString lastProcessError() = 0;
+
     // trigger install / uninstall
-    Q_SLOT virtual void slotInstallPackages() = 0;
-    Q_SLOT virtual void slotUninstallPackage(int index) = 0;
+    Q_SLOT virtual bool slotInstallPackages() = 0;
+    Q_SLOT virtual bool slotUninstallPackage(int index) = 0;
 
     virtual void reset() = 0;
     virtual void resetInstallStatus() = 0;

--- a/src/deb-installer/model/abstract_package_list_model.h
+++ b/src/deb-installer/model/abstract_package_list_model.h
@@ -75,6 +75,8 @@ public:
 
     // raw output of install/uninstall failures
     virtual QString lastProcessError() = 0;
+    // a package signature verification fails
+    virtual bool containsSignatureFailed() const = 0;
 
     // trigger install / uninstall
     Q_SLOT virtual bool slotInstallPackages() = 0;

--- a/src/deb-installer/model/deblistmodel.h
+++ b/src/deb-installer/model/deblistmodel.h
@@ -149,12 +149,12 @@ public:
      * @brief checkPackageDigitalSignature 查找指定包安装状态
      * @param package_path 路径
      */
-    int checkInstallStatus(const QString &package_path);
+    Pkg::PackageInstallStatus checkInstallStatus(const QString &package_path) override;
     /**
      * @brief searchPackageInstallInfo 查找指定包依赖
      * @param package_path 路径
      */
-    int checkDependsStatus(const QString &package_path);
+    Pkg::DependsStatus checkDependsStatus(const QString &package_path) override;
     /**
      * @brief searchPackageInstallInfo 查找指定包数字签名
      * @param package_path 路径
@@ -164,11 +164,10 @@ public:
      * @brief searchPackageInstallInfo 查找指定包信息
      * @param package_path 路径
      */
-    QStringList getPackageInfo(const QString &package_path);
-    /**
-     * @brief getInstallErrorMessage 安装错误信息
-     */
-    QString getInstallErrorMessage();
+    QStringList getPackageInfo(const QString &package_path) override;
+
+    QString lastProcessError() override;
+
     /**
      * @brief checkPackageValid 查找指定包信息
      * @param package_path 路径
@@ -201,13 +200,13 @@ public slots:
     /**
      * @brief slotInstallPackages 开始安装所有的包
      */
-    void slotInstallPackages() override;
+    bool slotInstallPackages() override;
 
     /**
      * @brief slotUninstallPackage     卸载某一个包
      * @param index   包的index
      */
-    void slotUninstallPackage(int index) override;
+    bool slotUninstallPackage(int index) override;
 
     /**
      * @brief slotAppendPackage 添加包
@@ -388,7 +387,7 @@ private:
     /**
      * @brief showDevelopDigitalErrWindow 开发者模式下弹出数字签名无效的弹窗
      */
-    void showDevelopDigitalErrWindow(ErrorCode code);
+    void showDevelopDigitalErrWindow(Pkg::ErrorCode code);
 
     /**
      * @brief showNoDigitalErrWindowInDdimProcess DDIM流程下的签名错误弹窗
@@ -418,7 +417,7 @@ private:
      *
      * @param errorCode 错误原因代码
      */
-    void digitalVerifyFailed(ErrorCode errorCode);
+    void digitalVerifyFailed(Pkg::ErrorCode errorCode);
 
 private:
     /**

--- a/src/deb-installer/model/deblistmodel.h
+++ b/src/deb-installer/model/deblistmodel.h
@@ -167,6 +167,7 @@ public:
     QStringList getPackageInfo(const QString &package_path) override;
 
     QString lastProcessError() override;
+    bool containsSignatureFailed() const override;
 
     /**
      * @brief checkPackageValid 查找指定包信息
@@ -398,11 +399,6 @@ private:
      * @brief showProhibitWindow 弹出数字签名校验错误的错误弹窗
      */
     void showProhibitWindow();
-
-    /**
-     * @brief showHierarchicalVerifyWindow 弹出分级管控安全等级设置引导提示窗口
-     */
-    void showHierarchicalVerifyWindow();
 
     /**
      * @brief 检查当前将要安装的包是否在黑名单中。

--- a/src/deb-installer/model/proxy_package_list_model.cpp
+++ b/src/deb-installer/model/proxy_package_list_model.cpp
@@ -192,7 +192,7 @@ ProxyPackageListModel::ModelPtr ProxyPackageListModel::addModel(Pkg::PackageType
         newInfo.model = newModel;
         m_packageModels.append(newInfo);
 
-        // sort, ensure uab package model first.
+        // sort, ensure deb package model first.
         std::sort(m_packageModels.begin(), m_packageModels.end(), [](const ModelInfo &info1, const ModelInfo &info2) {
             return info1.model->supportPackage() < info2.model->supportPackage();
         });

--- a/src/deb-installer/model/proxy_package_list_model.cpp
+++ b/src/deb-installer/model/proxy_package_list_model.cpp
@@ -128,6 +128,14 @@ QString ProxyPackageListModel::lastProcessError()
     return errorMessage;
 }
 
+bool ProxyPackageListModel::containsSignatureFailed() const
+{
+    auto findItr = std::find_if(m_packageModels.begin(), m_packageModels.end(), [](const ModelInfo &info) {
+        return info.model->containsSignatureFailed();
+    });
+    return findItr != m_packageModels.end();
+}
+
 bool ProxyPackageListModel::slotInstallPackages()
 {
     if (!isWorkerPrepare()) {
@@ -329,7 +337,7 @@ QPair<ProxyPackageListModel::ModelPtr, int> ProxyPackageListModel::findFromProxy
     return qMakePair(nullptr, -1);
 }
 
-int ProxyPackageListModel::proxyIndexFormModel(ModelPtr findModel, int index)
+int ProxyPackageListModel::proxyIndexFromModel(ModelPtr findModel, int index)
 {
     if (m_packageModels.isEmpty()) {
         return -1;
@@ -409,7 +417,7 @@ void ProxyPackageListModel::onSourceCurrentProcessPackageIndex(int index)
             return;
         }
 
-        const int proxyIndex = proxyIndexFormModel(sendModel, index);
+        const int proxyIndex = proxyIndexFromModel(sendModel, index);
         Q_EMIT signalCurrentProcessPackageIndex(proxyIndex);
 
     } else {

--- a/src/deb-installer/model/proxy_package_list_model.h
+++ b/src/deb-installer/model/proxy_package_list_model.h
@@ -23,16 +23,23 @@ public:
     void removePackage(int index) override;
     QString checkPackageValid(const QString &packagePath) override;
 
-    Q_SLOT void slotInstallPackages() override;
-    Q_SLOT void slotUninstallPackage(int index) override;
+    Pkg::PackageInstallStatus checkInstallStatus(const QString &packagePath) override;
+    Pkg::DependsStatus checkDependsStatus(const QString &packagePath) override;
+    QStringList getPackageInfo(const QString &packagePath) override;
+    QString lastProcessError() override;
+
+    Q_SLOT bool slotInstallPackages() override;
+    Q_SLOT bool slotUninstallPackage(int index) override;
 
     void reset() override;
     void resetInstallStatus() override;
 
-private:
-    void nextModelInstall();
-
     ModelPtr modelFromType(Pkg::PackageType type);
+    ModelPtr addModelFromFile(const QString &packagePath);
+
+private:
+    bool nextModelInstall();
+
     ModelPtr addModel(Pkg::PackageType type);
     void connectModel(ModelPtr model);
 

--- a/src/deb-installer/model/proxy_package_list_model.h
+++ b/src/deb-installer/model/proxy_package_list_model.h
@@ -27,6 +27,7 @@ public:
     Pkg::DependsStatus checkDependsStatus(const QString &packagePath) override;
     QStringList getPackageInfo(const QString &packagePath) override;
     QString lastProcessError() override;
+    bool containsSignatureFailed() const override;
 
     Q_SLOT bool slotInstallPackages() override;
     Q_SLOT bool slotUninstallPackage(int index) override;
@@ -44,7 +45,7 @@ private:
     void connectModel(ModelPtr model);
 
     QPair<ModelPtr, int> findFromProxyIndex(int proxyIndex) const;
-    int proxyIndexFormModel(ModelPtr findModel, int index);
+    int proxyIndexFromModel(ModelPtr findModel, int index);
 
     // signals forwarded through
     Q_SLOT void onSourcePacakgeCountChanged(int count);

--- a/src/deb-installer/singleInstallerApplication.cpp
+++ b/src/deb-installer/singleInstallerApplication.cpp
@@ -4,6 +4,7 @@
 
 #include "singleInstallerApplication.h"
 #include "view/pages/debinstaller.h"
+#include "uab/uab_backend.h"
 
 #include <DWidgetUtil>
 #include <DGuiApplicationHelper>
@@ -41,6 +42,10 @@ void SingleInstallerApplication::activateWindow()
     }
 
     if (bIsDbus) {
+        // init uab backend synchronous on bus mode, but must be initialized after deb backend.
+        // sa PackageAnalyzer::instance()
+        Uab::UabBackend::instance()->initBackend(false);
+
         m_qspMainWnd->hide();
     }
 
@@ -157,7 +162,7 @@ bool SingleInstallerApplication::parseCmdLine()
         qDebug() << "Register dbus service successfully";
         const QStringList paraList = parser.positionalArguments();
         if (paraList.isEmpty()) {
-            // dbus打开不显示界面
+            // hide main window on dbus
             if (parser.isSet("dbus")) {
                 bIsDbus = true;
             }

--- a/src/deb-installer/singleInstallerApplication.cpp
+++ b/src/deb-installer/singleInstallerApplication.cpp
@@ -167,7 +167,6 @@ bool SingleInstallerApplication::parseCmdLine()
                 bIsDbus = true;
             }
         } else {
-            QStringList paraList = parser.positionalArguments();
             for (auto it : paraList) {
                 if (it.endsWith("ddim")) {
                     m_ddimFiles.append(it);

--- a/src/deb-installer/uab/uab_backend.h
+++ b/src/deb-installer/uab/uab_backend.h
@@ -22,7 +22,7 @@ public:
 
     UabPkgInfo::Ptr findPackage(const QString &packageId);
 
-    void initBackend();
+    void initBackend(bool async = true);
     bool backendInited() const;
     Q_SIGNAL void backendInitFinsihed();
 

--- a/src/deb-installer/uab/uab_backend.h
+++ b/src/deb-installer/uab/uab_backend.h
@@ -26,6 +26,9 @@ public:
     bool backendInited() const;
     Q_SIGNAL void backendInitFinsihed();
 
+    bool linglongExists() const;
+    bool recheckLinglongExists();
+
     QString lastError() const;
     void dumpPackageList() const;
 
@@ -36,6 +39,8 @@ public:
     // internal
     Q_SLOT void backendInitData(const QList<UabPkgInfo::Ptr> &packageList, const QSet<QString> &archs);
     static void backendProcess(const QPointer<Uab::UabBackend> &notifyPtr);
+    static bool parsePackagesFromRawJson(const QByteArray &jsonData, QList<UabPkgInfo::Ptr> &packageList);
+    static bool parsePackagesFromRawOutput(const QByteArray &output, QList<UabPkgInfo::Ptr> &packageList);
     static void sortPackages(QList<UabPkgInfo::Ptr> &packageList);
 
     // update backend database after controller process finished.
@@ -48,6 +53,7 @@ private:
 
 private:
     bool m_init{false};
+    bool m_linglongExists{false};  // check Linglong executable (ll-cli) exists.
     QList<UabPkgInfo::Ptr> m_packageList;
     QSet<QString> m_supportArchSet;
     QString m_lastError;

--- a/src/deb-installer/uab/uab_defines.h
+++ b/src/deb-installer/uab/uab_defines.h
@@ -38,7 +38,7 @@ struct UabPkgInfo
     QString appName;   // display name
     QString version;
     QStringList architecture;  // uab package may support multiple arch
-    QString shortDescription;
+    QString description;
     QString channel;
 };
 

--- a/src/deb-installer/uab/uab_package.cpp
+++ b/src/deb-installer/uab/uab_package.cpp
@@ -8,6 +8,11 @@
 
 namespace Uab {
 
+/**
+ * @class UabPackage
+ * @brief Uab package, contains package information and runtime status.
+ *        Store version, install status, operation status, error code, and error message.
+ */
 UabPackage::UabPackage(const UabPkgInfo::Ptr &metaPtr)
     : m_metaPtr(metaPtr)
 {
@@ -21,7 +26,7 @@ const UabPkgInfo::Ptr &UabPackage::info() const
 
 bool UabPackage::isValid() const
 {
-    if (!m_metaPtr) {
+    if (!m_metaPtr || !fileExists()) {
         return false;
     }
 
@@ -48,6 +53,16 @@ void UabPackage::setProcessError(Pkg::ErrorCode err, const QString &errorString)
 {
     m_errorCode = err;
     m_processError = errorString;
+}
+
+bool UabPackage::fileExists() const
+{
+    return m_exists;
+}
+
+void UabPackage::markNotExists()
+{
+    m_exists = false;
 }
 
 Pkg::DependsStatus UabPackage::dependsStatus() const
@@ -112,6 +127,9 @@ void UabPackage::reset()
 
     m_installedVersion.clear();
     m_installStatus = Pkg::NotInstalled;
+
+    m_errorCode = Pkg::NoError;
+    m_processError.clear();
 
     if (!Uab::UabBackend::instance()->linglongExists()) {
         setDependsStatus(Pkg::DependsBreak);

--- a/src/deb-installer/uab/uab_package.cpp
+++ b/src/deb-installer/uab/uab_package.cpp
@@ -44,22 +44,33 @@ void UabPackage::setDependsStatus(Pkg::DependsStatus status)
     }
 }
 
-Pkg::DependsStatus UabPackage::dependsStatus()
+void UabPackage::setProcessError(Pkg::ErrorCode err, const QString &errorString)
+{
+    m_errorCode = err;
+    m_processError = errorString;
+}
+
+Pkg::DependsStatus UabPackage::dependsStatus() const
 {
     return m_dependsStatus;
 }
 
-Pkg::PackageInstallStatus UabPackage::installStatus()
+Pkg::PackageInstallStatus UabPackage::installStatus() const
 {
     return m_installStatus;
 }
 
-Pkg::PackageOperationStatus UabPackage::operationStatus()
+Pkg::PackageOperationStatus UabPackage::operationStatus() const
 {
     return m_operationStatus;
 }
 
-QString UabPackage::installedVersion()
+Pkg::ErrorCode UabPackage::errorCode() const
+{
+    return m_errorCode;
+}
+
+QString UabPackage::installedVersion() const
 {
     return m_installedVersion;
 }
@@ -67,6 +78,16 @@ QString UabPackage::installedVersion()
 QString UabPackage::failedReason() const
 {
     return m_failReason;
+}
+
+QString UabPackage::processError() const
+{
+    return m_processError;
+}
+
+UabPackage::Ptr UabPackage::fromInfo(const UabPkgInfo::Ptr &infoPtr)
+{
+    return Uab::UabPackage::Ptr::create(infoPtr);
 }
 
 UabPackage::Ptr UabPackage::fromFilePath(const QString &filePath)

--- a/src/deb-installer/uab/uab_package.h
+++ b/src/deb-installer/uab/uab_package.h
@@ -21,6 +21,8 @@ public:
     bool isValid() const;
     void setDependsStatus(Pkg::DependsStatus status);
     void setProcessError(Pkg::ErrorCode err, const QString &errorString);
+    bool fileExists() const;
+    void markNotExists();
 
     Pkg::DependsStatus dependsStatus() const;
     Pkg::PackageInstallStatus installStatus() const;
@@ -39,6 +41,8 @@ private:
 
 private:
     Uab::UabPkgInfo::Ptr m_metaPtr;
+
+    bool m_exists{true};
 
     Pkg::DependsStatus m_dependsStatus{Pkg::DependsOk};            // package's depends info
     Pkg::PackageInstallStatus m_installStatus{Pkg::NotInstalled};  // version check

--- a/src/deb-installer/uab/uab_package.h
+++ b/src/deb-installer/uab/uab_package.h
@@ -18,18 +18,20 @@ public:
     explicit UabPackage(const Uab::UabPkgInfo::Ptr &metaPtr);
 
     const Uab::UabPkgInfo::Ptr &info() const;
-
     bool isValid() const;
-
     void setDependsStatus(Pkg::DependsStatus status);
+    void setProcessError(Pkg::ErrorCode err, const QString &errorString);
 
-    Pkg::DependsStatus dependsStatus();
-    Pkg::PackageInstallStatus installStatus();
-    Pkg::PackageOperationStatus operationStatus();
+    Pkg::DependsStatus dependsStatus() const;
+    Pkg::PackageInstallStatus installStatus() const;
+    Pkg::PackageOperationStatus operationStatus() const;
+    Pkg::ErrorCode errorCode() const;
 
-    QString installedVersion();
+    QString installedVersion() const;
     QString failedReason() const;
+    QString processError() const;
 
+    static UabPackage::Ptr fromInfo(const Uab::UabPkgInfo::Ptr &infoPtr);
     static UabPackage::Ptr fromFilePath(const QString &filePath);
 
 private:
@@ -41,9 +43,11 @@ private:
     Pkg::DependsStatus m_dependsStatus{Pkg::DependsOk};            // package's depends info
     Pkg::PackageInstallStatus m_installStatus{Pkg::NotInstalled};  // version check
     Pkg::PackageOperationStatus m_operationStatus{Pkg::Prepare};   // status for operation flow
+    Pkg::ErrorCode m_errorCode{Pkg::NoError};
 
     QString m_installedVersion;
     QString m_failReason;
+    QString m_processError;  // runtime install/uninstall error raw output
 
     friend class UabPackageListModel;
 

--- a/src/deb-installer/uab/uab_package.h
+++ b/src/deb-installer/uab/uab_package.h
@@ -21,6 +21,8 @@ public:
 
     bool isValid() const;
 
+    void setDependsStatus(Pkg::DependsStatus status);
+
     Pkg::DependsStatus dependsStatus();
     Pkg::PackageInstallStatus installStatus();
     Pkg::PackageOperationStatus operationStatus();

--- a/src/deb-installer/uab/uab_package_list_model.cpp
+++ b/src/deb-installer/uab/uab_package_list_model.cpp
@@ -59,7 +59,7 @@ QVariant UabPackageListModel::data(const QModelIndex &index, int role) const
         case PackageShortDescriptionRole:
             Q_FALLTHROUGH();
         case PackageLongDescriptionRole:
-            return uabPtr->info()->shortDescription;
+            return uabPtr->info()->description;
         case PackageVersionStatusRole:
             return uabPtr->installStatus();
         case PackageDependsStatusRole:
@@ -144,6 +144,15 @@ void UabPackageListModel::slotInstallPackages()
         return;
     }
 
+    if (!Uab::UabBackend::instance()->recheckLinglongExists()) {
+        // todo reset status;
+        for (const auto &uabPtr : m_uabPkgList) {
+            uabPtr->setDependsStatus(Pkg::DependsBreak);
+            Q_EMIT dataChanged(index(0), index(m_uabPkgList.size() - 1), {PackageOperateStatusRole});
+        }
+        return;
+    }
+
     // reset, mark package waiting install
     resetInstallStatus();
     for (auto uabPtr : m_uabPkgList) {
@@ -157,6 +166,10 @@ void UabPackageListModel::slotInstallPackages()
 
 void UabPackageListModel::slotUninstallPackage(const int i)
 {
+    if (!Uab::UabBackend::instance()->recheckLinglongExists()) {
+        // todo reset status;
+    }
+
     bool callRet = false;
 
     do {

--- a/src/deb-installer/uab/uab_package_list_model.h
+++ b/src/deb-installer/uab/uab_package_list_model.h
@@ -11,6 +11,8 @@
 #include "uab_process_controller.h"
 #include "model/abstract_package_list_model.h"
 
+class QFileSystemWatcher;
+
 namespace Uab {
 
 class UabPackageListModel : public AbstractPackageListModel
@@ -30,6 +32,7 @@ public:
     Pkg::DependsStatus checkDependsStatus(const QString &packagePath) override;
     QStringList getPackageInfo(const QString &packagePath) override;
     QString lastProcessError() override;
+    bool containsSignatureFailed() const override;
 
     Q_SLOT bool slotInstallPackages() override;
     Q_SLOT bool slotUninstallPackage(int index) override;
@@ -49,12 +52,16 @@ private:
     bool packageExists(const UabPackage::Ptr &uabPtr) const;
     bool linglongExists();
 
+    Q_SLOT void slotFileChanged(const QString &filePath);
+
 private:
     int m_operatingIndex{-1};
     QList<UabPackage::Ptr> m_uabPkgList;
     UabProcessController *m_processor{nullptr};
 
     QStringList m_delayAppendPackages;  // wait for backend inited.
+
+    QFileSystemWatcher *m_fileWatcher{nullptr};
 };
 
 }  // namespace Uab

--- a/src/deb-installer/uab/uab_package_list_model.h
+++ b/src/deb-installer/uab/uab_package_list_model.h
@@ -26,14 +26,19 @@ public:
     void removePackage(int index) override;
     QString checkPackageValid(const QString &packagePath) override;
 
-    Q_SLOT void slotInstallPackages() override;
-    Q_SLOT void slotUninstallPackage(int index) override;
+    Pkg::PackageInstallStatus checkInstallStatus(const QString &packagePath) override;
+    Pkg::DependsStatus checkDependsStatus(const QString &packagePath) override;
+    QStringList getPackageInfo(const QString &packagePath) override;
+    QString lastProcessError() override;
+
+    Q_SLOT bool slotInstallPackages() override;
+    Q_SLOT bool slotUninstallPackage(int index) override;
 
     void reset() override;
     void resetInstallStatus() override;
 
 private:
-    void installNextUab();
+    bool installNextUab();
 
     Q_SLOT void slotBackendProgressChanged(float progress);
     Q_SLOT void slotBackendProcessFinished(bool success);
@@ -41,7 +46,8 @@ private:
     void setCurrentOperation(Pkg::PackageOperationStatus s);
     bool checkIndexValid(int index) const;
     UabPackage::Ptr preCheckPackage(const QString &packagePath);
-    bool packageExists(const UabPackage::Ptr &uabPtr);
+    bool packageExists(const UabPackage::Ptr &uabPtr) const;
+    bool linglongExists();
 
 private:
     int m_operatingIndex{-1};

--- a/src/deb-installer/uab/uab_process_controller.h
+++ b/src/deb-installer/uab/uab_process_controller.h
@@ -5,9 +5,9 @@
 #ifndef UABPROCESSCONTROLLER_H
 #define UABPROCESSCONTROLLER_H
 
-#include "uab_defines.h"
-
 #include <QObject>
+
+#include "uab_package.h"
 
 class QProcess;
 
@@ -35,11 +35,9 @@ public:
     bool isRunning() const;
 
     bool reset();
-    bool markInstall(const UabPkgInfo::Ptr &installPtr);
-    bool markUninstall(const UabPkgInfo::Ptr &unisntallPtr);
+    bool markInstall(const UabPackage::Ptr &installPtr);
+    bool markUninstall(const UabPackage::Ptr &unisntallPtr);
     bool commitChanges();
-
-    QString lastError() const;
 
     Q_SIGNAL void processStart();
     Q_SIGNAL void processFinished(bool success);
@@ -55,10 +53,11 @@ private:
 
     bool nextProcess();
 
-    bool installImpl(const UabPkgInfo::Ptr &installPtr);
-    bool uninstallImpl(const UabPkgInfo::Ptr &uninstallPtr);
+    bool installImpl(const UabPackage::Ptr &installPtr);
+    bool uninstallImpl(const UabPackage::Ptr &uninstallPtr);
 
     bool checkIndexValid();
+    UabPackage::Ptr currentPackagePtr();
 
     void commitCurrentChangeToBackend();
 
@@ -67,7 +66,7 @@ private:
 
     ProcFlags m_procFlag{Prepare};
     int m_currentIndex{-1};
-    QList<QPair<ProcFlag, UabPkgInfo::Ptr>> m_procList;  // install/uninstall package list
+    QList<QPair<ProcFlag, UabPackage::Ptr>> m_procList;  // install/uninstall package list
 
     Q_DISABLE_COPY(UabProcessController);
 };

--- a/src/deb-installer/uab/uab_process_controller.h
+++ b/src/deb-installer/uab/uab_process_controller.h
@@ -48,6 +48,8 @@ public:
 
 private:
     bool ensureProcess();
+    void parseProgressFromJson(const QByteArray &jsonData);
+    void parseProgressFromRawOutput(const QByteArray &output);
     Q_SLOT void onReadOutput();
     Q_SLOT void onFinished(int exitCode, int exitStatus);
 

--- a/src/deb-installer/utils/package_defines.h
+++ b/src/deb-installer/utils/package_defines.h
@@ -24,8 +24,8 @@ using DependsPair = QPair<QList<DependInfo>, QList<DependInfo>>;
 
 enum PackageType {
     UnknownPackage,
-    Uab,  // ensure uab priority
-    Deb,
+    Deb,  // ensure deb priority
+    Uab,
     Ddim,
     Proxy,  // both deb and uab
 };

--- a/src/deb-installer/utils/package_defines.h
+++ b/src/deb-installer/utils/package_defines.h
@@ -70,6 +70,16 @@ enum PackageOperationStatus {
     VerifyFailed,  // runtime signature verfiy failed (hierarchical verify)
 };
 
+// Signature fail error code
+enum ErrorCode {
+    NoError,
+    UnknownError,
+    NoDigitalSignature = 101,
+    DigitalSignatureError,
+    ConfigAuthCancel = 127,     // Authentication failed
+    ApplocationProhibit = 404,  // the current package is in the blacklist and is prohibited from installation
+};
+
 }  // namespace Pkg
 
 Q_DECLARE_METATYPE(Pkg::DependsPair)

--- a/src/deb-installer/utils/utils.cpp
+++ b/src/deb-installer/utils/utils.cpp
@@ -301,7 +301,7 @@ Pkg::PackageReadability Utils::checkPackageReadable(const QString &packagePath)
     // Determine whether the route information is a local path
     QStorageInfo info(packagePath);
     QString device = info.device();
-    // Blacklist identifies, gvfs/cifs as the file system 
+    // Blacklist identifies, gvfs/cifs as the file system
     // that currently manages the remote directory
     if (device.startsWith("gvfs") || device.startsWith("cifs")) {
         qWarning() << "Disable open remote file, the devices is" << device;

--- a/src/deb-installer/utils/utils.cpp
+++ b/src/deb-installer/utils/utils.cpp
@@ -337,7 +337,7 @@ int Utils::compareVersion(const QString &v1, const QString &v2)
 
 Pkg::PackageType Utils::detectPackage(const QString &filePath)
 {
-    const QMimeDatabase db;
+    QMimeDatabase db;
     const QMimeType mime = db.mimeTypeForFile(filePath);
     const QFileInfo info(filePath);
 
@@ -414,6 +414,22 @@ bool Utils::isDevelopMode()
     });
 
     return kIsDevelopMode;
+}
+
+/**
+ * @brief Mark whether the wine pre-dependency is being installed.
+ *        Not thread-safe.
+ */
+static bool kWinePreDependsStatus = false;
+
+bool GlobalStatus::winePreDependsInstalling()
+{
+    return kWinePreDependsStatus;
+}
+
+void GlobalStatus::setWinePreDependsInstalling(bool b)
+{
+    kWinePreDependsStatus = b;
 }
 
 DebApplicationHelper *DebApplicationHelper::instance()

--- a/src/deb-installer/utils/utils.h
+++ b/src/deb-installer/utils/utils.h
@@ -75,4 +75,12 @@ public:
     static bool isDevelopMode();  // Check if develop mode (root)
 };
 
+class GlobalStatus
+{
+public:
+    // wine depends installing flag
+    static bool winePreDependsInstalling();
+    static void setWinePreDependsInstalling(bool b);
+};
+
 #endif

--- a/src/deb-installer/view/pages/debinstaller.h
+++ b/src/deb-installer/view/pages/debinstaller.h
@@ -243,6 +243,9 @@ private slots:
      */
     void slotShowPkgProcessBlockPage(BackendProcessPage::DisplayMode mode, int currentRate, int pkgCount);
 
+    // install / unisntall finished
+    void slotWorkerFinished();
+
 private:
     /**
      * @brief initUI

--- a/src/deb-installer/view/pages/debinstaller.h
+++ b/src/deb-installer/view/pages/debinstaller.h
@@ -182,8 +182,6 @@ private slots:
      */
     void slotSettingDialogVisiable();
 
-    // TODO(renbin): DBus interface, refactor later
-#if 0
     /**
      * @brief PackagesSelected
      * 添加包，但是不显示主窗口
@@ -221,7 +219,6 @@ private slots:
      * 查找包信息,返回(包名，包的路径，包的版本，包可用的架构，包的短描述，包的长描述)
      */
     QString getPackageInfo(const QString &debPath);
-#endif
 
     /**
      * @brief slotShowSelectPage
@@ -328,8 +325,8 @@ private:
     DdimSt analyzeV10(const QJsonObject &ddimobj, const QString &ddimDir);
 
 private:
-    AbstractPackageListModel *m_fileListModel = nullptr;         // model 类
-    FileChooseWidget *m_fileChooseWidget = nullptr;  // 文件选择的widget
+    AbstractPackageListModel *m_fileListModel = nullptr;  // model 类
+    FileChooseWidget *m_fileChooseWidget = nullptr;       // 文件选择的widget
     UninstallConfirmPage *m_uninstallPage = nullptr;
 
     QPointer<QWidget> m_lastPage;               // 存放上一个页面的指针
@@ -356,7 +353,7 @@ private:
         SinglePage = 2,
         UninstallPage = 3,
     };
-    CurrentPage m_Filterflag { ChoosePage };  // Determine the current page      choose:-1;multiple:1;single:2;uninstall:3
+    CurrentPage m_Filterflag{ChoosePage};  // Determine the current page      choose:-1;multiple:1;single:2;uninstall:3
 
     bool m_packageAppending = false;
     int m_wineAuthStatus = -1;  // 记录依赖配置授权状态

--- a/src/deb-installer/view/pages/multipleinstallpage.cpp
+++ b/src/deb-installer/view/pages/multipleinstallpage.cpp
@@ -338,8 +338,7 @@ void MultipleInstallPage::initConnections()
         QVariant data = m_debListModel->data(index, AbstractPackageListModel::PackageDependsDetailRole);
         auto depends = data.value<Pkg::DependsPair>();
 
-        // TODO: implement later
-        slotDependPackages(depends, false);
+        slotDependPackages(depends, GlobalStatus::winePreDependsInstalling());
     });
 }
 

--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -779,8 +779,7 @@ void SingleInstallPage::slotRefreshSinglePackageDepends()
         QVariant data = m_packagesModel->data(index, AbstractPackageListModel::PackageDependsDetailRole);
         auto depends = data.value<Pkg::DependsPair>();
 
-        // TODO: implement later
-        slotDependPackages(depends, false);
+        slotDependPackages(depends, GlobalStatus::winePreDependsInstalling());
     }
 }
 

--- a/src/deb-installer/view/widgets/error_notify_dialog_helper.cpp
+++ b/src/deb-installer/view/widgets/error_notify_dialog_helper.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "error_notify_dialog_helper.h"
+
+#include <QStyle>
+#include <QLabel>
+#include <QPushButton>
+
+#include <DDialog>
+
+#include "utils/hierarchicalverify.h"
+
+DWIDGET_USE_NAMESPACE
+
+static const int kDefaultDialogWidth = 380;
+
+/**
+ * @class ErrorNotifyDialogHelper
+ * @brief A helper class to show the error notify dialog.
+ */
+ErrorNotifyDialogHelper::ErrorNotifyDialogHelper(QObject *parent)
+    : QObject{parent}
+{
+}
+
+void ErrorNotifyDialogHelper::showHierarchicalVerifyWindow()
+{
+    if (!HierarchicalVerify::instance()->isValid()) {
+        return;
+    }
+
+    DDialog *dialog = new DDialog();
+    // limit the display width
+    dialog->setFixedWidth(kDefaultDialogWidth);
+    dialog->setFocusPolicy(Qt::TabFocus);
+    dialog->setModal(true);
+    dialog->setWindowFlag(Qt::WindowStaysOnTopHint);
+
+    // set the information displayed by the pop-up window
+    dialog->setTitle(QObject::tr("Unable to install"));
+    dialog->setMessage(
+        QObject::tr("This package does not have a valid digital signature and has been blocked from installing/running. "
+                    "Go to Security Center > Tools > App Security to change the settings."));
+    dialog->setIcon(QIcon::fromTheme("di_popwarning"));
+    dialog->addButton(QObject::tr("Cancel", "button"), false, DDialog::ButtonNormal);
+    dialog->addButton(QObject::tr("Proceed", "button"), true, DDialog::ButtonRecommend);
+    dialog->show();
+
+    // Copy from ddialog.cpp, used to set the default dialog height.
+    // Avoid incomplete display at large font size/high zoom ratio, called after show().
+    auto *msgLabel = dialog->findChild<QLabel *>("MessageLabel");
+    if (msgLabel) {
+        auto *dialogStyle = dialog->style();
+        if (dialogStyle) {
+            const QSize sz =
+                dialogStyle->itemTextRect(msgLabel->fontMetrics(), msgLabel->rect(), Qt::TextWordWrap, false, msgLabel->text())
+                    .size();
+            msgLabel->setMinimumHeight(qMax(sz.height(), msgLabel->sizeHint().height()));
+        }
+    }
+
+    auto *btnPorceed = qobject_cast<QPushButton *>(dialog->getButton(1));
+    if (btnPorceed) {
+        btnPorceed->setFocusPolicy(Qt::TabFocus);
+        btnPorceed->setFocus();
+    }
+
+    connect(dialog, &DDialog::finished, [dialog](int result) {
+        if (QDialog::Accepted == result) {
+            HierarchicalVerify::instance()->proceedDefenderSafetyPage();
+        }
+        dialog->deleteLater();
+    });
+}

--- a/src/deb-installer/view/widgets/error_notify_dialog_helper.h
+++ b/src/deb-installer/view/widgets/error_notify_dialog_helper.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ERROR_NOTIFY_DIALOG_HELPER_H
+#define ERROR_NOTIFY_DIALOG_HELPER_H
+
+#include <QObject>
+
+// popup error dialogs, support deb / uab packages
+class ErrorNotifyDialogHelper : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ErrorNotifyDialogHelper(QObject *parent = nullptr);
+    ~ErrorNotifyDialogHelper() override = default;
+
+    static void showHierarchicalVerifyWindow();
+
+private:
+    Q_DISABLE_COPY_MOVE(ErrorNotifyDialogHelper);
+};
+
+#endif  // ERROR_NOTIFY_DIALOG_HELPER_H

--- a/tests/src/manager/ut_packagemanager.cpp
+++ b/tests/src/manager/ut_packagemanager.cpp
@@ -10,6 +10,7 @@
 #include "../deb-installer/manager/AddPackageThread.h"
 #include "../deb-installer/model/deblistmodel.h"
 #include "../deb-installer/model/packageanalyzer.h"
+#include "../deb-installer/utils/utils.h"
 
 #include <stub.h>
 #include <QFuture>
@@ -875,7 +876,8 @@ TEST_F(UT_packagesManager, PackageManager_UT_packageInstallStatus_01)
 
     m_packageManager->appendPackage({"/1"});
     ASSERT_EQ(m_packageManager->packageInstallStatus(0), 0);
-    ASSERT_EQ(Pkg::PackageInstallStatus::NotInstalled, m_packageManager->m_packageInstallStatus[m_packageManager->m_packageMd5.value(0)]);
+    ASSERT_EQ(Pkg::PackageInstallStatus::NotInstalled,
+              m_packageManager->m_packageInstallStatus[m_packageManager->m_packageMd5.value(0)]);
 }
 
 TEST_F(UT_packagesManager, PackageManager_UT_packageInstallStatus_02)
@@ -987,13 +989,13 @@ TEST_F(UT_packagesManager, PackageManager_UT_DealDependResult)
     m_packageManager->slotDealDependResult(5, 0, "");
     EXPECT_EQ(Pkg::DependsStatus::DependsBreak,
               m_packageManager->m_packageMd5DependsStatus[m_packageManager->m_dependInstallMark[0]].status);
-    m_packageManager->installWineDepends = true;
+    GlobalStatus::setWinePreDependsInstalling(true);
     m_packageManager->slotDealDependResult(5, 0, "");
     EXPECT_EQ(Pkg::DependsStatus::DependsBreak,
               m_packageManager->m_packageMd5DependsStatus[m_packageManager->m_dependInstallMark[0]].status);
     m_packageManager->m_preparedPackages.append({"1", "2"});
     m_packageManager->slotDealDependResult(5, 0, "");
-    EXPECT_FALSE(m_packageManager->installWineDepends);
+    EXPECT_FALSE(GlobalStatus::winePreDependsInstalling());
     EXPECT_EQ(Pkg::DependsStatus::DependsBreak,
               m_packageManager->m_packageMd5DependsStatus[m_packageManager->m_dependInstallMark[0]].status);
 }

--- a/tests/src/model/ut_deblistmodel.cpp
+++ b/tests/src/model/ut_deblistmodel.cpp
@@ -10,6 +10,7 @@
 #include "../deb-installer/utils/utils.h"
 #include "../deb-installer/utils/result.h"
 #include "../deb-installer/utils/hierarchicalverify.h"
+#include "../deb-installer/view/widgets/error_notify_dialog_helper.h"
 
 #include <stub.h>
 
@@ -858,7 +859,8 @@ TEST_F(ut_DebListModel_test, deblistmodel_UT_DealDependResult)
 TEST_F(ut_DebListModel_test, deblistmodel_UT_DealDependResult_VerifyDependsErr)
 {
     Stub tmpStub;
-    tmpStub.set(ADDR(DebListModel, showHierarchicalVerifyWindow), stub_DebListModel_showHierarchicalVerifyWindow_DoNothing);
+    tmpStub.set(ADDR(ErrorNotifyDialogHelper, showHierarchicalVerifyWindow),
+                stub_DebListModel_showHierarchicalVerifyWindow_DoNothing);
 
     g_VerifyDeependErrCount = 0;
     m_debListModel->slotDealDependResult(DebListModel::VerifyDependsErr, 0, "");
@@ -895,7 +897,7 @@ TEST_F(ut_DebListModel_test, deblistmodel_UT_bumpInstallIndex)
     EXPECT_EQ("", m_debListModel->m_operatingPackageMd5);
 }
 
-TEST_F(ut_DebListModel_test, deblistmodel_UT_bumpInstallIndex_showHierarchicalVerifyWindow)
+TEST_F(ut_DebListModel_test, deblistmodel_UT_slotInstallPackages_resetHierarchicalVerify)
 {
     stub.set(ADDR(DebListModel, installNextDeb), model_installNextDeb);
     m_debListModel->m_operatingIndex = 0;
@@ -903,12 +905,7 @@ TEST_F(ut_DebListModel_test, deblistmodel_UT_bumpInstallIndex_showHierarchicalVe
     m_debListModel->m_packageMd5.append("1");
     m_debListModel->m_hierarchicalVerifyError = true;
 
-    Stub tmpStub;
-    tmpStub.set(ADDR(DebListModel, showHierarchicalVerifyWindow), stub_DebListModel_showHierarchicalVerifyWindow_DoNothing);
-
-    g_VerifyDeependErrCount = 0;
-    m_debListModel->bumpInstallIndex();
-    EXPECT_EQ(g_VerifyDeependErrCount, 1);
+    m_debListModel->slotInstallPackages();
     EXPECT_FALSE(m_debListModel->m_hierarchicalVerifyError);
 }
 

--- a/tests/src/model/ut_deblistmodel.cpp
+++ b/tests/src/model/ut_deblistmodel.cpp
@@ -762,7 +762,7 @@ TEST_F(ut_DebListModel_test, deblistmodel_UT_checkDigitalSignature_03)
     m_debListModel->m_isDigitalVerify = true;
     stub.set((Utils::VerifyResultCode(*)(QString))ADDR(Utils, Digital_Verify), model_Digital_Verify2);
     ASSERT_TRUE(m_debListModel->checkDigitalSignature());
-    m_debListModel->showDevelopDigitalErrWindow(DebListModel::NoDigitalSignature);
+    m_debListModel->showDevelopDigitalErrWindow(Pkg::NoDigitalSignature);
     EXPECT_EQ(1, m_debListModel->preparedPackages().size());
 }
 
@@ -1008,7 +1008,7 @@ TEST_F(ut_DebListModel_test, onTransactionFinished_HierarchicalVerify_Failed)
 
     m_debListModel->slotTransactionFinished();
     EXPECT_EQ(nullptr, m_debListModel->m_currentTransaction);
-    EXPECT_EQ(DebListModel::DigitalSignatureError, m_debListModel->m_packageFailCode[m_debListModel->m_operatingPackageMd5]);
+    EXPECT_EQ(Pkg::DigitalSignatureError, m_debListModel->m_packageFailCode[m_debListModel->m_operatingPackageMd5]);
     EXPECT_TRUE(m_debListModel->m_hierarchicalVerifyError);
 
     delete g_transaction;
@@ -1239,12 +1239,12 @@ const QList<QString> ut_preparedPackages()
 TEST_F(ut_DebListModel_test, deblistmodel_UT_digitalVerifyFailed)
 {
     //    stub.set(ADDR(DebListModel,preparedPackages),ut_preparedPackages);
-    m_debListModel->digitalVerifyFailed(DebListModel::ErrorCode::DigitalSignatureError);
+    m_debListModel->digitalVerifyFailed(Pkg::ErrorCode::DigitalSignatureError);
     QStringList list;
     list << "/";
     m_debListModel->slotAppendPackage(list);
     m_debListModel->m_isDevelopMode = true;
-    m_debListModel->digitalVerifyFailed(DebListModel::ErrorCode::DigitalSignatureError);
+    m_debListModel->digitalVerifyFailed(Pkg::ErrorCode::DigitalSignatureError);
     EXPECT_EQ(1, m_debListModel->m_packageFailCode.size());
 }
 

--- a/tests/src/uab/ut_uab_process_controller.cpp
+++ b/tests/src/uab/ut_uab_process_controller.cpp
@@ -31,7 +31,7 @@ void utDebProcessController::SetUp()
     utStub.set((void(QProcess::*)(QProcess::OpenMode))ADDR(QProcess, start), stub_QProcess_start);
 }
 
-void utDebProcessController::TearDown() { }
+void utDebProcessController::TearDown() {}
 
 TEST_F(utDebProcessController, installExecSuccess)
 {
@@ -39,7 +39,7 @@ TEST_F(utDebProcessController, installExecSuccess)
     auto uabPtr = Uab::UabPkgInfo::Ptr::create();
     uabPtr->filePath = "localtest";
     uabController.reset();
-    uabController.markInstall(uabPtr);
+    uabController.markInstall(Uab::UabPackage::fromInfo(uabPtr));
     uabController.commitChanges();
 
     EXPECT_EQ(uabController.m_process->program(), uabPtr->filePath);


### PR DESCRIPTION
[feat: check linglong env and json parser](https://github.com/linuxdeepin/deepin-deb-installer/commit/f4509915dd85bb823a7371117cdd3841edd8d0ef) 

Check ll-cli environment before install;
Add json style ll-cli output parser;
Deb package has higher priority than uab pacakge.

Log: Check linglong env and json parser
Influence: uab-package

[refactor: update the installer dbus interface](https://github.com/linuxdeepin/deepin-deb-installer/commit/50608f9cd7ab01bcbb0ce6f1aa2bab134c5abe1b) 

Update installer DBus interface to support uab package.

Log: The DBus interface supports uab package.
Influence: uab-package

[fix: tip for installation process](https://github.com/linuxdeepin/deepin-deb-installer/commit/9308cf6f837194888abacbe9417b7ae17d4a5c28) 

Add the wine pre-depends flag function;
Add monitoring and tips for UAB file changes;
Adjust the hierarchical signature verification dialog.

Log: Fix tips for installation process.