### PR TITLE
feat: adapt compatibility mode

### DIFF
--- a/assets/icons/deepin/builtin/dark/icons/di_dialog-warning_85px.svg
+++ b/assets/icons/deepin/builtin/dark/icons/di_dialog-warning_85px.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="85px" height="85px" viewBox="0 0 85 85" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>status/64/dialog-warning</title>
+    <defs>
+        <filter x="-8.6%" y="-7.3%" width="117.3%" height="117.3%" filterUnits="objectBoundingBox" id="filter-1">
+            <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.2 0" type="matrix" in="shadowBlurOuter1" result="shadowMatrixOuter1"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
+                <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+        </filter>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-2">
+            <stop stop-color="#FADA00" offset="0%"></stop>
+            <stop stop-color="#F38C00" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-3">
+            <stop stop-color="#000000" stop-opacity="0.05" offset="0%"></stop>
+            <stop stop-color="#000000" stop-opacity="0.1" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="适配v20子系统" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="卸载" transform="translate(-229, -142)" fill-rule="nonzero">
+            <g id="dialog-warning" transform="translate(233.8906, 145.8906)" filter="url(#filter-1)">
+                <circle id="Oval" fill="url(#linearGradient-2)" cx="37.609375" cy="37.609375" r="37.609375"></circle>
+                <path d="M37.609375,0 C58.3804593,0 75.21875,16.8382907 75.21875,37.609375 C75.21875,58.3804593 58.3804593,75.21875 37.609375,75.21875 C16.8382907,75.21875 0,58.3804593 0,37.609375 C0,16.8382907 16.8382907,0 37.609375,0 Z M37.609375,1.296875 C17.554535,1.296875 1.296875,17.554535 1.296875,37.609375 C1.296875,57.664215 17.554535,73.921875 37.609375,73.921875 C57.664215,73.921875 73.921875,57.664215 73.921875,37.609375 C73.921875,17.554535 57.664215,1.296875 37.609375,1.296875 Z" id="Oval" fill="url(#linearGradient-3)"></path>
+                <path d="M37.6630241,46.6875 L37.6630241,46.6875 C35.9709079,46.6875 34.584984,45.4459819 34.5305947,43.8801032 L33.7207961,20.5764728 C33.6502912,18.5445588 35.410898,16.859375 37.6086347,16.859375 L37.6086347,16.859375 C39.8003282,16.859375 41.5589205,18.5333739 41.4984878,20.5596955 L40.7954537,43.86519 C40.749122,45.4385253 39.3611838,46.6875 37.6630241,46.6875 L37.6630241,46.6875 Z" id="Shape" fill="#FFFFFF"></path>
+                <circle id="Oval" fill="#FFFFFF" cx="37.609375" cy="55.765625" r="3.890625"></circle>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/assets/icons/deepin/builtin/light/icons/di_dialog-warning_85px.svg
+++ b/assets/icons/deepin/builtin/light/icons/di_dialog-warning_85px.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="85px" height="85px" viewBox="0 0 85 85" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>status/64/dialog-warning</title>
+    <defs>
+        <filter x="-8.6%" y="-7.3%" width="117.3%" height="117.3%" filterUnits="objectBoundingBox" id="filter-1">
+            <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.2 0" type="matrix" in="shadowBlurOuter1" result="shadowMatrixOuter1"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
+                <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+        </filter>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-2">
+            <stop stop-color="#FADA00" offset="0%"></stop>
+            <stop stop-color="#F38C00" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-3">
+            <stop stop-color="#000000" stop-opacity="0.05" offset="0%"></stop>
+            <stop stop-color="#000000" stop-opacity="0.1" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="适配v20子系统" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="卸载" transform="translate(-229, -142)" fill-rule="nonzero">
+            <g id="dialog-warning" transform="translate(233.8906, 145.8906)" filter="url(#filter-1)">
+                <circle id="Oval" fill="url(#linearGradient-2)" cx="37.609375" cy="37.609375" r="37.609375"></circle>
+                <path d="M37.609375,0 C58.3804593,0 75.21875,16.8382907 75.21875,37.609375 C75.21875,58.3804593 58.3804593,75.21875 37.609375,75.21875 C16.8382907,75.21875 0,58.3804593 0,37.609375 C0,16.8382907 16.8382907,0 37.609375,0 Z M37.609375,1.296875 C17.554535,1.296875 1.296875,17.554535 1.296875,37.609375 C1.296875,57.664215 17.554535,73.921875 37.609375,73.921875 C57.664215,73.921875 73.921875,57.664215 73.921875,37.609375 C73.921875,17.554535 57.664215,1.296875 37.609375,1.296875 Z" id="Oval" fill="url(#linearGradient-3)"></path>
+                <path d="M37.6630241,46.6875 L37.6630241,46.6875 C35.9709079,46.6875 34.584984,45.4459819 34.5305947,43.8801032 L33.7207961,20.5764728 C33.6502912,18.5445588 35.410898,16.859375 37.6086347,16.859375 L37.6086347,16.859375 C39.8003282,16.859375 41.5589205,18.5333739 41.4984878,20.5596955 L40.7954537,43.86519 C40.749122,45.4385253 39.3611838,46.6875 37.6630241,46.6875 L37.6630241,46.6875 Z" id="Shape" fill="#FFFFFF"></path>
+                <circle id="Oval" fill="#FFFFFF" cx="37.609375" cy="55.765625" r="3.890625"></circle>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/assets/resources.qrc
+++ b/assets/resources.qrc
@@ -28,5 +28,7 @@
         <file>icons/deepin/builtin/light/icons/di_fail_96px.png</file>
         <file>icons/deepin/builtin/dark/icons/di_fail_96px.png</file>
         <file>icons/deepin/uab/uos-application-bundle.dci</file>
+        <file>icons/deepin/builtin/dark/icons/di_dialog-warning_85px.svg</file>
+        <file>icons/deepin/builtin/light/icons/di_dialog-warning_85px.svg</file>
     </qresource>
 </RCC>

--- a/src/AptInstallDepend/CMakeLists.txt
+++ b/src/AptInstallDepend/CMakeLists.txt
@@ -29,7 +29,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -fstack-protector-all")
 string(REGEX REPLACE "(.*)/(.*)" "\\1" PROJECT_INIT_PATH  ${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_INIT_PATH}/deb-installer/process)
 
