### PR TITLE
fix: init flag before check 'or depends'

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -618,6 +618,7 @@ bool PackagesManager::targetPackageCanReplace(QApt::Package *targetPackage, QApt
         QList<DependencyItem> rdependsDep = rdependPackage->depends();
         for (const DependencyItem &item : rdependsDep) {
             replaceable = false;
+            containsInstalledProvides = false;
 
             // or depends
             for (const DependencyInfo &info : item) {
@@ -631,7 +632,6 @@ bool PackagesManager::targetPackageCanReplace(QApt::Package *targetPackage, QApt
                         const auto type = info.relationType();
                         const auto result = Package::compareVersion(version, info.packageVersion());
                         if (!dependencyVersionMatch(result, type)) {
-                            replaceable = false;
                             break;
                         }
                     }
@@ -645,7 +645,7 @@ bool PackagesManager::targetPackageCanReplace(QApt::Package *targetPackage, QApt
                     const auto type = info.relationType();
                     const auto result = Package::compareVersion(targetPackage->version(), info.packageVersion());
                     if (!dependencyVersionMatch(result, type)) {
-                        replaceable = false;
+                        break;
                     }
 
                     replaceable = true;


### PR DESCRIPTION
As title.

Log: Fix wrong state when checking 'or depends'.
Bug: https://pms.uniontech.com/bug-view-275221.html