-file(GLOB_RECURSE AUTH_CPP_FILES ${CMAKE_CURRENT_LIST_DIR}/*.cpp ${PROJECT_INIT_PATH}/deb-installer/process/*.cpp)
+file(GLOB_RECURSE AUTH_CPP_FILES ${CMAKE_CURRENT_LIST_DIR}/*.h ${CMAKE_CURRENT_LIST_DIR}/*.cpp ${PROJECT_INIT_PATH}/deb-installer/process/*.cpp)
 add_executable (${EXE_NAME}
     ${AUTH_CPP_FILES}
 )

--- a/src/AptInstallDepend/installDebThread.h
+++ b/src/AptInstallDepend/installDebThread.h
@@ -1,15 +1,16 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2024 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #ifndef INSTALLDEBTHREAD_H
 #define INSTALLDEBTHREAD_H
 
-// #include <QObject>
 #include <QThread>
 #include <QProcess>
 #include <QFile>
 #include <QDir>
+#include <QCommandLineParser>
+
 #include "kprocess.h"
 
 #define TEMPLATE_DIR "/tmp/DEBIAN_TMP"
@@ -18,29 +19,54 @@
 class InstallDebThread : public QThread
 {
     Q_OBJECT
+
 public:
+    enum Command {
+        InstallWine = 1 << 1,
+        InstallConfig = 1 << 2,  // DebConf install
+
+        Compatible = 1 << 3,  // compatible mode
+
+        Install = 1 << 4,  // common process
+        Remove = 1 << 5,
+    };
+    Q_DECLARE_FLAGS(Commands, Command)
+    Q_FLAG(Commands);
+
     InstallDebThread();
     virtual ~InstallDebThread();
-    void setParam(const QStringList &tParam);
+
+    void setParam(const QStringList &arguments);
     void getDescription(const QString &debPath);
+
     void run();
-    int m_resultFlag = -1;
+
+    inline int retFlag() const { return m_resultFlag; }
 
 public slots:
-    void onFinished(int);
-    void on_readoutput();
+    void onFinished(int num, QProcess::ExitStatus exitStatus);
+    void onReadoutput();
 
 private:
-    KProcess *m_proc;
-    QStringList m_listParam;
-    QList<QString> m_listDescribeData;
+    void installWine();
+    void installConfig();
+    void compatibleProcess();
 
-private:
-    const QString m_tempLinkDir = "/tmp/LinkTemp/";
     // 使用软连接方式解决文件路径中存在空格的问题。
     QString SymbolicLink(const QString &previousName, const QString &packageName);
     QString link(const QString &linkPath, const QString &packageName);
     bool mkTempDir();
     bool rmTempDir();
+
+    const QString m_tempLinkDir = "/tmp/LinkTemp/";
+
+    QCommandLineParser m_parser;
+    Commands m_cmds;
+    QString m_rootfs;  // for comaptible mode : select rootfs
+
+    KProcess *m_proc;
+    QStringList m_listParam;
+    QList<QString> m_listDescribeData;
+    int m_resultFlag = -1;
 };
 #endif  // INSTALLDEBTHREAD_H

--- a/src/AptInstallDepend/main.cpp
+++ b/src/AptInstallDepend/main.cpp
@@ -1,21 +1,20 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2024 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include <QCommandLineParser>
 #include <QCoreApplication>
 #include <QDebug>
 #include <QFile>
 #include <QProcess>
+#include <QStandardPaths>
 #include <QString>
 #include <QStringList>
 #include <QThread>
-#include <QStandardPaths>
-#include <iostream>
-#include "installDebThread.h"
 
 #include <sys/types.h>
 #include <unistd.h>
+
+#include "installDebThread.h"
 
 bool isValidInvoker()
 {
@@ -57,13 +56,9 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    QCommandLineParser parser;
-    parser.process(app);
-    const QStringList tParamList = parser.positionalArguments();
-
     InstallDebThread mThread;
-    mThread.setParam(tParamList);
+    mThread.setParam(app.arguments());
     mThread.run();
     mThread.wait();
-    return mThread.m_resultFlag;
+    return mThread.retFlag();
 }

--- a/src/deb-installer/compatible/compatible_backend.cpp
+++ b/src/deb-installer/compatible/compatible_backend.cpp
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "compatible_backend.h"
+
+#include <QApplication>
+#include <QProcess>
+#include <QtConcurrent/QtConcurrentRun>
+#include <QTextStream>
+#include <QRegExp>
+#include <QStandardPaths>
+
+#include <mutex>
+
+namespace Compatible {
+
+// compatible controller params
+static const QString kCompatibleBin = "deepin-compatible-ctl";
+static const QString kCompList = "list";
+static const QString kCompSepecificRootFs = "r";
+static const QString kCompRootFs = "rootfs";
+static const QString kCompApp = "app";
+static const QString kCompInstall = "install";
+static const QString kCompRemove = "remove";
+
+CompatibleBackend::CompatibleBackend(QObject *parent)
+    : QObject{parent}
+{
+    recheckCompatibleExists();
+}
+
+CompatibleBackend *CompatibleBackend::instance()
+{
+    static CompatibleBackend ins;
+    return &ins;
+}
+
+bool CompatibleBackend::compatibleValid() const
+{
+    return m_init && !m_rootfsList.isEmpty();
+}
+
+bool CompatibleBackend::compatibleExists() const
+{
+    return m_compatibleExists;
+}
+
+bool CompatibleBackend::recheckCompatibleExists()
+{
+    // find ll-cli in $PATH
+    const QString execPath = QStandardPaths::findExecutable(kCompatibleBin);
+    m_compatibleExists = !execPath.isEmpty();
+
+    return m_compatibleExists;
+}
+
+QList<RootfsInfo::Ptr> CompatibleBackend::rootfsList() const
+{
+    return m_rootfsList;
+}
+
+QString CompatibleBackend::osName(const QString &rootfsName) const
+{
+    auto findItr = std::find_if(m_rootfsList.begin(), m_rootfsList.end(), [&](const RootfsInfo::Ptr &rootfsPtr){
+        return rootfsPtr->name == rootfsName;
+    });
+
+    if (findItr != m_rootfsList.end()) {
+        return (*findItr)->osName;
+    }
+
+    return {};
+}
+
+CompPkgInfo::Ptr CompatibleBackend::containsPackage(const QString &packageName)
+{
+    return m_packages.value(packageName);
+}
+
+void CompatibleBackend::packageInstalled(const CompPkgInfo::Ptr &appendPtr)
+{
+    if (!appendPtr) {
+        return;
+    }
+    appendPtr->rootfs = appendPtr->targetRootfs;
+
+    m_packages.insert(appendPtr->name, appendPtr);
+}
+
+void CompatibleBackend::packageRemoved(const CompPkgInfo::Ptr &removePtr)
+{
+    if (!removePtr) {
+        return;
+    }
+    removePtr->rootfs.clear();
+
+    m_packages.remove(removePtr->name);
+}
+
+QList<RootfsInfo::Ptr> CompatibleBackend::parseRootfsFromRawOutput(const QByteArray &output)
+{
+    QTextStream stream(output, QIODevice::ReadOnly);
+
+    // remove title
+    stream.readLine();
+    stream.readLine();
+
+    bool convert{false};
+    QString temp;
+    QList<RootfsInfo::Ptr> rootfsList;
+    QRegExp priorityReg("^\\d+");
+    QRegExp createTimeReg("\\d{4}-\\d{2}-\\d{2}");
+
+    while (!stream.atEnd()) {
+        auto rootfsPtr = RootfsInfo::Ptr::create();
+        stream >> temp;
+        rootfsPtr->prioriy = temp.toInt(&convert);
+        if (!convert) {
+            int priority = priorityReg.indexIn(temp);
+            if (priority != -1) {
+                rootfsPtr->prioriy = priorityReg.cap().toInt();
+            }
+        }
+
+        stream >> rootfsPtr->name;
+
+        // special field: os name ( contains space ), wen
+        temp = stream.readLine();
+        int createTimePos = createTimeReg.indexIn(temp);
+        if (-1 != createTimePos) {
+            rootfsPtr->osName = temp.left(createTimePos).trimmed();
+        }
+
+        rootfsList.append(rootfsPtr);
+    }
+
+    return rootfsList;
+}
+
+QHash<QString, CompPkgInfo::Ptr> CompatibleBackend::parseAppListFromRawOutput(const QByteArray &output)
+{
+    QHash<QString, CompPkgInfo::Ptr> packageList;
+
+    QTextStream stream(output, QIODevice::ReadOnly);
+
+    // remove title
+    stream.readLine();
+    stream.readLine();
+
+    while (!stream.atEnd()) {
+        auto pkgPtr = CompPkgInfo::Ptr::create();
+
+        stream >> pkgPtr->name;
+        stream >> pkgPtr->version;
+        stream >> pkgPtr->arch;
+        stream >> pkgPtr->rootfs;
+
+        packageList.insert(pkgPtr->name, pkgPtr);
+    }
+
+    return packageList;
+}
+
+void CompatibleBackend::initBackend(bool async)
+{
+    static std::once_flag kCompInitFlag;
+    std::call_once(kCompInitFlag, [this, async]() {
+        if (async) {
+            QtConcurrent::run([this]() { CompatibleBackend::backendProcess(this); });
+        } else {
+            CompatibleBackend::backendProcess(this);
+        }
+    });
+}
+
+void CompatibleBackend::backendProcess(CompatibleBackend *backend)
+{
+    QProcess queryProcess;
+    queryProcess.setProgram(kCompatibleBin);
+    queryProcess.setArguments({kCompRootFs, kCompList});
+    queryProcess.start();
+    queryProcess.waitForFinished();
+
+    QByteArray output = queryProcess.readAllStandardOutput();
+    auto rootfsList = parseRootfsFromRawOutput(output);
+
+    queryProcess.setArguments({kCompApp, kCompList});
+    queryProcess.start();
+    queryProcess.waitForFinished();
+    output = queryProcess.readAllStandardOutput();
+    auto packages = parseAppListFromRawOutput(output);
+
+    // NOTE: ComaptibleBackend might not inited in main thread( no event loop ), so use qApp instaed.
+    QMetaObject::invokeMethod(qApp, [backend, rootfsList, packages]() { backend->initFinished(rootfsList, packages); }, Qt::QueuedConnection);
+}
+
+void CompatibleBackend::initFinished(const QList<RootfsInfo::Ptr> &rootfsList, const QHash<QString, CompPkgInfo::Ptr> &packages)
+{
+    m_init = true;
+    m_rootfsList = rootfsList;
+    m_packages = packages;
+
+    Q_EMIT compatibleInitFinished();
+}
+
+};  // namespace Compatible

--- a/src/deb-installer/compatible/compatible_backend.h
+++ b/src/deb-installer/compatible/compatible_backend.h
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef COMPATIBLEBACKEND_H
+#define COMPATIBLEBACKEND_H
+
+#include <QObject>
+
+#include "compatible_defines.h"
+
+class QProcess;
+
+namespace Compatible {
+
+// Backend for comaptible mode package manage.
+class CompatibleBackend : public QObject
+{
+    Q_OBJECT
+
+public:
+    static CompatibleBackend *instance();
+
+    void initBackend(bool async = true);
+    [[nodiscard]] bool compatibleValid() const;
+    Q_SIGNAL void compatibleInitFinished();
+
+    [[nodiscard]] bool compatibleExists() const;
+    bool recheckCompatibleExists();
+
+    [[nodiscard]] QList<QPair<QString, QString>> osNameList() const;
+    [[nodiscard]] CompPkgInfo::Ptr containsPackage(const QString &packageName);
+
+    // update backend database after controller process finished.
+    void packageInstalled(const CompPkgInfo::Ptr &appendPtr);
+    void packageRemoved(const CompPkgInfo::Ptr &removePtr);
+
+private:
+    explicit CompatibleBackend(QObject *parent = nullptr);
+    ~CompatibleBackend() override = default;
+
+    void initFinished(const QList<RootfsInfo::Ptr> &rootfsList, const QHash<QString, CompPkgInfo::Ptr> &packages);
+    static void backendProcess(CompatibleBackend *backend);
+    [[nodiscard]] static QList<RootfsInfo::Ptr> parseRootfsFromRawOutput(const QByteArray &output);
+    [[nodiscard]] static QHash<QString, CompPkgInfo::Ptr> parseAppListFromRawOutput(const QByteArray &output);
+
+    bool m_init{false};
+    bool m_compatibleExists{false};
+    QList<RootfsInfo::Ptr> m_rootfsList;          // rootfs list
+    QHash<QString, CompPkgInfo::Ptr> m_packages;  // all packages, every package is unique
+
+    Q_DISABLE_COPY(CompatibleBackend)
+};
+
+}  // namespace Compatible
+
+using CompBackend = Compatible::CompatibleBackend;
+
+#endif  // COMPATIBLEBACKEND_H

--- a/src/deb-installer/compatible/compatible_backend.h
+++ b/src/deb-installer/compatible/compatible_backend.h
@@ -28,7 +28,8 @@ public:
     [[nodiscard]] bool compatibleExists() const;
     bool recheckCompatibleExists();
 
-    [[nodiscard]] QList<QPair<QString, QString>> osNameList() const;
+    [[nodiscard]] QList<RootfsInfo::Ptr> rootfsList() const;
+    [[nodiscard]] QString osName(const QString &rootfsName) const;
     [[nodiscard]] CompPkgInfo::Ptr containsPackage(const QString &packageName);
 
     // update backend database after controller process finished.

--- a/src/deb-installer/compatible/compatible_defines.h
+++ b/src/deb-installer/compatible/compatible_defines.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef COMPATIBLE_DEFINES_H
+#define COMPATIBLE_DEFINES_H
+
+#include <QString>
+#include <QSharedPointer>
+
+namespace Compatible {
+
+enum CompCode {
+    CompError = -1,
+    CompSuccess = 0,
+    AuthError = 126,  // pkexec auth cancel or error
+};
+
+struct CompPkgInfo
+{
+    using Ptr = QSharedPointer<CompPkgInfo>;
+
+    QString filePath;  // for local file
+    QString name;
+    QString version;
+    QString arch;          // architecture
+    QString rootfs;        // rootfs name, which installed this package
+    QString targetRootfs;  // target rootfs, prepare for install pacakge to specific rootfs
+
+    inline bool installed() const { return !rootfs.isEmpty(); }
+};
+
+struct RootfsInfo
+{
+    using Ptr = QSharedPointer<RootfsInfo>;
+
+    int prioriy{0};
+    QString name;
+    QString osName;
+};
+
+}  // namespace Compatible
+
+#endif  // COMPATIBLE_DEFINES_H

--- a/src/deb-installer/compatible/compatible_process_controller.cpp
+++ b/src/deb-installer/compatible/compatible_process_controller.cpp
@@ -57,6 +57,9 @@ bool CompatibleProcessController::install(const Deb::DebPackage::Ptr &package)
     m_outputList.clear();
     m_currentPackage = package;
 
+    // reset state
+    m_currentPackage->setError(Pkg::NoError, {});
+
     // For historical reasons, the first argument in programArguments is the
     // name of the program to execute, so create a list consisting of all
     // but the first argument to pass to setProgram()
@@ -94,6 +97,9 @@ bool CompatibleProcessController::uninstall(const Deb::DebPackage::Ptr &package)
     m_outputList.clear();
     m_currentPackage = package;
 
+    // reset state
+    m_currentPackage->setError(Pkg::NoError, {});
+
     // For historical reasons, the first argument in programArguments is the
     // name of the program to execute, so create a list consisting of all
     // but the first argument to pass to setProgram()
@@ -113,6 +119,19 @@ bool CompatibleProcessController::uninstall(const Deb::DebPackage::Ptr &package)
     qInfo() << "Comaptible uninstall:" << m_process->program();
     Q_EMIT processStart();
     return true;
+}
+
+bool CompatibleProcessController::containTemplates() const
+{
+    return m_currentPackage && m_currentPackage->containsTemplates();
+}
+
+void CompatibleProcessController::writeConfigData(const QString &configData)
+{
+    if (m_process) {
+        m_process->pty()->write(configData.toUtf8());
+        m_process->pty()->write("\n");
+    }
 }
 
 bool CompatibleProcessController::ensureProcess()

--- a/src/deb-installer/compatible/compatible_process_controller.cpp
+++ b/src/deb-installer/compatible/compatible_process_controller.cpp
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "compatible_process_controller.h"
+
+#include <QDebug>
+
+#include <math.h>
+
+#include "compatible_backend.h"
+#include "process/Pty.h"
+#include "utils/hierarchicalverify.h"
+
+namespace Compatible {
+
+// transport install/remove task to higher level permission process.
+static const QString kPkexecBin = "pkexec";
+static const QString kInstallProcessorBin = "deepin-deb-installer-dependsInstall";
+static const QString kParamCompatible = "--install_compatible";
+static const QString kParamInstallConfig = "--install_config";
+static const QString kParamInstall = "--install";
+static const QString kParamRemove = "--remove";
+static const QString kParamRootfs = "--rootfs";
+
+CompatibleProcessController::CompatibleProcessController(QObject *parent)
+    : QObject{parent}
+{
+}
+
+const Deb::DebPackage::Ptr &CompatibleProcessController::currentPackage() const
+{
+    return m_currentPackage;
+}
+
+bool CompatibleProcessController::isRunning() const
+{
+    if (m_process && QProcess::NotRunning != m_process->state()) {
+        return true;
+    }
+
+    return false;
+}
+
+bool CompatibleProcessController::install(const Deb::DebPackage::Ptr &package)
+{
+    if (!package || !package->isValid() || isRunning()) {
+        return false;
+    }
+    if (!ensureProcess()) {
+        return false;
+    }
+
+    // e.g.: pkexec deepin-deb-installer-dependsInstall Compatible InstallConfig[Optional] \
+    //       install --rootfs [rootfs name] [path to deb file]
+    m_type = Install;
+    m_outputList.clear();
+    m_currentPackage = package;
+
+    // For historical reasons, the first argument in programArguments is the
+    // name of the program to execute, so create a list consisting of all
+    // but the first argument to pass to setProgram()
+    // sa: Pty::start()
+    QStringList params{kPkexecBin,
+                       kInstallProcessorBin,
+                       kParamCompatible,
+                       kParamInstall,
+                       kParamRootfs,
+                       m_currentPackage->compatible()->targetRootfs,
+                       m_currentPackage->filePath()};
+    if (m_currentPackage->containsTemplates()) {
+        params << kParamInstallConfig;
+    }
+
+    m_process->start(kPkexecBin, params, {}, 0, false);
+
+    qInfo() << "Comaptible install:" << m_process->program();
+    Q_EMIT processStart();
+    return true;
+}
+
+bool CompatibleProcessController::uninstall(const Deb::DebPackage::Ptr &package)
+{
+    if (!package || !package->isValid() || isRunning()) {
+        return false;
+    }
+    if (!ensureProcess()) {
+        return false;
+    }
+
+    // e.g.: pkexec deepin-deb-installer-dependsInstall Compatible \
+    //       remove --rootfs [rootfs name] [package name]
+    m_type = Unintsall;
+    m_outputList.clear();
+    m_currentPackage = package;
+
+    // For historical reasons, the first argument in programArguments is the
+    // name of the program to execute, so create a list consisting of all
+    // but the first argument to pass to setProgram()
+    // sa: Pty::start()
+    m_process->start(kPkexecBin,
+                     {kPkexecBin,
+                      kInstallProcessorBin,
+                      kParamCompatible,
+                      kParamRemove,
+                      kParamRootfs,
+                      m_currentPackage->compatible()->rootfs,
+                      m_currentPackage->debInfo()->packageName()},
+                     {},
+                     0,
+                     false);
+
+    qInfo() << "Comaptible uninstall:" << m_process->program();
+    Q_EMIT processStart();
+    return true;
+}
+
+bool CompatibleProcessController::ensureProcess()
+{
+    if (!m_process) {
+        m_process = new Konsole::Pty(this);
+
+        connect(m_process, &Konsole::Pty::receivedData, this, &CompatibleProcessController::onReadOutput);
+        connect(m_process,
+                QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+                this,
+                &CompatibleProcessController::onFinished);
+    } else if (QProcess::NotRunning != m_process->state()) {
+        qWarning() << "Unable to restart compatible process is still running";
+        return false;
+    }
+
+    return true;
+}
+
+void CompatibleProcessController::onReadOutput(const char *buffer, int length, bool isCommandExec)
+{
+    Q_UNUSED(isCommandExec);
+
+    const QByteArray output = QByteArray::fromRawData(buffer, length);
+    Q_EMIT processOutput(output);
+
+    // TODO: use `sudo apt -o Dpkg::Progress-Fancy="1" *.deb` instead
+
+    // simulate porgress, progress = log2(x) * 10
+    m_outputList.append(output);
+
+    int bitCount = 0;
+    int logCount = m_outputList.size();
+    while (logCount > 0) {
+        logCount >>= 1;
+        bitCount++;
+    }
+
+    float progress = bitCount * 10;
+    Q_EMIT progressChanged(progress);
+}
+
+void CompatibleProcessController::onFinished(int exitCode, int exitStatus)
+{
+    const bool success = (CompSuccess == exitCode && QProcess::NormalExit == exitStatus);
+    if (!success) {
+        switch (exitCode) {
+            case AuthError:
+                m_currentPackage->setError(Pkg::ConfigAuthCancel, {});
+                break;
+            default: {  // up to 100 outputs
+                static const int kMaxCheckLen = 100;
+                for (int i = m_outputList.size() - 1; i >= qMax(0, m_outputList.size() - kMaxCheckLen); --i) {
+                    if (HierarchicalVerify::instance()->checkTransactionError(m_currentPackage->debInfo()->packageName(),
+                                                                              m_outputList.at(i))) {
+                        // mark hierachical verify failed
+                        m_currentPackage->setError(Pkg::DigitalSignatureError, {});
+                    }
+                }
+            } break;
+        }
+    }
+
+    Q_EMIT processFinished(success);
+
+    if (success) {
+        switch (m_type) {
+            case Install:
+                CompatibleBackend::instance()->packageInstalled(m_currentPackage->compatible());
+                break;
+            case Unintsall:
+                CompatibleBackend::instance()->packageRemoved(m_currentPackage->compatible());
+                break;
+            default:
+                break;
+        }
+    }
+
+    // release temp data
+    m_outputList.clear();
+}
+
+};  // namespace Compatible

--- a/src/deb-installer/compatible/compatible_process_controller.h
+++ b/src/deb-installer/compatible/compatible_process_controller.h
@@ -29,6 +29,9 @@ public:
     [[nodiscard]] bool install(const Deb::DebPackage::Ptr &package);
     [[nodiscard]] bool uninstall(const Deb::DebPackage::Ptr &package);
 
+    [[nodiscard]] bool containTemplates() const;
+    void writeConfigData(const QString &configData);
+
     Q_SIGNAL void processStart();
     Q_SIGNAL void processFinished(bool success);
     Q_SIGNAL void processOutput(const QString &output);

--- a/src/deb-installer/compatible/compatible_process_controller.h
+++ b/src/deb-installer/compatible/compatible_process_controller.h
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef COMPATIBLEPROCESSCONTROLLER_H
+#define COMPATIBLEPROCESSCONTROLLER_H
+
+#include <QObject>
+
+#include "utils/deb_package.h"
+
+namespace Konsole {
+class Pty;
+};  // namespace Konsole
+
+namespace Compatible {
+
+class CompatibleProcessController : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit CompatibleProcessController(QObject *parent = nullptr);
+    ~CompatibleProcessController() override = default;
+
+    [[nodiscard]] const Deb::DebPackage::Ptr &currentPackage() const;
+
+    [[nodiscard]] bool isRunning() const;
+    [[nodiscard]] bool install(const Deb::DebPackage::Ptr &package);
+    [[nodiscard]] bool uninstall(const Deb::DebPackage::Ptr &package);
+
+    Q_SIGNAL void processStart();
+    Q_SIGNAL void processFinished(bool success);
+    Q_SIGNAL void processOutput(const QString &output);
+    Q_SIGNAL void progressChanged(float progress);
+
+private:
+    [[nodiscard]] bool ensureProcess();
+
+    Q_SLOT void onReadOutput(const char *buffer, int length, bool isCommandExec);
+    Q_SLOT void onFinished(int exitCode, int exitStatus);
+
+    enum ProcessType {
+        Install,
+        Unintsall,
+    };
+    ProcessType m_type{Install};
+    QStringList m_outputList;  // for simunalte progress
+
+    Konsole::Pty *m_process{nullptr};
+    Deb::DebPackage::Ptr m_currentPackage;
+
+    Q_DISABLE_COPY(CompatibleProcessController)
+};
+
+};  // namespace Compatible
+
+#endif  // COMPATIBLEPROCESSCONTROLLER_H

--- a/src/deb-installer/manager/DealDependThread.cpp
+++ b/src/deb-installer/manager/DealDependThread.cpp
@@ -63,7 +63,7 @@ void DealDependThread::run()
     emit signalDependResult(DebListModel::AuthBefore, m_index, m_brokenDepend);
     proc->start("pkexec",
                 QStringList() << "deepin-deb-installer-dependsInstall"
-                              << "InstallDeepinWine" << m_dependsList);
+                              << "--install_wine" << m_dependsList);
     emit signalEnableCloseButton(false);
 }
 

--- a/src/deb-installer/manager/PackageDependsStatus.cpp
+++ b/src/deb-installer/manager/PackageDependsStatus.cpp
@@ -7,23 +7,23 @@
 
 PackageDependsStatus PackageDependsStatus::ok()
 {
-    return { Pkg::DependsStatus::DependsOk, QString() };
+    return {Pkg::DependsStatus::DependsOk, QString()};
 }
 
 PackageDependsStatus PackageDependsStatus::available(const QString &package)
 {
     // 修复卸载p7zip导致deepin-wine-helper被卸载的问题，Available 添加packageName
-    return { Pkg::DependsStatus::DependsAvailable, package };
+    return {Pkg::DependsStatus::DependsAvailable, package};
 }
 
 PackageDependsStatus PackageDependsStatus::_break(const QString &package)
 {
-    return { Pkg::DependsStatus::DependsBreak, package };
+    return {Pkg::DependsStatus::DependsBreak, package};
 }
 
 PackageDependsStatus PackageDependsStatus::_prohibit(const QString &package)
 {
-    return { Pkg::DependsStatus::DependsBreak, package };
+    return {Pkg::DependsStatus::DependsBreak, package};
 }
 
 PackageDependsStatus::PackageDependsStatus()
@@ -95,4 +95,14 @@ bool PackageDependsStatus::isAvailable() const
 bool PackageDependsStatus::isProhibit() const
 {
     return status == Pkg::DependsStatus::Prohibit;
+}
+
+bool PackageDependsStatus::canInstall() const
+{
+    return status == Pkg::DependsAvailable || status == Pkg::DependsOk;
+}
+
+bool PackageDependsStatus::canInstallCompatible() const
+{
+    return status == Pkg::CompatibleNotInstalled;
 }

--- a/src/deb-installer/manager/PackageDependsStatus.h
+++ b/src/deb-installer/manager/PackageDependsStatus.h
@@ -104,6 +104,9 @@ public:
      */
     bool isProhibit() const;
 
+    bool canInstall() const;
+    bool canInstallCompatible() const;
+
 public:
     int status;
     QString package;

--- a/src/deb-installer/model/abstract_package_list_model.h
+++ b/src/deb-installer/model/abstract_package_list_model.h
@@ -34,6 +34,9 @@ public:
 
         PackageTypeRole,           // is uab or deb package, sa Pkg::PackageType
         PackageDependsDetailRole,  // details for unfinished depends, empty if no errors occur, sa Pkg::DependsPair
+
+        CompatibleRootfsRole,        // compatible mode only, provides current compatible rootfs name
+        CompatibleTargetRootfsRole,  // target rootfs name
     };
 
     // the list model backend installer status

--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -1224,7 +1224,7 @@ void DebListModel::installNextDeb()
             m_procInstallConfig->start("pkexec",
                                        QStringList() << "pkexec"
                                                      << "deepin-deb-installer-dependsInstall"
-                                                     << "InstallConfig" << sPackageName,
+                                                     << "--install_config" << sPackageName,
                                        {},
                                        0,
                                        false);  // 配置安装流程

--- a/src/deb-installer/model/deblistmodel.h
+++ b/src/deb-installer/model/deblistmodel.h
@@ -472,6 +472,8 @@ private:
      */
     void printDependsChanges();
 
+    QString itemToolTips(int index) const;
+
     // Compatbile interface
     // compatible mode only support single package install/uninstall.
     [[nodiscard]] inline bool supportCompatible() const { return 1 == m_packagesManager->m_preparedPackages.size(); }
@@ -480,7 +482,7 @@ private:
     [[nodiscard]] bool installCompatiblePackage();
     [[nodiscard]] bool uninstallCompatiblePackage();
 
-    Deb::DebPackage::Ptr packagePtr(int index);
+    Deb::DebPackage::Ptr packagePtr(int index) const;
 
 private:
     // 当前正在操作的index

--- a/src/deb-installer/model/packageanalyzer.h
+++ b/src/deb-installer/model/packageanalyzer.h
@@ -5,10 +5,12 @@
 #ifndef PACKAGEANALYZER_H
 #define PACKAGEANALYZER_H
 
-#include "model/packageselectmodel.h"
-
 #include <QObject>
+
 #include <atomic>
+
+#include "model/packageselectmodel.h"
+#include "utils/package_defines.h"
 
 namespace QApt {
 class Backend;
@@ -18,15 +20,8 @@ class Package;
 class PackageAnalyzer : public QObject
 {
     Q_OBJECT
-public:
-    // 包安装状态
-    enum PackageInstallStatus {
-        NotInstalled,             // 当前包没有被安装
-        InstalledSameVersion,     // 当前已经安装过相同的版本
-        InstalledEarlierVersion,  // 当前已经安装过较早的版本
-        InstalledLaterVersion     // 当前已经安装过更新的版本
-    };
 
+public:
     static PackageAnalyzer &instance();
 
     // 异步信号
@@ -47,7 +42,7 @@ public:
     inline QStringList supportArchList() const { return archs; }
 
     // 软件包安装状态，first:安装状态，secend:已安装版本（当状态不为NotInstalled时有效）
-    QPair<PackageInstallStatus, QString> packageInstallStatus(const DebIr &ir) const;
+    QPair<Pkg::PackageInstallStatus, QString> packageInstallStatus(const DebIr &ir) const;
 
     // 分析包结构
 

--- a/src/deb-installer/model/packageslistdelegate.cpp
+++ b/src/deb-installer/model/packageslistdelegate.cpp
@@ -248,11 +248,10 @@ void PackagesListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         info_str = index.data(DebListModel::PackageFailReasonRole).toString();
         forground.setColor(palette.color(colorGroup, DPalette::TextWarning));  // 安装失败或依赖错误
     }
+    // not contains prohibit error
     if (dependsStat == Pkg::DependsStatus::DependsBreak || dependsStat == Pkg::DependsStatus::DependsAuthCancel ||
-        dependsStat == Pkg::DependsStatus::DependsVerifyFailed ||
-        dependsStat == Pkg::DependsStatus::ArchBreak  // 添加对架构不匹配的处理
-        //                || dependsStat == Pkg::DependsStatus::Prohibit  //增加应用黑名单
-    ) {
+        dependsStat == Pkg::DependsStatus::DependsVerifyFailed || dependsStat == Pkg::DependsStatus::ArchBreak ||
+        dependsStat == Pkg::CompatibleIntalled || dependsStat == Pkg::CompatibleNotInstalled) {
         info_str = index.data(DebListModel::PackageFailReasonRole).toString();
         forground.setColor(palette.color(colorGroup, DPalette::TextWarning));  // 安装失败或依赖错误
     }

--- a/src/deb-installer/model/proxy_package_list_model.cpp
+++ b/src/deb-installer/model/proxy_package_list_model.cpp
@@ -28,6 +28,21 @@ QVariant ProxyPackageListModel::data(const QModelIndex &index, int role) const
     return model->data(model->index(modelWithIndex.second), role);
 }
 
+bool ProxyPackageListModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    if (m_packageModels.empty()) {
+        return false;
+    }
+
+    auto modelWithIndex = findFromProxyIndex(index.row());
+    ModelPtr model = modelWithIndex.first;
+    if (!model) {
+        return false;
+    }
+
+    return model->setData(model->index(modelWithIndex.second), value, role);
+}
+
 int ProxyPackageListModel::rowCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
@@ -283,7 +298,6 @@ void ProxyPackageListModel::connectModel(ModelPtr model)
     QObject::connect(
         model, &AbstractPackageListModel::signalPackageCannotFind, this, &ProxyPackageListModel::signalPackageCannotFind);
 
-    // TODO: might be move to singleton
     QObject::connect(model, &AbstractPackageListModel::signalLockForAuth, this, &ProxyPackageListModel::signalLockForAuth);
     QObject::connect(model, &AbstractPackageListModel::signalAuthCancel, this, &ProxyPackageListModel::signalAuthCancel);
     QObject::connect(

--- a/src/deb-installer/model/proxy_package_list_model.cpp
+++ b/src/deb-installer/model/proxy_package_list_model.cpp
@@ -211,7 +211,6 @@ bool ProxyPackageListModel::nextModelInstall()
     if (m_procModelIndex >= m_packageModels.count()) {
         setWorkerStatus(WorkerFinished);
         Q_EMIT signalWholeProgressChanged(100);
-        setWorkerStatus(WorkerFinished);
         return true;
     }
 

--- a/src/deb-installer/model/proxy_package_list_model.cpp
+++ b/src/deb-installer/model/proxy_package_list_model.cpp
@@ -299,7 +299,11 @@ void ProxyPackageListModel::connectModel(ModelPtr model)
         model, &AbstractPackageListModel::signalPackageCannotFind, this, &ProxyPackageListModel::signalPackageCannotFind);
 
     QObject::connect(model, &AbstractPackageListModel::signalLockForAuth, this, &ProxyPackageListModel::signalLockForAuth);
-    QObject::connect(model, &AbstractPackageListModel::signalAuthCancel, this, &ProxyPackageListModel::signalAuthCancel);
+    QObject::connect(model, &AbstractPackageListModel::signalAuthCancel, this, [this]() {
+        // if auth canceled, reset to prepare state.
+        setWorkerStatus(WorkerPrepare);
+        Q_EMIT signalAuthCancel();
+    });
     QObject::connect(
         model, &AbstractPackageListModel::signalEnableReCancelBtn, this, &ProxyPackageListModel::signalEnableReCancelBtn);
     QObject::connect(model, &AbstractPackageListModel::signalDependResult, this, &ProxyPackageListModel::signalDependResult);

--- a/src/deb-installer/model/proxy_package_list_model.h
+++ b/src/deb-installer/model/proxy_package_list_model.h
@@ -17,6 +17,7 @@ public:
     explicit ProxyPackageListModel(QObject *parent = nullptr);
 
     QVariant data(const QModelIndex &index, int role) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
     Q_SLOT void slotAppendPackage(const QStringList &packageList) override;

--- a/src/deb-installer/utils/deb_package.cpp
+++ b/src/deb-installer/utils/deb_package.cpp
@@ -10,8 +10,8 @@
 namespace Deb {
 
 DebPackage::DebPackage(const QString &debFilePath)
+    : m_debFilePtr(QSharedPointer<QApt::DebFile>::create(debFilePath))
 {
-    m_debFilePtr = QSharedPointer<QApt::DebFile>::create(debFilePath);
 }
 
 bool DebPackage::isValid() const

--- a/src/deb-installer/utils/deb_package.cpp
+++ b/src/deb-installer/utils/deb_package.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "deb_package.h"
+#include "compatible/compatible_backend.h"
+#include "compatible/compatible_defines.h"
+#include "utils/utils.h"
+
+namespace Deb {
+
+DebPackage::DebPackage(const QString &debFilePath)
+{
+    m_debFilePtr = QSharedPointer<QApt::DebFile>::create(debFilePath);
+}
+
+bool DebPackage::isValid() const
+{
+    return m_debFilePtr->isValid();
+}
+
+bool DebPackage::fileExists() const
+{
+    return m_exists;
+}
+
+void DebPackage::markNotExists()
+{
+    m_exists = false;
+}
+
+QString DebPackage::filePath() const
+{
+    return m_debFilePtr->filePath();
+}
+
+QByteArray DebPackage::md5()
+{
+    if (m_md5.isEmpty() && m_debFilePtr->isValid()) {
+        m_md5 = m_debFilePtr->md5Sum();
+    }
+
+    return m_md5;
+}
+
+const QSharedPointer<QApt::DebFile> &DebPackage::debInfo() const
+{
+    return m_debFilePtr;
+}
+
+void DebPackage::setOperationStatus(Pkg::PackageOperationStatus s)
+{
+    m_operationStatus = s;
+}
+
+Pkg::PackageOperationStatus DebPackage::operationStatus() const
+{
+    return m_operationStatus;
+}
+
+Pkg::PackageInstallStatus DebPackage::installStatus() const
+{
+    return m_installStatus;
+}
+
+PackageDependsStatus &DebPackage::dependsStatus()
+{
+    return m_dependsStatus;
+}
+
+bool DebPackage::containsTemplates()
+{
+    return Utils::checkPackageContainsDebConf(m_debFilePtr->filePath());
+}
+
+void DebPackage::setError(int code, const QString &string)
+{
+    m_errorCode = code;
+    m_errorString = string;
+}
+
+int DebPackage::errorCode() const
+{
+    return m_errorCode;
+}
+
+QString DebPackage::errorString() const
+{
+    return m_errorString;
+}
+
+const QSharedPointer<Compatible::CompPkgInfo> &DebPackage::compatible()
+{
+    if (!m_compInfoPtr && isValid()) {
+        // might installed in compatbile mode.
+        m_compInfoPtr = CompBackend::instance()->containsPackage(m_debFilePtr->packageName());
+
+        if (!m_compInfoPtr) {
+            m_compInfoPtr = Compatible::CompPkgInfo::Ptr::create();
+
+            m_compInfoPtr->name = m_debFilePtr->packageName();
+            m_compInfoPtr->version = m_debFilePtr->version();
+            m_compInfoPtr->arch = m_debFilePtr->architecture();
+        }
+
+        m_compInfoPtr->filePath = m_debFilePtr->filePath();
+    }
+
+    return m_compInfoPtr;
+}
+
+};  // namespace Deb

--- a/src/deb-installer/utils/deb_package.cpp
+++ b/src/deb-installer/utils/deb_package.cpp
@@ -70,7 +70,11 @@ PackageDependsStatus &DebPackage::dependsStatus()
 
 bool DebPackage::containsTemplates()
 {
-    return Utils::checkPackageContainsDebConf(m_debFilePtr->filePath());
+    if (UnknownTemplates == m_templatesState) {
+        m_templatesState = Utils::checkPackageContainsDebConf(m_debFilePtr->filePath()) ? ContainTemplates : NoTemplates;
+    }
+
+    return m_templatesState == ContainTemplates;
 }
 
 void DebPackage::setError(int code, const QString &string)

--- a/src/deb-installer/utils/deb_package.h
+++ b/src/deb-installer/utils/deb_package.h
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DEBPACKAGE_H
+#define DEBPACKAGE_H
+
+#include <QSharedPointer>
+
+#include <QApt/DebFile>
+
+#include "manager/PackageDependsStatus.h"
+#include "package_defines.h"
+
+namespace Compatible {
+class CompPkgInfo;
+};  // namespace Compatible
+
+namespace Deb {
+
+// TODO: Use DebPackage::Ptr to replace the scattered package data in the DebListModel / PackageAnalyzer
+class DebPackage
+{
+public:
+    using Ptr = QSharedPointer<DebPackage>;
+
+    explicit DebPackage(const QString &debFilePath);
+    ~DebPackage() = default;
+
+    [[nodiscard]] bool isValid() const;
+    [[nodiscard]] bool fileExists() const;
+    void markNotExists();
+
+    [[nodiscard]] QString filePath() const;
+    [[nodiscard]] QByteArray md5();
+    [[nodiscard]] const QSharedPointer<QApt::DebFile> &debInfo() const;
+
+    void setOperationStatus(Pkg::PackageOperationStatus s);
+    [[nodiscard]] Pkg::PackageOperationStatus operationStatus() const;
+    [[nodiscard]] Pkg::PackageInstallStatus installStatus() const;
+
+    // direct access
+    [[nodiscard]] PackageDependsStatus &dependsStatus();
+
+    bool containsTemplates();
+
+    // error
+    void setError(int code, const QString &string);
+    [[nodiscard]] int errorCode() const;
+    [[nodiscard]] QString errorString() const;
+
+    // for compatible mode
+    const QSharedPointer<Compatible::CompPkgInfo> &compatible();
+
+private:
+    bool m_exists{true};  // file exists
+
+    QByteArray m_md5;  // package's md5 sum
+    QSharedPointer<QApt::DebFile> m_debFilePtr;
+
+    Pkg::PackageOperationStatus m_operationStatus{Pkg::Prepare};
+    Pkg::PackageInstallStatus m_installStatus{Pkg::NotInstalled};
+
+    PackageDependsStatus m_dependsStatus;
+
+    int m_errorCode{Pkg::NoError};  // sa Pkg::ErrorCode and QApt::ErrorCode
+    QString m_errorString;
+
+    QSharedPointer<Compatible::CompPkgInfo> m_compInfoPtr;
+
+    Q_DISABLE_COPY(DebPackage)
+};
+
+};  // namespace Deb
+
+#endif  // DEBPACKAGE_H

--- a/src/deb-installer/utils/deb_package.h
+++ b/src/deb-installer/utils/deb_package.h
@@ -68,6 +68,13 @@ private:
 
     QSharedPointer<Compatible::CompPkgInfo> m_compInfoPtr;
 
+    enum TemplatesState {
+        UnknownTemplates,
+        ContainTemplates,
+        NoTemplates,
+    };
+    TemplatesState m_templatesState{UnknownTemplates};
+
     Q_DISABLE_COPY(DebPackage)
 };
 

--- a/src/deb-installer/utils/hierarchicalverify.cpp
+++ b/src/deb-installer/utils/hierarchicalverify.cpp
@@ -68,19 +68,7 @@ bool HierarchicalVerify::isValid()
     }
 
     static std::once_flag checkFlag;
-    std::call_once(checkFlag, [this]() {
-        const bool availabled = checkHierarchicalInterface();
-        if (valid != availabled) {
-            valid = availabled;
-
-            // if the hierarchical signature verification is not available, clear cache.
-            if (!valid) {
-                clearVerifyResult();
-            }
-
-            Q_EMIT validChanged(valid);
-        }
-    });
+    std::call_once(checkFlag, [this]() { checkValidImpl(); });
 
     return valid;
 }
@@ -184,6 +172,23 @@ bool HierarchicalVerify::checkHierarchicalInterface()
                        .arg(DBUS_HIERARCHICAL_INTERFACE)
                        .arg(interface.lastError().name())
                        .arg(interface.lastError().message());
+    }
+
+    return availabled;
+}
+
+bool HierarchicalVerify::checkValidImpl()
+{
+    const bool availabled = checkHierarchicalInterface();
+    if (valid != availabled) {
+        valid = availabled;
+
+        // if the hierarchical signature verification is not available, clear cache.
+        if (!valid) {
+            clearVerifyResult();
+        }
+
+        Q_EMIT validChanged(valid);
     }
 
     return availabled;

--- a/src/deb-installer/utils/hierarchicalverify.h
+++ b/src/deb-installer/utils/hierarchicalverify.h
@@ -27,6 +27,7 @@ public:
 
 private:
     bool checkHierarchicalInterface();
+    bool checkValidImpl();
 
 private:
     bool valid = false;             ///< 分级管控是否开启

--- a/src/deb-installer/utils/package_defines.h
+++ b/src/deb-installer/utils/package_defines.h
@@ -59,6 +59,9 @@ enum DependsStatus {
     DependsAuthCancel,    // pre depends (wine, linglong) auth check failed
     ArchBreak,            // arch check failed, e.g.: amd64 package cannot install in arm system
     Prohibit,             // The application is restricted by the domain management and cannot be installed
+
+    CompatibleNotInstalled,  // Package depends break, but can install to compatible rootfs
+    CompatibleIntalled,      // Package depends ok, but installed in (compatible mode / current system)
 };
 
 enum PackageOperationStatus {

--- a/src/deb-installer/utils/utils.h
+++ b/src/deb-installer/utils/utils.h
@@ -21,6 +21,8 @@
 
 #define dApp (static_cast<DApplication *>(QCoreApplication::instance()))
 
+class QTextDocumnet;
+
 DWIDGET_USE_NAMESPACE
 
 class DebApplicationHelper : public DGuiApplicationHelper
@@ -77,6 +79,8 @@ public:
     static bool checkPackageContainsDebConf(const QString &filePath);
 
     static bool isDevelopMode();  // Check if develop mode (root)
+
+    static QString formatWrapText(const QString &text, int textWidth);
 };
 
 class GlobalStatus

--- a/src/deb-installer/utils/utils.h
+++ b/src/deb-installer/utils/utils.h
@@ -73,6 +73,9 @@ public:
     static Pkg::PackageType detectPackage(const QString &filePath);
     static QIcon packageIcon(Pkg::PackageType type);
 
+    // check package contains DebConf templates config file
+    static bool checkPackageContainsDebConf(const QString &filePath);
+
     static bool isDevelopMode();  // Check if develop mode (root)
 };
 

--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -161,7 +161,6 @@ void DebInstaller::initConnections()
 
     // Select the focus of the page
 
-    // TODO: remove to instance later.
     // Determine the status of the current application based on the status of the authorization box.
     connect(m_fileListModel, &DebListModel::signalLockForAuth, this, &DebInstaller::slotSetAuthingStatus);
     connect(m_fileListModel, &DebListModel::signalAuthCancel, this, &DebInstaller::slotShowHiddenButton);
@@ -796,6 +795,12 @@ void DebInstaller::slotShowUninstallConfirmPage()
     m_uninstallPage->setRequiredList(
         index.data(DebListModel::PackageReverseDependsListRole).toStringList());  // 查看是否有包依赖于当前要卸载的包，病获取列表
     m_uninstallPage->setPackage(index.data().toString());                         // 添加卸载提示语
+
+    // compatible mode, if rootfs is empty, fallback normal debian package uninstall flow
+    QString rootfs = index.data(AbstractPackageListModel::CompatibleRootfsRole).toString();
+    if (!rootfs.isEmpty()) {
+        m_uninstallPage->setCompatibleInfo(rootfs);
+    }
 
     m_Filterflag = UninstallPage;
     m_centralLayout->addWidget(m_uninstallPage);  // 添加卸载页面到主界面中

--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -556,7 +556,7 @@ void SingleInstallPage::initConnections()
     connect(m_confirmButton, &DPushButton::clicked, this, [this]() {
         QModelIndex index = m_packagesModel->index(0);
         const int dependsStat = index.data(DebListModel::PackageDependsStatusRole).toInt();
-        if (Pkg::CompatibleNotInstalled == dependsStat) {
+        if (Finished != m_operate && Pkg::CompatibleNotInstalled == dependsStat) {
             // requset install package to compatible.
             m_targetRootfsOsName = m_compatibleBox->currentText();
             const QString targetRootfs = m_compatibleBox->currentData().toString();
@@ -882,6 +882,9 @@ void SingleInstallPage::slotWorkerFinished()
     }
     if (!m_upDown)
         m_infoControlButton->setShrinkTips(tr("Collapse"));
+
+    // mark down
+    m_operate = Finished;
 }
 
 void SingleInstallPage::slotWorkerProgressChanged(const int progress)

--- a/src/deb-installer/view/pages/singleinstallpage.h
+++ b/src/deb-installer/view/pages/singleinstallpage.h
@@ -83,13 +83,14 @@ signals:
 
 private:
     /**
-     * @brief The Operate enum 当前进行的操作
+     * @brief The current operate
      */
     enum Operate {
         Unknown,
-        Install,    // 安装
-        Uninstall,  // 卸载
-        Reinstall   // 重新安装
+        Install,
+        Uninstall,
+        Reinstall,
+        Finished,  // install/uninstall finished
     };
 
 private:

--- a/src/deb-installer/view/pages/singleinstallpage.h
+++ b/src/deb-installer/view/pages/singleinstallpage.h
@@ -302,8 +302,8 @@ private:
 
     // for comaptible mode
     bool m_inCompatibleMode = false;  // current pacakge in comaptbile mode;
-    QString m_rootfs;                 // current package rootfs (empty if not installed)
-    QString m_targetRootfs;
+    QString m_rootfsOsName;           // current package rootfs (empty if not installed)
+    QString m_targetRootfsOsName;
     DLabel *m_compatibleLabel = nullptr;
     DComboBox *m_compatibleBox = nullptr;  // compatible rootfs selector
     QHBoxLayout *m_compatibleLayout = nullptr;

--- a/src/deb-installer/view/pages/singleinstallpage.h
+++ b/src/deb-installer/view/pages/singleinstallpage.h
@@ -17,6 +17,7 @@
 #include <DSpinner>
 #include <DDialog>
 #include <DCommandLinkButton>
+#include <DComboBox>
 
 #include <QWidget>
 #include <QProcess>
@@ -107,6 +108,8 @@ private:
      */
     void initInstallWineLoadingLayout();
 
+    void initCompatibleSelectLayout();
+
     /**
      * @brief initPkgInfoView 初始化 包信息视图布局
      * @param fontinfosize  字体大小
@@ -184,6 +187,8 @@ private:
      */
     void setAuthDependsSuccess();
 
+    bool dependsError(int status) const;
+
 private slots:
 
     /**
@@ -253,7 +258,7 @@ private:
     bool m_workerStarted = false;  // 安装是否开始
     bool m_upDown = false;         // 当前是详细信息是展开还是收缩
 
-    AbstractPackageListModel *m_packagesModel = nullptr; //model类
+    AbstractPackageListModel *m_packagesModel = nullptr;  // model类
 
     QWidget *m_contentFrame = nullptr;   // 主布局
     QWidget *m_itemInfoFrame = nullptr;  // 包信息框架
@@ -294,6 +299,14 @@ private:
     int dependAuthStatu = -1;                       // 存储依赖授权状态
 
     bool resetButtonFocus = true;  // 展示包信息前，复位焦点状态，切换后第一次显示有效
+
+    // for comaptible mode
+    bool m_inCompatibleMode = false;  // current pacakge in comaptbile mode;
+    QString m_rootfs;                 // current package rootfs (empty if not installed)
+    QString m_targetRootfs;
+    DLabel *m_compatibleLabel = nullptr;
+    DComboBox *m_compatibleBox = nullptr;  // compatible rootfs selector
+    QHBoxLayout *m_compatibleLayout = nullptr;
 };
 
 #endif  // SINGLEINSTALLPAGE_H

--- a/src/deb-installer/view/pages/uninstallconfirmpage.cpp
+++ b/src/deb-installer/view/pages/uninstallconfirmpage.cpp
@@ -123,6 +123,8 @@ UninstallConfirmPage::UninstallConfirmPage(QWidget *parent)
 
 void UninstallConfirmPage::setPackage(const QString &name)
 {
+    m_packageName = name;
+
     // add tips
     QString tips = tr("Are you sure you want to uninstall %1?\nAll dependencies will also be removed");
     if (!m_requiredList.isEmpty()) {
@@ -150,8 +152,21 @@ void UninstallConfirmPage::setRequiredList(const QStringList &requiredList)
 
 void UninstallConfirmPage::setPackageType(Pkg::PackageType type)
 {
-    QIcon icon = Utils::packageIcon(type);
+    const QIcon icon = Utils::packageIcon(type);
     m_icon->setPixmap(icon.pixmap(m_icon->size()));
+}
+
+void UninstallConfirmPage::setCompatibleInfo(const QString &rootfs)
+{
+    m_rootfs = rootfs;
+    if (rootfs.isEmpty()) {
+        return;
+    }
+
+    m_infoWrapperWidget->layout()->setContentsMargins(0, 60, 0, 60);
+    m_icon->setFixedSize(85, 85);
+    m_icon->setPixmap(QIcon::fromTheme("dialog-warning").pixmap(m_icon->size()));
+    m_tips->setText(tr("Are you sure you want to uninstall %2 \nfrom %1 compatibility mode?").arg(m_rootfs).arg(m_packageName));
 }
 
 void UninstallConfirmPage::showEvent(QShowEvent *e)

--- a/src/deb-installer/view/pages/uninstallconfirmpage.h
+++ b/src/deb-installer/view/pages/uninstallconfirmpage.h
@@ -34,6 +34,8 @@ public:
 
     void setPackageType(Pkg::PackageType type);
 
+    void setCompatibleInfo(const QString &rootfs);
+
 signals:
 
     /**
@@ -75,5 +77,8 @@ private:
 
     QStringList m_requiredList = {};
     QString m_description = "";
+
+    QString m_packageName;
+    QString m_rootfs;
 };
 #endif  // UNINSTALLCONFIRMPAGE_H

--- a/src/deb-installer/view/widgets/debinfolabel.cpp
+++ b/src/deb-installer/view/widgets/debinfolabel.cpp
@@ -71,14 +71,14 @@ void DebInfoLabel::paintEvent(QPaintEvent *event)
             DPalette palette = DebApplicationHelper::instance()->palette(&tmpWidget);
             QPainter painter(this);
             painter.setPen(QColor(00, 130, 252));
-            painter.drawText(contentsRect(), static_cast<int>(alignment()), text());
+            painter.drawText(contentsRect(), static_cast<int>(alignment()), paintText());
             QWidget::paintEvent(event);
         } else {
             // 当前使用的是自定义颜色
             DPalette palette = DebApplicationHelper::instance()->palette(&tmpWidget);
             QPainter painter(this);
             painter.setPen(QColor(palette.color(m_colorType)));
-            painter.drawText(contentsRect(), static_cast<int>(alignment()), text());
+            painter.drawText(contentsRect(), static_cast<int>(alignment()), paintText());
             QWidget::paintEvent(event);
         }
     } else {
@@ -89,8 +89,18 @@ void DebInfoLabel::paintEvent(QPaintEvent *event)
             DPalette palette = DebApplicationHelper::instance()->palette(&tmpWidget);
             QPainter painter(this);
             painter.setPen(QColor(palette.color(m_colorRole)));
-            painter.drawText(contentsRect(), static_cast<int>(alignment()), text());
+            painter.drawText(contentsRect(), static_cast<int>(alignment()), paintText());
             QWidget::paintEvent(event);
         }
     }
+}
+
+QString DebInfoLabel::paintText() const
+{
+    QString paintString = text();
+    if (Qt::ElideNone != elideMode()) {
+        return fontMetrics().elidedText(paintString, elideMode(), width());
+    }
+
+    return paintString;
 }

--- a/src/deb-installer/view/widgets/debinfolabel.cpp
+++ b/src/deb-installer/view/widgets/debinfolabel.cpp
@@ -60,6 +60,13 @@ void DebInfoLabel::setCustomDPalette()
     this->setPalette(palette);
 }
 
+void DebInfoLabel::setTextAndTips(const QString &text)
+{
+    setText(text);
+    m_toolTip = text;
+    updateTipText();
+}
+
 void DebInfoLabel::paintEvent(QPaintEvent *event)
 {
     QWidget tmpWidget;
@@ -95,12 +102,29 @@ void DebInfoLabel::paintEvent(QPaintEvent *event)
     }
 }
 
-QString DebInfoLabel::paintText() const
+QString DebInfoLabel::paintText()
 {
+    // update tips while repaint
+    updateTipText();
+
     QString paintString = text();
     if (Qt::ElideNone != elideMode()) {
         return fontMetrics().elidedText(paintString, elideMode(), width());
     }
 
     return paintString;
+}
+
+/**
+ * @brief Default tooltip not provides wordwrap, use QTextDocument layout instead.
+ */
+void DebInfoLabel::updateTipText()
+{
+    if (m_toolTip.isEmpty()) {
+        setToolTip(m_toolTip);
+        return;
+    }
+
+    QString tipsText = Utils::formatWrapText(m_toolTip, width());
+    setToolTip(tipsText);
 }

--- a/src/deb-installer/view/widgets/debinfolabel.h
+++ b/src/deb-installer/view/widgets/debinfolabel.h
@@ -44,6 +44,9 @@ public:
     void paintEvent(QPaintEvent *event) override;
 
 private:
+    [[nodiscard]] QString paintText() const;
+
+private:
     QPalette::ColorRole m_colorRole;  // 当前label的字体颜色角色（QPalette）
     DPalette::ColorType m_colorType;  // 当前Label的字体颜色类型（DPalette）
 

--- a/src/deb-installer/view/widgets/debinfolabel.h
+++ b/src/deb-installer/view/widgets/debinfolabel.h
@@ -6,8 +6,11 @@
 #define DEBINFOLABEL_H
 
 #include <DLabel>
+#include <QScopedPointer>
 
 DWIDGET_USE_NAMESPACE
+
+class QTextDocument;
 
 /**
  * @brief The DebInfoLabel class
@@ -41,10 +44,13 @@ public:
      */
     void setCustomDPalette();
 
+    void setTextAndTips(const QString &text);
+
     void paintEvent(QPaintEvent *event) override;
 
 private:
-    [[nodiscard]] QString paintText() const;
+    [[nodiscard]] QString paintText();
+    void updateTipText();
 
 private:
     QPalette::ColorRole m_colorRole;  // 当前label的字体颜色角色（QPalette）
@@ -52,6 +58,8 @@ private:
 
     bool m_bUserColorType = false;  // 是否是使用的DPalette
     bool m_bMultiIns = false;       // 是否是使用的自定义DPalette风格
+
+    QString m_toolTip;
 };
 
 #endif  // DEBINFOLABEL_H

--- a/src/deb-installer/view/widgets/packageselectitem.cpp
+++ b/src/deb-installer/view/widgets/packageselectitem.cpp
@@ -74,18 +74,18 @@ void PackageSelectItem::setDebIR(const DebIr &ir)
         auto installStatus = installInfo.first;
         auto installedVersion = installInfo.second;
         switch (installStatus) {
-            case PackageAnalyzer::NotInstalled:  // 未安装
+            case Pkg::NotInstalled:  // 未安装
                 displayText = ir.shortDescription;
                 checkBox->setChecked(true);
                 break;
-            case PackageAnalyzer::InstalledSameVersion:  // 已安装相同版本
+            case Pkg::InstalledSameVersion:  // 已安装相同版本
                 displayText = tr("Same version installed");
                 break;
-            case PackageAnalyzer::InstalledEarlierVersion:  // 已安装较早版本
+            case Pkg::InstalledEarlierVersion:  // 已安装较早版本
                 displayText = tr("Earlier version installed: %1").arg(installedVersion);
                 checkBox->setChecked(true);
                 break;
-            case PackageAnalyzer::InstalledLaterVersion:  // 已安装较新版本
+            case Pkg::InstalledLaterVersion:  // 已安装较新版本
                 displayText = tr("Later version installed: %1").arg(installedVersion);
                 break;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,6 +138,7 @@ file(GLOB_RECURSE APP_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/../src/deb-installer/view/pages/*.cpp
     ${CMAKE_CURRENT_LIST_DIR}/../src/deb-installer/view/widgets/*.cpp
     ${CMAKE_CURRENT_LIST_DIR}/../src/deb-installer/uab/*.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/../src/deb-installer/compatible/*.cpp
     )
 FILE(GLOB allTestSource
   src/*.cpp

--- a/tests/src/model/ut_deblistmodel.cpp
+++ b/tests/src/model/ut_deblistmodel.cpp
@@ -648,6 +648,11 @@ ConflictResult ut_packageConflictStat()
     return ConflictResult::err("");
 }
 
+PackageDependsStatus getPackageDependsStatus(const int)
+{
+    return PackageDependsStatus::_break("");
+}
+
 TEST_F(ut_DebListModel_test, deblistmodel_UT_packageFailedReason)
 {
     QStringList list;
@@ -659,6 +664,7 @@ TEST_F(ut_DebListModel_test, deblistmodel_UT_packageFailedReason)
     stub.set(ADDR(PackagesManager, isArchError), model_package_isArchError1);
     stub.set(ADDR(PackageDependsStatus, isBreak), ut_model_isBreak);
     stub.set(ADDR(PackagesManager, packageConflictStat), ut_packageConflictStat);
+    stub.set(ADDR(PackagesManager, getPackageDependsStatus), getPackageDependsStatus);
     m_debListModel->packageFailedReason(0);
     EXPECT_TRUE(m_debListModel->packageFailedReason(0).contains("Broken dependencies"));
 }

--- a/tests/src/model/ut_packageanalyzer.cpp
+++ b/tests/src/model/ut_packageanalyzer.cpp
@@ -36,15 +36,15 @@ TEST_F(ut_packageanalyzer_TEST, PackageAnalyzer_UT_packageInstallStatus)
 
     ir.version = "1.0";
     auto data = PackageAnalyzer::instance().packageInstallStatus(ir);
-    ASSERT_EQ(data.first, PackageAnalyzer::NotInstalled);
+    ASSERT_EQ(data.first, Pkg::NotInstalled);
 
     ir.packageName = "libc6";
     data = PackageAnalyzer::instance().packageInstallStatus(ir);
-    ASSERT_EQ(data.first, PackageAnalyzer::InstalledLaterVersion);
+    ASSERT_EQ(data.first, Pkg::InstalledLaterVersion);
 
     ir.version = "999.999";
     data = PackageAnalyzer::instance().packageInstallStatus(ir);
-    ASSERT_EQ(data.first, PackageAnalyzer::InstalledEarlierVersion);
+    ASSERT_EQ(data.first, Pkg::InstalledEarlierVersion);
 }
 
 TEST_F(ut_packageanalyzer_TEST, PackageAnalyzer_UT_packageWithArch)

--- a/tests/src/uab/ut_uab_process_controller.cpp
+++ b/tests/src/uab/ut_uab_process_controller.cpp
@@ -33,15 +33,31 @@ void utDebProcessController::SetUp()
 
 void utDebProcessController::TearDown() {}
 
+bool stub_isValid_true()
+{
+    return true;
+}
+
+bool stub_installDBusImpl_true(const Uab::UabPackage::Ptr &)
+{
+    return true;
+}
+
 TEST_F(utDebProcessController, installExecSuccess)
 {
+    Stub s;
+    s.set(ADDR(Uab::UabPackage, isValid), stub_isValid_true);
+    s.set(ADDR(Uab::UabProcessController, installDBusImpl), stub_installDBusImpl_true);
+
     Uab::UabProcessController uabController;
     auto uabPtr = Uab::UabPkgInfo::Ptr::create();
     uabPtr->filePath = "localtest";
     uabController.reset();
     uabController.markInstall(Uab::UabPackage::fromInfo(uabPtr));
-    uabController.commitChanges();
+    EXPECT_TRUE(uabController.commitChanges());
 
-    EXPECT_EQ(uabController.m_process->program(), uabPtr->filePath);
-    EXPECT_TRUE(uabController.m_procFlag.testFlag(Uab::UabProcessController::Installing));
+    if (Uab::UabProcessController::Cli == uabController.processType()) {
+        EXPECT_EQ(uabController.m_process->program(), uabPtr->filePath);
+    }
+    EXPECT_TRUE(uabController.m_procFlag.testFlag(Uab::UabProcessController::Processing));
 }

--- a/tests/src/utils/ut_hierarchicalverify.cpp
+++ b/tests/src/utils/ut_hierarchicalverify.cpp
@@ -50,16 +50,13 @@ TEST_F(ut_HierarchicalVerify_TEST, isValid_WithInterface_True)
     Stub stub;
     stub.set(ADDR(HierarchicalVerify, checkHierarchicalInterface), stub_checkHierarchicalInterface_true);
 
-    ASSERT_TRUE(HierarchicalVerify::instance()->isValid());
+    ASSERT_TRUE(HierarchicalVerify::instance()->checkValidImpl());
 }
 
 TEST_F(ut_HierarchicalVerify_TEST, isValid_NoInterface_False)
 {
-    Stub stub;
-    stub.set(ADDR(QDBusAbstractInterface, isValid), stub_dbus_isValid_false);
-
+    HierarchicalVerify::instance()->interfaceInvalid = false;
     ASSERT_FALSE(HierarchicalVerify::instance()->isValid());
-    ASSERT_TRUE(HierarchicalVerify::instance()->interfaceInvalid);
 }
 
 TEST_F(ut_HierarchicalVerify_TEST, checkTransactionError_TestRegExp_True)
@@ -101,24 +98,6 @@ TEST_F(ut_HierarchicalVerify_TEST, checkTransactionError_TestRegExp_False)
                                                 "install-hook -e hc-verifysign;fi 出错，退出状态为 xxx"));
 
     ASSERT_TRUE(hVerify->invalidPackages.isEmpty());
-}
-
-TEST_F(ut_HierarchicalVerify_TEST, validChanged_Notify_Count)
-{
-    auto hVerify = HierarchicalVerify::instance();
-    QSignalSpy spy(hVerify, SIGNAL(validChanged(bool)));
-
-    Stub stub;
-    stub.set(ADDR(HierarchicalVerify, checkHierarchicalInterface), stub_checkHierarchicalInterface_switch);
-    hVerify->valid = false;
-    hVerify->interfaceInvalid = false;
-    stub_switchValid = true;
-
-    ASSERT_TRUE(hVerify->isValid());
-    stub_switchValid = false;
-    ASSERT_FALSE(hVerify->isValid());
-
-    ASSERT_EQ(spy.count(), 2);
 }
 
 TEST_F(ut_HierarchicalVerify_TEST, verifyResult_Store_True)

--- a/tests/src/view/pages/ut_singleinstallpage.cpp
+++ b/tests/src/view/pages/ut_singleinstallpage.cpp
@@ -137,8 +137,8 @@ TEST_F(UT_SingleInstallpage, UT_SingleInstallpage_total)
     stub.set(ADDR(DebFile, shortDescription), stud_singleshortDescription);
     stub.set(ADDR(PackagesManager, getPackageDependsStatus), stud_singlegetPackageDependsStatus);
     stub.set(ADDR(PackagesManager, packageInstallStatus), stud_singlepackageInstallStatus);
-    stub.set(ADDR(DebListModel, slotInstallPackages), stud_installPackages);
-    stub.set(ADDR(DebListModel, slotUninstallPackage), stud_singleuninstallPackage);
+    stub.set(decltype (&stud_installPackages)(&DebListModel::slotInstallPackages), stud_installPackages);
+    stub.set(decltype (&stud_singleuninstallPackage)(&DebListModel::slotUninstallPackage), stud_singleuninstallPackage);
     stub.set(ADDR(DebListModel, recheckPackagePath), stud_recheckPackagePath);
 
     model = new DebListModel();
@@ -289,8 +289,8 @@ TEST_F(UT_SingleInstallpage, UT_SingleInstallpage_onWorkFinishedFailed)
     stub.set(ADDR(DebFile, shortDescription), stud_singleshortDescription);
     stub.set(ADDR(PackagesManager, getPackageDependsStatus), stud_singlegetPackageDependsStatus);
     stub.set(ADDR(PackagesManager, packageInstallStatus), stud_singlepackageInstallStatus);
-    stub.set(ADDR(DebListModel, slotInstallPackages), stud_installPackages);
-    stub.set(ADDR(DebListModel, slotUninstallPackage), stud_singleuninstallPackage);
+    stub.set((decltype(&stud_installPackages))ADDR(DebListModel, slotInstallPackages), stud_installPackages);
+    stub.set((decltype(&stud_singleuninstallPackage))ADDR(DebListModel, slotUninstallPackage), stud_singleuninstallPackage);
     stub.set(ADDR(DebListModel, recheckPackagePath), stud_recheckPackagePath);
 
     model = new DebListModel();
@@ -325,8 +325,8 @@ TEST_F(UT_SingleInstallpage, UT_SingleInstallpage_onWorkFinishedSuccees)
     stub.set(ADDR(DebFile, shortDescription), stud_singleshortDescription);
     stub.set(ADDR(PackagesManager, getPackageDependsStatus), stud_singlegetPackageDependsStatus);
     stub.set(ADDR(PackagesManager, packageInstallStatus), stud_singlepackageInstallStatus);
-    stub.set(ADDR(DebListModel, slotInstallPackages), stud_installPackages);
-    stub.set(ADDR(DebListModel, slotUninstallPackage), stud_singleuninstallPackage);
+    stub.set((decltype(&stud_installPackages))ADDR(DebListModel, slotInstallPackages), stud_installPackages);
+    stub.set((decltype(&stud_singleuninstallPackage))ADDR(DebListModel, slotUninstallPackage), stud_singleuninstallPackage);
     stub.set(ADDR(QModelIndex, data), stu_data);
     stub.set(ADDR(DebListModel, recheckPackagePath), stud_recheckPackagePath);
     model = new DebListModel();
@@ -376,8 +376,8 @@ TEST_F(UT_SingleInstallpage, UT_SingleInstallpage_initTabOrder)
     stub.set(ADDR(DebFile, shortDescription), stud_singleshortDescription);
     stub.set(ADDR(PackagesManager, getPackageDependsStatus), stud_singlegetPackageDependsStatus);
     stub.set(ADDR(PackagesManager, packageInstallStatus), stud_singlepackageInstallStatus);
-    stub.set(ADDR(DebListModel, slotInstallPackages), stud_installPackages);
-    stub.set(ADDR(DebListModel, slotUninstallPackage), stud_singleuninstallPackage);
+    stub.set((decltype(&stud_installPackages))ADDR(DebListModel, slotInstallPackages), stud_installPackages);
+    stub.set((decltype(&stud_singleuninstallPackage))ADDR(DebListModel, slotUninstallPackage), stud_singleuninstallPackage);
     stub.set(ADDR(QModelIndex, data), stu_data);
     stub.set(ADDR(DebListModel, recheckPackagePath), stud_recheckPackagePath);
     model = new DebListModel();
@@ -415,8 +415,8 @@ TEST_F(UT_SingleInstallpage, UT_SingleInstallpage_paintEvent)
     stub.set(ADDR(DebFile, shortDescription), stud_singleshortDescription);
     stub.set(ADDR(PackagesManager, getPackageDependsStatus), stud_singlegetPackageDependsStatus);
     stub.set(ADDR(PackagesManager, packageInstallStatus), stud_singlepackageInstallStatus);
-    stub.set(ADDR(DebListModel, slotInstallPackages), stud_installPackages);
-    stub.set(ADDR(DebListModel, slotUninstallPackage), stud_singleuninstallPackage);
+    stub.set((decltype(&stud_installPackages))ADDR(DebListModel, slotInstallPackages), stud_installPackages);
+    stub.set((decltype(&stud_singleuninstallPackage))ADDR(DebListModel, slotUninstallPackage), stud_singleuninstallPackage);
     stub.set(ADDR(QModelIndex, data), stu_data);
     stub.set(ADDR(DebListModel, recheckPackagePath), stud_recheckPackagePath);
     model = new DebListModel();
@@ -441,8 +441,8 @@ TEST_F(UT_SingleInstallpage, UT_SingleInstallpage_slotDependPackages)
     stub.set(ADDR(DebFile, shortDescription), stud_singleshortDescription);
     stub.set(ADDR(PackagesManager, getPackageDependsStatus), stud_singlegetPackageDependsStatus);
     stub.set(ADDR(PackagesManager, packageInstallStatus), stud_singlepackageInstallStatus);
-    stub.set(ADDR(DebListModel, slotInstallPackages), stud_installPackages);
-    stub.set(ADDR(DebListModel, slotUninstallPackage), stud_singleuninstallPackage);
+    stub.set((decltype(&stud_installPackages))ADDR(DebListModel, slotInstallPackages), stud_installPackages);
+    stub.set((decltype(&stud_singleuninstallPackage))ADDR(DebListModel, slotUninstallPackage), stud_singleuninstallPackage);
     stub.set(ADDR(QModelIndex, data), stu_data);
     stub.set(ADDR(DebListModel, recheckPackagePath), stud_recheckPackagePath);
     model = new DebListModel();

--- a/tests/src/view/widgets/ut_packageselectitem.cpp
+++ b/tests/src/view/widgets/ut_packageselectitem.cpp
@@ -13,28 +13,28 @@
 #define private public
 #include "../deb-installer/view/widgets/packageselectitem.h"
 
-QPair<PackageAnalyzer::PackageInstallStatus, QString> packageInstallStatus_earilier(const DebIr &ir)
+QPair<Pkg::PackageInstallStatus, QString> packageInstallStatus_earilier(const DebIr &ir)
 {
     Q_UNUSED(ir)
-    return {PackageAnalyzer::InstalledEarlierVersion, "123"};
+    return {Pkg::InstalledEarlierVersion, "123"};
 }
 
-QPair<PackageAnalyzer::PackageInstallStatus, QString> packageInstallStatus_same(const DebIr &ir)
+QPair<Pkg::PackageInstallStatus, QString> packageInstallStatus_same(const DebIr &ir)
 {
     Q_UNUSED(ir)
-    return {PackageAnalyzer::InstalledSameVersion, "321"};
+    return {Pkg::InstalledSameVersion, "321"};
 }
 
-QPair<PackageAnalyzer::PackageInstallStatus, QString> packageInstallStatus_later(const DebIr &ir)
+QPair<Pkg::PackageInstallStatus, QString> packageInstallStatus_later(const DebIr &ir)
 {
     Q_UNUSED(ir)
-    return {PackageAnalyzer::InstalledLaterVersion, "123321"};
+    return {Pkg::InstalledLaterVersion, "123321"};
 }
 
-QPair<PackageAnalyzer::PackageInstallStatus, QString> packageInstallStatus_none(const DebIr &ir)
+QPair<Pkg::PackageInstallStatus, QString> packageInstallStatus_none(const DebIr &ir)
 {
     Q_UNUSED(ir)
-    return {PackageAnalyzer::NotInstalled, "1234567"};
+    return {Pkg::NotInstalled, "1234567"};
 }
 
 class ut_packageselectitem_TEST : public ::testing::Test


### PR DESCRIPTION
* Fix some outdated unit tests.
  Recent changes to the interface, improved unit testing.

* Adapt compatible install
  Update deepin-deb-installer-dependsInstall, Allow authentication permissions to install/remove packages in compatibility mode.

* Add compatible backend
  
* Adapt package model with compatibility mode
  Add a compatibility mode processing branch to the Debian package installation process;
  Provides compatibility mode roles, used to read / write from the UI;
  Adapt Deb::DebPackage::Ptr, prepare to replace scattered package data in the DebListModel / PackageAnalyzer;

* Adapt compatibility mode UI
  Only update the single-package processing.
  Added a drop-down box to select the compatibility mode;
  Added prompt information for installation/uninstall process;
  Updated interface layout.

* Update the prompt info

* Compatibility mode support DebConf and verify.
