### PR TITLE
fix: adapt compact mode/add display of packages to be removed

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -7,6 +7,7 @@
 #include "PackageDependsStatus.h"
 #include "AddPackageThread.h"
 #include "utils/utils.h"
+#include "utils/deb_package.h"
 #include "model/deblistmodel.h"
 #include "model/dependgraph.h"
 #include "model/packageanalyzer.h"
@@ -796,6 +797,18 @@ int PackagesManager::packageInstallStatus(const int index)
     return ret;
 }
 
+/**
+   @return The package list that \a md5 will install/upgrade/remove...
+ */
+QStringList PackagesManager::removePackages(const QByteArray &md5) const
+{
+    if (auto markedPtr = m_markedDepends.value(md5)) {
+        return markedPtr->removePackages();
+    }
+
+    return {};
+}
+
 void PackagesManager::slotDealDependResult(int iAuthRes, int iIndex, const QString &dependName)
 {
     if (iIndex < 0 || iIndex > m_preparedPackages.size())
@@ -979,6 +992,12 @@ PackageDependsStatus PackagesManager::getPackageDependsStatus(const int index)
     if (dependsStatus.isBreak())
         Q_ASSERT(!dependsStatus.package.isEmpty());
 
+    // If depends need install
+    if (DebListModel::DependsOk == dependsStatus.status ||
+        DebListModel::DependsAvailable == dependsStatus.status) {
+        refreshPackageMarkedInfo(currentPackageMd5, debFile.filePath());
+    }
+
     m_packageMd5DependsStatus.insert(currentPackageMd5, dependsStatus);
     return dependsStatus;
 }
@@ -1124,7 +1143,12 @@ const QString PackagesManager::packageInstalledVersion(const int index)
 
 const QStringList PackagesManager::packageAvailableDepends(const int index)
 {
-    DebFile debFile(m_preparedPackages[index]);
+    return debFileAvailableDepends(m_preparedPackages[index]);
+}
+
+QStringList PackagesManager::debFileAvailableDepends(const QString &filePath)
+{
+    DebFile debFile(filePath);
     if (!debFile.isValid())
         return QStringList();
     QSet<QString> choose_set;
@@ -1391,6 +1415,7 @@ void PackagesManager::reset()
     m_preparedPackages.clear();
     m_packageInstallStatus.clear();
     m_packageMd5DependsStatus.clear();  //修改依赖状态的存储结构，此处清空存储的依赖状态数据
+    m_markedDepends.clear();
     m_appendedPackagesMd5.clear();
     m_packageMd5.clear();
     m_dependGraph.reset();
@@ -1417,6 +1442,8 @@ void PackagesManager::resetPackageDependsStatus(const int index)
     //reloadCache必须要加
     PackageAnalyzer::instance().backendPtr()->reloadCache();
     m_packageMd5DependsStatus.remove(currentPackageMd5);  //删除当前包的依赖状态（之后会重新获取此包的依赖状态）
+
+    // we don't need reset m_markedDepends on installing
 }
 
 /**
@@ -1437,10 +1464,10 @@ void PackagesManager::removePackage(const int index)
     if (m_dependInstallMark.contains(md5))      //如果这个包是wine包，则在wine标记list中删除
         m_dependInstallMark.removeOne(md5);
 
-    m_appendedPackagesMd5.remove(md5);
     m_preparedPackages.removeAt(index);
 
     m_appendedPackagesMd5.remove(md5);          //在判断是否重复的md5的集合中删除掉当前包的md5
+    m_markedDepends.remove(md5);
     m_packageMd5DependsStatus.remove(md5);      //删除指定包的依赖状态
     m_packageMd5.removeAt(index);                               //在索引map中删除指定的项
     m_dependsPackages.remove(md5); //删除指定包的依赖关系
@@ -2334,6 +2361,19 @@ void PackagesManager::filterNeedInstallWinePackage(QStringList &dependList, cons
     });
 
     dependList.erase(removedIter, dependList.end());
+}
+
+void PackagesManager::refreshPackageMarkedInfo(const QByteArray &md5, const QString &filePath)
+{
+    if (m_markedDepends.contains(md5)) {
+        return;
+    }
+
+    const QStringList availableDepends = debFileAvailableDepends(filePath);
+    auto markedPtr = Deb::DebPackage::Ptr::create(filePath);
+    markedPtr->setMarkedPackages(availableDepends);
+
+    m_markedDepends.insert(md5, markedPtr);
 }
 
 bool PackagesManager::isBlackApplication(const QString &applicationName)

--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -27,6 +27,10 @@ class DebListModel;
 class DealDependThread;
 class AddPackageThread;
 
+namespace Deb {
+class DebPackage;
+}; // namespace Deb
+
 /**
  * @brief init_backend 初始化后端
  * @return 初始化完成的后端指针
@@ -103,6 +107,9 @@ public:
      * @param package_path 包名字
      */
     QString checkPackageValid(const QStringList &package_path);
+
+    QStringList removePackages(const QByteArray &md5) const;
+
 public slots:
     /**
      * @brief DealDependResult 处理wine依赖下载结果的槽函数
@@ -268,6 +275,8 @@ public:
      * @return  指定包所有的需要下载的依赖
      */
     const QStringList packageAvailableDepends(const int index);
+
+    QStringList debFileAvailableDepends(const QString &filePath);
 
     /**
      * @brief getPackageDependsStatus 获取指定包的依赖的状态
@@ -540,6 +549,8 @@ private:
      */
     void filterNeedInstallWinePackage(QStringList &dependList, const DebFile &debFile, const QHash<QString, DependencyInfo>& dependInfoMap);
 
+    void refreshPackageMarkedInfo(const QByteArray &md5, const QString &filePath);
+
 private:
     QMap<QByteArray, int> m_errorIndex;        //wine依赖错误的包的下标 QMap<MD5, DebListModel::DependsAuthStatus>
 
@@ -566,6 +577,13 @@ private:
      * 2.使用之前的方式会导致所有包的依赖状态错乱
      */
     QMap<QByteArray, PackageDependsStatus> m_packageMd5DependsStatus;
+
+    /**
+       @brief The key is md5, the value is the dependent info of the package,
+            marked packages NewInstall/ToUpgrade/ToRemove...
+            If the status of other packages is not changed, the value is nullptr.
+     */
+    QMap<QByteArray, QSharedPointer<Deb::DebPackage>> m_markedDepends;
 
     /**
      * @brief m_packageInstallStatus 包安装状态的Map

--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -326,6 +326,10 @@ QVariant DebListModel::data(const QModelIndex &index, int role) const
         else
             return Prepare;
     }
+    case PackageRemoveDependsRole: {
+        const QByteArray md5 = m_packagesManager->getPackageMd5(currentRow);
+        return m_packagesManager->removePackages(md5);
+    }
     case Qt::SizeHintRole:                                          //设置当前index的大小
         return QSize(0, 48);
 

--- a/src/deb-installer/model/deblistmodel.h
+++ b/src/deb-installer/model/deblistmodel.h
@@ -87,6 +87,8 @@ public:
         PackageFailReasonRole,              //包安装失败的原因
         PackageOperateStatusRole,           //包的操作状态
         PackageReverseDependsListRole,      //依赖于此包的程序
+
+        PackageRemoveDependsRole,           // Package will be remove if current install
     };
 
     /**

--- a/src/deb-installer/model/packageslistdelegate.cpp
+++ b/src/deb-installer/model/packageslistdelegate.cpp
@@ -260,6 +260,13 @@ void PackagesListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         forground.setColor(palette.color(colorGroup, DPalette::TextWarning));       //安装失败或依赖错误
     }
 
+    // No other error, show will remove packages
+    QStringList removePackages = index.data(DebListModel::PackageRemoveDependsRole).toStringList();
+    if (!removePackages.isEmpty()) {
+        forground.setColor(palette.color(colorGroup, DPalette::TextWarning));
+        info_str = QObject::tr("Will remove: ") + removePackages.join(' ');
+    }
+
     //当前选中 设置高亮
     if (option.state & DStyle::State_Enabled) {
         if (option.state & DStyle::State_Selected) {

--- a/src/deb-installer/utils/deb_package.cpp
+++ b/src/deb-installer/utils/deb_package.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "deb_package.h"
+
+#include <QApt/Backend>
+#include <QApt/Package>
+
+#include "model/packageanalyzer.h"
+
+namespace Deb {
+
+DebPackage::DebPackage(const QString &debFilePath)
+    : m_debFilePtr(QSharedPointer<QApt::DebFile>::create(debFilePath))
+{
+}
+
+bool DebPackage::isValid() const
+{
+    return m_debFilePtr->isValid();
+}
+
+bool DebPackage::fileExists() const
+{
+    return m_exists;
+}
+
+void DebPackage::markNotExists()
+{
+    m_exists = false;
+}
+
+QString DebPackage::filePath() const
+{
+    return m_debFilePtr->filePath();
+}
+
+QByteArray DebPackage::md5()
+{
+    if (m_md5.isEmpty() && m_debFilePtr->isValid()) {
+        m_md5 = m_debFilePtr->md5Sum();
+    }
+
+    return m_md5;
+}
+
+const QSharedPointer<QApt::DebFile> &DebPackage::debInfo() const
+{
+    return m_debFilePtr;
+}
+
+PackageDependsStatus &DebPackage::dependsStatus()
+{
+    return m_dependsStatus;
+}
+
+bool DebPackage::containRemovePackages() const
+{
+    return !m_removePackages.isEmpty();
+}
+
+void DebPackage::setMarkedPackages(const QStringList &installDepends)
+{
+    m_removePackages.clear();
+    if (!m_debFilePtr->isValid()) {
+        return;
+    }
+
+    QApt::Backend *backend = PackageAnalyzer::instance().backendPtr();
+    if (!backend) {
+        return;
+    }
+
+    backend->saveCacheState();
+
+    for (const QString &depends : installDepends) {
+        // annother error
+        if (depends.contains(" not found")) {
+            backend->undo();
+            return;
+        }
+        backend->markPackageForInstall(depends);
+    }
+
+    QApt::PackageList markedPackages = backend->markedPackages();
+
+    for (const QApt::Package *package : markedPackages) {
+        if (package->state() & QApt::Package::ToRemove) {
+            m_removePackages << package->name();
+        }
+    }
+
+    // must restore changes, not install now
+    backend->undo();
+
+    /* In the dependency check of the PacakgesManager, the dependency satisfaction of
+       the breaks/conflicts package has been detected, but only the packages that
+       will be installed have been marked.
+       Mark the breaks/conflicts package for uninstalling.
+    */
+    const QList<QApt::DependencyItem> selfRemovePackages = m_debFilePtr->breaks() + m_debFilePtr->conflicts();
+    for (const QApt::DependencyItem &item : selfRemovePackages) {
+        for (const QApt::DependencyInfo &info : item) {
+            QApt::Package *package = backend->package(info.packageName());
+            if (package && package->isInstalled()) {
+                m_removePackages << package->name();
+            }
+        }
+    }
+}
+
+QStringList DebPackage::removePackages() const
+{
+    return m_removePackages;
+}
+
+void DebPackage::setError(int code, const QString &string)
+{
+    m_errorCode = code;
+    m_errorString = string;
+}
+
+int DebPackage::errorCode() const
+{
+    return m_errorCode;
+}
+
+QString DebPackage::errorString() const
+{
+    return m_errorString;
+}
+
+};  // namespace Deb

--- a/src/deb-installer/utils/deb_package.h
+++ b/src/deb-installer/utils/deb_package.h
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DEBPACKAGE_H
+#define DEBPACKAGE_H
+
+#include <QSharedPointer>
+
+#include <QApt/DebFile>
+
+#include "manager/PackageDependsStatus.h"
+
+namespace Compatible {
+class CompPkgInfo;
+};  // namespace Compatible
+
+namespace Deb {
+
+// TODO: Use DebPackage::Ptr to replace the scattered package data in the DebListModel / PackageAnalyzer
+class DebPackage
+{
+public:
+    using Ptr = QSharedPointer<DebPackage>;
+
+    explicit DebPackage(const QString &debFilePath);
+    ~DebPackage() = default;
+
+    [[nodiscard]] bool isValid() const;
+    [[nodiscard]] bool fileExists() const;
+    void markNotExists();
+
+    [[nodiscard]] QString filePath() const;
+    [[nodiscard]] QByteArray md5();
+    [[nodiscard]] const QSharedPointer<QApt::DebFile> &debInfo() const;
+
+    // direct access
+    [[nodiscard]] PackageDependsStatus &dependsStatus();
+
+    // depends info
+    bool containRemovePackages() const;
+    void setMarkedPackages(const QStringList &installDepends);
+    QStringList removePackages() const;
+
+    // error
+    void setError(int code, const QString &string);
+    [[nodiscard]] int errorCode() const;
+    [[nodiscard]] QString errorString() const;
+
+    // for compatible mode
+    const QSharedPointer<Compatible::CompPkgInfo> &compatible();
+
+private:
+    bool m_exists{true};  // file exists
+
+    QByteArray m_md5;  // package's md5 sum
+    QSharedPointer<QApt::DebFile> m_debFilePtr;
+
+    PackageDependsStatus m_dependsStatus;
+
+    QStringList m_removePackages;
+
+    int m_errorCode{0};  // sa Pkg::ErrorCode and QApt::ErrorCode
+    QString m_errorString;
+
+    QSharedPointer<Compatible::CompPkgInfo> m_compInfoPtr;
+
+    enum TemplatesState {
+        UnknownTemplates,
+        ContainTemplates,
+        NoTemplates,
+    };
+    TemplatesState m_templatesState{UnknownTemplates};
+
+    Q_DISABLE_COPY(DebPackage)
+};
+
+};  // namespace Deb
+
+#endif  // DEBPACKAGE_H

--- a/src/deb-installer/view/pages/AptConfigMessage.cpp
+++ b/src/deb-installer/view/pages/AptConfigMessage.cpp
@@ -72,14 +72,8 @@ void AptConfigMessage::initControl()
 
     // 初始化输入框
     m_inputEdit = new DLineEdit();
-    m_inputEdit->setMinimumSize(220, 36);
+    m_inputEdit->setMinimumWidth(220);
 
-    //设置输入框只接受两个数字，配置的选项在99个以内（1-99）
-    //兼容有些包（mysql-community-server）配置时需要输入密码，取消对输入框的限制
-    //    QRegExp regExp("[0-9]{1,2}");
-    //    m_inputEdit->setValidator(new QRegExpValidator(regExp, this));
-
-    // 初始化提示信息lable
     m_pQuestionLabel = new DLabel(tr("Enter the number to configure: "));
     m_pQuestionLabel->setMaximumWidth(360);
     m_pQuestionLabel->setFocusPolicy(Qt::NoFocus);
@@ -87,7 +81,7 @@ void AptConfigMessage::initControl()
     //初始化提交信息按钮
     m_pushbutton = new DSuggestButton(tr("OK", "button"));
     m_pushbutton->setDefault(true);
-    m_pushbutton->setMinimumSize(130, 36);
+    m_pushbutton->setMinimumWidth(130);
 
     //焦点在信息输入框时，按回车触发提交信息。
     connect(m_inputEdit, &DLineEdit::returnPressed, m_pushbutton, &DPushButton::click);

--- a/src/deb-installer/view/pages/ddimerrorpage.cpp
+++ b/src/deb-installer/view/pages/ddimerrorpage.cpp
@@ -41,7 +41,7 @@ DdimErrorPage::DdimErrorPage(QWidget *parent)
     allLayout->setSpacing(0);
 
     confimButton->setFocusPolicy(Qt::StrongFocus);
-    confimButton->setFixedSize(120, 36);
+    confimButton->setFixedWidth(120);
     confimButton->setDefault(true);
     connect(confimButton, &QPushButton::clicked, this, &DdimErrorPage::comfimPressed);
 }

--- a/src/deb-installer/view/pages/multipleinstallpage.cpp
+++ b/src/deb-installer/view/pages/multipleinstallpage.cpp
@@ -449,6 +449,8 @@ void MultipleInstallPage::slotHiddenCancelButton()
     m_appsListView->setRightMenuShowStatus(false);      //安装开始时，不允许调用右键菜单
     m_backButton->setVisible(false);                    //隐藏返回按钮
     m_installButton->setVisible(false);                 //隐藏安装按钮
+
+    m_showDependsButton->shrinkContent();
     m_showDependsButton->setVisible(false);
 }
 
@@ -482,10 +484,30 @@ void MultipleInstallPage::slotDependPackages(DependsPair dependPackages, bool in
 {
     // 依赖关系满足或者正在下载wine依赖，则不显示依赖关系
     m_showDependsView->clearText();
-    if (!(dependPackages.second.size() > 0 && !installWineDepends)) {
-        m_showDependsButton->setVisible(false);
+    m_showDependsButton->setVisible(false);
+
+    if (installWineDepends) {
         return;
     }
+    if (dependPackages.second.isEmpty()) {
+        // depends ok or available, show package that will be remove after install
+        QModelIndex index = m_appsListView->currentIndex();
+        const QStringList removePackages = index.data(DebListModel::PackageRemoveDependsRole).toStringList();
+        if (!removePackages.isEmpty()) {
+            QString removeInfo = tr("Install %1 will remove: ").arg(index.data(DebListModel::PackageNameRole).toString());
+            removeInfo.append('\n');
+            removeInfo.append(removePackages.join('\n'));
+            removeInfo.append('\n');
+
+            m_showDependsView->appendText(removeInfo);
+            m_showDependsButton->setVisible(true);
+
+            m_tipsLabel->setText(removeInfo.simplified());
+        }
+
+        return;
+    }
+
     m_showDependsButton->setVisible(true);
     if (dependPackages.first.size() > 0) {
         m_showDependsView->appendText(tr("Dependencies in the repository"));

--- a/src/deb-installer/view/pages/multipleinstallpage.cpp
+++ b/src/deb-installer/view/pages/multipleinstallpage.cpp
@@ -161,9 +161,9 @@ void MultipleInstallPage::initUI()
     appsViewLayout->addWidget(m_appsListView);
     appsViewLayout->addSpacing(10);
 
-    m_installButton->setMinimumSize(120, 36);     //设置安装按钮的大小
-    m_acceptButton->setMinimumSize(120, 36);      //设置确认按钮的大小
-    m_backButton->setMinimumSize(120, 36);        //设置返回按钮的大小
+    m_installButton->setMinimumWidth(120);  // 设置安装按钮的大小
+    m_acceptButton->setMinimumWidth(120);   // 设置确认按钮的大小
+    m_backButton->setMinimumWidth(120);     // 设置返回按钮的大小
 
     m_installButton->setText(tr("Install", "button"));    //设置安装按钮的提示语
     m_acceptButton->setText(tr("Done", "button"));        //设置完成按钮的提示
@@ -230,7 +230,23 @@ void MultipleInstallPage::initUI()
     btnsLayout->addWidget(m_acceptButton);                                                      //添加完成按钮
     btnsLayout->setSpacing(20);                                                                 //设置按钮间的间距为20px
     btnsLayout->addStretch();
-    btnsLayout->setContentsMargins(0, 0, 0, 0);                                                //底部间距30
+
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    // adapt compact mode
+    auto setBtnSizeMode = [btnsLayout]() {
+        if (DGuiApplicationHelper::instance()->isCompactMode()) {
+            btnsLayout->setContentsMargins(0, 0, 0, 4);
+        } else {
+            btnsLayout->setContentsMargins(0, 0, 0, 0);
+        }
+    };
+    setBtnSizeMode();
+    // setBtnSizeMode moved
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, setBtnSizeMode);
+
+#else
+    btnsLayout->setContentsMargins(0, 0, 0, 0);
+#endif  // DTKWIDGET_CLASS_DSizeMode
 
     QWidget *btnsFrame = new QWidget(this);
     btnsFrameLayout->addWidget(m_processFrame);                                                 //进度布局添加到btn布局中（二者互斥，一定不能同时出现）

--- a/src/deb-installer/view/pages/packageselectview.cpp
+++ b/src/deb-installer/view/pages/packageselectview.cpp
@@ -36,7 +36,7 @@ PackageSelectView::PackageSelectView(QWidget *parent)
     bottomLayout->addWidget(new QWidget);  //占位用
     bottomLayout->setContentsMargins(8, 0, 0, 20);
     bottomLayout->setSpacing(0);
-    installButton->setFixedSize(120, 36);
+    installButton->setFixedWidth(120);
 
     //设置列表控件
     packageListWidget->setFrameStyle(QFrame::NoFrame);

--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -356,12 +356,12 @@ void SingleInstallPage::initPkgInstallProcessView(int fontinfosize)
     m_packageDescription->setWordWrap(true);        //允许内容自动换行
 
     // 设置各个按钮的大小
-    m_installButton->setMinimumSize(120, 36);
-    m_uninstallButton->setMinimumSize(120, 36);
-    m_reinstallButton->setMinimumSize(120, 36);
-    m_confirmButton->setMinimumSize(120, 36);
-    m_backButton->setMinimumSize(120, 36);
-    m_doneButton->setMinimumSize(120, 36);
+    m_installButton->setMinimumWidth(120);
+    m_uninstallButton->setMinimumWidth(120);
+    m_reinstallButton->setMinimumWidth(120);
+    m_confirmButton->setMinimumWidth(120);
+    m_backButton->setMinimumWidth(120);
+    m_doneButton->setMinimumWidth(120);
 
     //启用焦点切换。
     initButtonFocusPolicy();
@@ -390,7 +390,23 @@ void SingleInstallPage::initPkgInstallProcessView(int fontinfosize)
     btnsLayout->addWidget(m_doneButton, 0, Qt::AlignBottom);
     btnsLayout->addStretch();
     btnsLayout->setSpacing(20);
+
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    // adapt compact mode
+    auto setBtnSizeMode = [btnsLayout]() {
+        if (DGuiApplicationHelper::instance()->isCompactMode()) {
+            btnsLayout->setContentsMargins(0, 0, 0, 4);
+        } else {
+            btnsLayout->setContentsMargins(0, 0, 0, 0);
+        }
+    };
+    setBtnSizeMode();
+    // setBtnSizeMode moved
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, setBtnSizeMode);
+
+#else
     btnsLayout->setContentsMargins(0, 0, 0, 0);
+#endif  // DTKWIDGET_CLASS_DSizeMode
 
     //进度条 布局
     QVBoxLayout *progressLayout = new QVBoxLayout();

--- a/src/deb-installer/view/pages/singleinstallpage.h
+++ b/src/deb-installer/view/pages/singleinstallpage.h
@@ -293,6 +293,7 @@ private:
     int dependAuthStatu = -1; //存储依赖授权状态
 
     bool resetButtonFocus = true; // 展示包信息前，复位焦点状态，切换后第一次显示有效
+    bool m_showRemovePackages = false;  // current package need show remove packages
 };
 
 #endif  // SINGLEINSTALLPAGE_H

--- a/src/deb-installer/view/pages/uninstallconfirmpage.cpp
+++ b/src/deb-installer/view/pages/uninstallconfirmpage.cpp
@@ -35,9 +35,9 @@ UninstallConfirmPage::UninstallConfirmPage(QWidget *parent)
 
     // cancel button settings
     m_cancelBtn->setText(tr("Cancel", "button"));
-    m_cancelBtn->setMinimumSize(120, 36);
+    m_cancelBtn->setMinimumWidth(120);
     m_confirmBtn->setText(tr("Confirm"));
-    m_confirmBtn->setMinimumSize(120, 36);
+    m_confirmBtn->setMinimumWidth(120);
 
     // 添加确认和返回按钮的焦点策略
     m_confirmBtn->setFocusPolicy(Qt::TabFocus);
@@ -55,14 +55,30 @@ UninstallConfirmPage::UninstallConfirmPage(QWidget *parent)
     //layout of buttons
     QHBoxLayout *btnsLayout = new QHBoxLayout();
     btnsLayout->setSpacing(0);
-    btnsLayout->setContentsMargins(0, 0, 0, 0);
     btnsLayout->addStretch();
     btnsLayout->addWidget(m_cancelBtn);
     btnsLayout->addSpacing(20);
     btnsLayout->addWidget(m_confirmBtn);
     btnsLayout->addStretch();
 
-    //Layout of icons and tips
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    // adapt compact mode
+    auto setBtnSizeMode = [btnsLayout]() {
+        if (DGuiApplicationHelper::instance()->isCompactMode()) {
+            btnsLayout->setContentsMargins(0, 0, 0, 4);
+        } else {
+            btnsLayout->setContentsMargins(0, 0, 0, 0);
+        }
+    };
+    setBtnSizeMode();
+    // setBtnSizeMode moved
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, setBtnSizeMode);
+
+#else
+    btnsLayout->setContentsMargins(0, 0, 0, 0);
+#endif  // DTKWIDGET_CLASS_DSizeMode
+
+    // Layout of icons and tips
     QVBoxLayout *contentLayout = new QVBoxLayout(this);
     contentLayout->setSpacing(0);
     contentLayout->setContentsMargins(0, 0, 0, 0);

--- a/src/deb-installer/view/widgets/infocontrolbutton.cpp
+++ b/src/deb-installer/view/widgets/infocontrolbutton.cpp
@@ -151,6 +151,13 @@ void InfoControlButton::setExpandTips(const QString text)
     m_tipsText->setText(m_expandTips);  //设置提示语
 }
 
+void InfoControlButton::shrinkContent()
+{
+    if (m_expand) {
+        onMouseRelease();
+    }
+}
+
 void InfoControlButton::setShrinkTips(const QString text)
 {
     m_shrinkTips = text;                //保存提示语

--- a/src/deb-installer/view/widgets/infocontrolbutton.h
+++ b/src/deb-installer/view/widgets/infocontrolbutton.h
@@ -47,6 +47,8 @@ public:
      */
     void setExpandTips(const QString text);
 
+    void shrinkContent();
+
 public:
     /**
      * @brief linkButton 返回当前使用的CommandLinkButton

--- a/translations/deepin-deb-installer.ts
+++ b/translations/deepin-deb-installer.ts
@@ -4,12 +4,12 @@
 <context>
     <name>AptConfigMessage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="83"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="77"/>
         <source>Enter the number to configure: </source>
         <translation>Enter the number to configure: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="88"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="82"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -55,49 +55,54 @@
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="130"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="537"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="543"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Installing other packages... Please open it later.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="547"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Parsing failed: An illegal file structure was found in the manifest file!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="543"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="549"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Parsing failed: An illegal version number was found in the manifest file!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="545"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="551"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>No deb packages found. Please check the folder.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="631"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="637"/>
         <source>The deb package may be broken</source>
         <translation>The deb package may be broken</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="639"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="645"/>
         <source>You can only install local deb packages</source>
         <translation>You can only install local deb packages</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="653"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="667"/>
         <source>Already Added</source>
         <translation>Already Added</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="662"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="676"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 does not exist, please reselect</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="330"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="669"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="799"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="333"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="683"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="811"/>
         <source>Bulk Install</source>
         <translation>Bulk Install</translation>
     </message>
@@ -129,14 +134,14 @@
     </message>
     <message>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="632"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="641"/>
         <source>Invalid digital signature</source>
         <translation>Invalid digital signature</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="124"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="625"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1576"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="634"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1595"/>
         <source>The administrator has set policies to prevent installation of this package</source>
         <translation>The administrator has set policies to prevent installation of this package</translation>
     </message>
@@ -146,12 +151,12 @@
         <translation>Installation Failed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="634"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="643"/>
         <source>Failed to install %1</source>
         <translation>Failed to install %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1617"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1638"/>
         <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -160,74 +165,74 @@
         <translation type="vanished">Failed to install %1: no valid digital singature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="961"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="972"/>
         <source>Unable to install - no digital signature</source>
         <translation>Unable to install - no digital signature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="973"/>
         <source>Please go to Control Center to enable developer mode and try again. Proceed?</source>
         <translation>Please go to Control Center to enable developer mode and try again. Proceed?</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="965"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1620"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="976"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1641"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="966"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1621"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="977"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1642"/>
         <source>Proceed</source>
         <comment>button</comment>
         <translation>Proceed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="919"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1021"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1578"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1032"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1597"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="923"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="934"/>
         <source>Failed to install %1: no valid digital signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1059"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1070"/>
         <source>This package does not have a valid digital signature. Continue with the installation?</source>
         <translation>This package does not have a valid digital signature. Continue with the installation?</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1061"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1072"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1062"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1073"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="917"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1018"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1575"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1616"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="928"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1029"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1594"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1637"/>
         <source>Unable to install</source>
         <translation>Unable to install</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1019"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1030"/>
         <source>This package does not have a valid digital signature</source>
         <translation>This package does not have a valid digital signature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="637"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="642"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="646"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="651"/>
         <source>Broken dependencies: %1</source>
         <translation>Broken dependencies: %1</translation>
     </message>
@@ -237,7 +242,7 @@
         <translation>Authentication failed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="623"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="632"/>
         <source>Unmatched package architecture</source>
         <translation>Unmatched package architecture</translation>
     </message>
@@ -269,35 +274,40 @@
         <translation>Collapse</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="171"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="168"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Install</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="172"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="169"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="174"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="171"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="468"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="495"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="511"/>
         <source>Dependencies in the repository</source>
         <translation>Dependencies in the repository</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="474"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="517"/>
         <source>Missing dependencies</source>
         <translation>Missing dependencies</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="523"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="569"/>
         <source>Installing dependencies: %1</source>
         <translation>Installing dependencies: %1</translation>
     </message>
@@ -328,12 +338,12 @@
 <context>
     <name>PackageSelectView</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="19"/>
+        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="22"/>
         <source>Select all</source>
         <translation>Select all</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="20"/>
+        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Install</translation>
@@ -409,138 +419,148 @@
         <translation>Check digital signatures if the developer mode is enabled</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="77"/>
+        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="82"/>
         <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="79"/>
+        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="84"/>
         <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="267"/>
+        <source>Will remove: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="707"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="754"/>
         <source>Collapse</source>
         <translation>Collapse</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="333"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="803"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="966"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="346"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="886"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Reinstall</source>
         <translation>Reinstall</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="806"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="969"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="889"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1075"/>
         <source>Later version installed: %1</source>
         <translation>Later version installed: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="808"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="971"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="891"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1077"/>
         <source>Downgrade</source>
         <translation>Downgrade</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="811"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="974"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="894"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1080"/>
         <source>Earlier version installed: %1</source>
         <translation>Earlier version installed: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="876"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="971"/>
         <source>Installing dependencies: %1</source>
         <translation>Installing dependencies: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1011"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1119"/>
         <source>Failed to install %1</source>
         <translation>Failed to install %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="178"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="186"/>
         <source>Version: </source>
         <translation>Version: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="325"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="338"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Install</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="329"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="342"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Remove</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="337"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="350"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="341"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="354"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="345"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="358"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="679"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="724"/>
         <source>Installed successfully</source>
         <translation>Installed successfully</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="684"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="729"/>
         <source>Uninstalled successfully</source>
         <translation>Uninstalled successfully</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="698"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
         <source>Uninstall Failed</source>
         <translation>Uninstall Failed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="727"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="778"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="796"/>
         <source>Dependencies in the repository</source>
         <translation>Dependencies in the repository</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="733"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="802"/>
         <source>Missing dependencies</source>
         <translation>Missing dependencies</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="813"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="976"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="896"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1082"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Update</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1124"/>
         <source>Invalid digital signature</source>
         <translation type="unfinished">Invalid digital signature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="166"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="174"/>
         <source>Name: </source>
         <translation>Name: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="802"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="965"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="885"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1071"/>
         <source>Same version installed</source>
         <translation>Same version installed</translation>
     </message>
@@ -549,9 +569,9 @@
     <name>SingleInstallPage_Install</name>
     <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="45"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="551"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="678"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="557"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="583"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="723"/>
         <source>Show details</source>
         <translation>Show details</translation>
     </message>
@@ -565,8 +585,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="576"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="683"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="609"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="728"/>
         <source>Show details</source>
         <translation>Show details</translation>
     </message>
@@ -596,14 +616,14 @@
         <translation>Confirm</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="112"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="128"/>
         <source>Are you sure you want to uninstall %1?
 All dependencies will also be removed</source>
         <translation>Are you sure you want to uninstall %1?
 All dependencies will also be removed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="114"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="130"/>
         <source>Are you sure you want to uninstall %1?
 The system or other applications may not work properly</source>
         <translation>Are you sure you want to uninstall %1?

--- a/translations/deepin-deb-installer_zh_CN.ts
+++ b/translations/deepin-deb-installer_zh_CN.ts
@@ -1,15 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="zh_CN">
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
 <context>
     <name>AptConfigMessage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="83"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="77"/>
         <source>Enter the number to configure: </source>
         <translation>请输入序号进行配置：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="88"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="82"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
@@ -44,65 +42,73 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="101"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="108"/>
         <source>Package Installer</source>
         <translation>软件包安装器</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="109"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="116"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="130"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="540"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="599"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="700"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>正在执行安装流程，无法打开</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="544"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="603"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>软件包解析失败，软件包清单包含非法的文件结构！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="546"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="605"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>软件包解析失败，软件包清单包含非法版本号！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="548"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="607"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>未检测到安装包，请检查安装目录！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="634"/>
-        <source>The deb package may be broken</source>
-        <translation>请检查deb包是否损坏</translation>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="719"/>
+        <source>The %1 package may be broken</source>
+        <translation>请检查%1包是否损坏</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="642"/>
-        <source>You can only install local deb packages</source>
-        <translation>只能安装本地的deb包</translation>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="727"/>
+        <source>You can only install local %1 packages</source>
+        <translation>只能安装本地的%1包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="650"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="735"/>
         <source>No permission to access this folder</source>
         <translation>没有权限访问文件夹</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="664"/>
+        <source>The deb package may be broken</source>
+        <translation type="vanished">请检查deb包是否损坏</translation>
+    </message>
+    <message>
+        <source>You can only install local deb packages</source>
+        <translation type="vanished">只能安装本地的deb包</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="751"/>
         <source>Already Added</source>
         <translation>已添加</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="673"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="760"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1文件不存在，请重新选择文件</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="333"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="680"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="810"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="382"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="767"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="908"/>
         <source>Bulk Install</source>
         <translation>批量安装</translation>
     </message>
@@ -110,135 +116,131 @@
 <context>
     <name>DebListModel</name>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="87"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="104"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="91"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="108"/>
         <source>Installation failed, please check your network connection</source>
         <translation>安装失败，请检查您的网络连接</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="89"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="94"/>
         <source>Installation failed, please check for updates in Control Center</source>
         <translation>安装失败，请在控制中心检查更新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="92"/>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="96"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="108"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="100"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="112"/>
         <source>Installation failed, insufficient disk space</source>
         <translation>安装失败，磁盘空间不足</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
         <source>No digital signature</source>
         <translation>无数字签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="637"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="121"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="717"/>
         <source>Invalid digital signature</source>
         <translation>数字签名无效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="124"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="630"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1591"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="707"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1603"/>
         <source>The administrator has set policies to prevent installation of this package</source>
         <translation>管理员已限制，该软件禁止安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="129"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="133"/>
         <source>Installation Failed</source>
         <translation>安装失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="639"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="719"/>
         <source>Failed to install %1</source>
         <translation>%1安装失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1634"/>
-        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
-        <translation>安装包没有有效的数字签名，已被禁止安装/运行，请前往安全中心-安全工具-应用安全进行调整。</translation>
+        <source>Failed to install %1: no valid digital singature</source>
+        <translation type="vanished">无法安装%1，安装包无有效的数字签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="968"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1070"/>
         <source>Unable to install - no digital signature</source>
         <translation>无法安装，安装包无数字签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1071"/>
         <source>Please go to Control Center to enable developer mode and try again. Proceed?</source>
         <translation>请进入控制中心，开启开发者模式后，再尝试继续安装。是否前往？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="972"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1637"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1074"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="973"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1638"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1075"/>
         <source>Proceed</source>
         <comment>button</comment>
         <translation>前 往</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="926"/>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1028"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1593"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1130"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1605"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1032"/>
         <source>Failed to install %1: no valid digital signature</source>
         <translation>无法安装%1，安装包无有效的数字签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1066"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1168"/>
         <source>This package does not have a valid digital signature. Continue with the installation?</source>
         <translation>此安装包没有有效的数字签名，是否继续安装？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1068"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1170"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1069"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1171"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>继续</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="924"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1025"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1590"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1633"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1026"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1602"/>
         <source>Unable to install</source>
         <translation>无法安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1026"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1128"/>
         <source>This package does not have a valid digital signature</source>
         <translation>此安装包没有有效的数字签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="642"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="647"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="722"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="727"/>
         <source>Broken dependencies: %1</source>
         <translation>依赖关系不满足：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="121"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="125"/>
         <source>Authentication failed</source>
         <translation>配置授权失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="628"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="687"/>
         <source>Unmatched package architecture</source>
         <translation>软件包架构不匹配</translation>
     </message>
@@ -246,12 +248,12 @@
 <context>
     <name>FileChooseWidget</name>
     <message>
-        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="47"/>
         <source>Drag deb packages here</source>
         <translation>拖拽软件包到此</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="102"/>
+        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="89"/>
         <source>Select File</source>
         <translation>选择文件</translation>
     </message>
@@ -259,46 +261,51 @@
 <context>
     <name>MultipleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="33"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="34"/>
         <source>Show details</source>
         <translation>显示详细信息</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="33"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="34"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>收 起</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="168"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="169"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="169"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="170"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="171"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="172"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="473"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="499"/>
+        <source>Install %1 will remove: </source>
+        <translation>安装%1将会卸载：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="515"/>
         <source>Dependencies in the repository</source>
         <translation>仓库中存在的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="479"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="521"/>
         <source>Missing dependencies</source>
         <translation>仓库中缺失的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="528"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="573"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安装依赖：%1</translation>
     </message>
@@ -329,12 +336,12 @@
 <context>
     <name>PackageSelectView</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="19"/>
+        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="22"/>
         <source>Select all</source>
         <translation>全选</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="20"/>
+        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 装</translation>
@@ -343,27 +350,27 @@
 <context>
     <name>PackagesListDelegate</name>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="60"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="57"/>
         <source>Installing</source>
         <translation>正在安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="64"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="61"/>
         <source>Installed</source>
         <translation>已安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="72"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="69"/>
         <source>Failed</source>
         <translation>安装失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="68"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="65"/>
         <source>Waiting</source>
         <translation>等待安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="231"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="232"/>
         <source>Same version installed</source>
         <translation>已安装相同版本</translation>
     </message>
@@ -373,7 +380,7 @@
         <translation>已安装较新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="237"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="236"/>
         <source>Earlier version installed: %1</source>
         <translation>已安装较早的版本：%1</translation>
     </message>
@@ -381,7 +388,7 @@
 <context>
     <name>PackagesListView</name>
     <message>
-        <location filename="../src/deb-installer/model/packagelistview.cpp" line="160"/>
+        <location filename="../src/deb-installer/model/packagelistview.cpp" line="161"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
@@ -389,9 +396,9 @@
 <context>
     <name>QApplication</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="30"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="45"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="49"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>收 起</translation>
@@ -419,129 +426,166 @@
         <source>Security Center &gt; Tools &gt; App Security</source>
         <translation>安全中心-安全工具-应用安全</translation>
     </message>
+    <message>
+        <location filename="../src/deb-installer/uab/uab_package.cpp" line="45"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation>系统无玲珑环境，请先安装</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="42"/>
+        <source>Unable to install</source>
+        <translation>无法安装</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="44"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation>安装包没有有效的数字签名，已被禁止安装/运行，请前往安全中心-安全工具-应用安全进行调整。</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>取 消</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="48"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation>前 往</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="264"/>
+        <source>Will remove: </source>
+        <translation>将会卸载：</translation>
+    </message>
 </context>
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="884"/>
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="341"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="826"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="992"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1232"/>
         <source>Reinstall</source>
         <translation>重新安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="829"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="995"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1055"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1236"/>
         <source>Later version installed: %1</source>
         <translation>已安装较新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="831"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="997"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1056"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1237"/>
         <source>Downgrade</source>
         <translation>安装旧版本</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="834"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1000"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1060"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1241"/>
         <source>Earlier version installed: %1</source>
         <translation>已安装较早的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="900"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1137"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安装依赖：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1037"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1284"/>
         <source>Failed to install %1</source>
         <translation>%1安装失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="181"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="236"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="333"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="337"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>卸 载</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="345"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="349"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="353"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="410"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="702"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="842"/>
         <source>Installed successfully</source>
         <translation>安装成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="707"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="855"/>
         <source>Uninstalled successfully</source>
         <translation>卸载成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="721"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="874"/>
         <source>Uninstall Failed</source>
         <translation>卸载失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="913"/>
+        <source>Install %1 will remove: </source>
+        <translation>安装%1将会卸载：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="931"/>
         <source>Dependencies in the repository</source>
         <translation>仓库中存在的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="756"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="937"/>
         <source>Missing dependencies</source>
         <translation>仓库中缺失的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="836"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1002"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1061"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1242"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1042"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1289"/>
         <source>Invalid digital signature</source>
         <translation>数字签名无效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="169"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="224"/>
         <source>Name: </source>
         <translation>名称：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="825"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="991"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1050"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
         <source>Same version installed</source>
         <translation>已安装相同版本</translation>
     </message>
@@ -549,16 +593,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="45"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="536"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="562"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="701"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="631"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="668"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="835"/>
         <source>Show details</source>
         <translation>显示详细信息</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="30"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="48"/>
         <source>Show dependencies</source>
         <translation>显示依赖包关系</translation>
     </message>
@@ -566,8 +610,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="588"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="706"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="705"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="848"/>
         <source>Show details</source>
         <translation>显示卸载进程</translation>
     </message>
@@ -597,14 +641,14 @@
         <translation>确定卸载</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="112"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="129"/>
         <source>Are you sure you want to uninstall %1?
 All dependencies will also be removed</source>
         <translation>您确定要卸载%1 吗？
 所有依赖也会被一起移除</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="114"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
         <source>Are you sure you want to uninstall %1?
 The system or other applications may not work properly</source>
         <translation>您确定要卸载%1吗？

--- a/translations/deepin-deb-installer_zh_HK.ts
+++ b/translations/deepin-deb-installer_zh_HK.ts
@@ -1,15 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="zh_HK">
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
 <context>
     <name>AptConfigMessage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="83"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="77"/>
         <source>Enter the number to configure: </source>
         <translation>請輸入序號進行配置：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="88"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="82"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -44,65 +42,73 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="101"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="108"/>
         <source>Package Installer</source>
         <translation>軟件包安裝器</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="109"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="116"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="130"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="540"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="599"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="700"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>正在執行安裝流程，無法打開</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="544"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="603"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>軟件包解析失敗，軟件包清單包含非法的文件結構！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="546"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="605"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>軟件包解析失敗，軟件包清單包含非法版本號！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="548"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="607"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>未檢測到安裝包，請檢查安裝目錄！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="634"/>
-        <source>The deb package may be broken</source>
-        <translation>請檢查deb包是否損壞</translation>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="719"/>
+        <source>The %1 package may be broken</source>
+        <translation>請檢查%1包是否損壞</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="642"/>
-        <source>You can only install local deb packages</source>
-        <translation>只能安裝本地的deb包</translation>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="727"/>
+        <source>You can only install local %1 packages</source>
+        <translation>只能安裝本地的%1包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="650"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="735"/>
         <source>No permission to access this folder</source>
-        <translation>沒有權限訪問此資料夾</translation>
+        <translation>沒有權限訪問文件夾</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="664"/>
+        <source>The deb package may be broken</source>
+        <translation type="vanished">請檢查deb包是否損壞</translation>
+    </message>
+    <message>
+        <source>You can only install local deb packages</source>
+        <translation type="vanished">只能安裝本地的deb包</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="751"/>
         <source>Already Added</source>
         <translation>已添加</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="673"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="760"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1文件不存在，請重新選擇文件</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="333"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="680"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="810"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="382"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="767"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="908"/>
         <source>Bulk Install</source>
         <translation>批量安裝</translation>
     </message>
@@ -110,135 +116,131 @@
 <context>
     <name>DebListModel</name>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="87"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="104"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="91"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="108"/>
         <source>Installation failed, please check your network connection</source>
         <translation>安裝失敗，請檢查您的網絡連接</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="89"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="94"/>
         <source>Installation failed, please check for updates in Control Center</source>
         <translation>安裝失敗，請在控制中心檢查更新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="92"/>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="96"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="108"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="100"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="112"/>
         <source>Installation failed, insufficient disk space</source>
         <translation>安裝失敗，磁盤空間不足</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
         <source>No digital signature</source>
         <translation>無數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="637"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="121"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="717"/>
         <source>Invalid digital signature</source>
         <translation>數字簽名無效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="124"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="630"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1591"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="707"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1603"/>
         <source>The administrator has set policies to prevent installation of this package</source>
         <translation>管理員已限制，該軟件禁止安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="129"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="133"/>
         <source>Installation Failed</source>
         <translation>安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="639"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="719"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1634"/>
-        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
-        <translation>安裝包沒有有效的數字簽名，已被禁止安裝/運行，請前往安全中心-安全工具-應用安全進行調整。</translation>
+        <source>Failed to install %1: no valid digital singature</source>
+        <translation type="vanished">無法安裝%1，安裝包無有效的數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="968"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1070"/>
         <source>Unable to install - no digital signature</source>
         <translation>無法安裝，安裝包無數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1071"/>
         <source>Please go to Control Center to enable developer mode and try again. Proceed?</source>
         <translation>請進入控制中心，開啟開發者模式後，再嘗試繼續安裝。是否前往？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="972"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1637"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1074"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="973"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1638"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1075"/>
         <source>Proceed</source>
         <comment>button</comment>
         <translation>前 往</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="926"/>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1028"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1593"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1130"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1605"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1032"/>
         <source>Failed to install %1: no valid digital signature</source>
         <translation>無法安裝%1，安裝包無有效的數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1066"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1168"/>
         <source>This package does not have a valid digital signature. Continue with the installation?</source>
         <translation>此安裝包沒有有效的數字簽名，是否繼續安裝？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1068"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1170"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1069"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1171"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>繼續</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="924"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1025"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1590"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1633"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1026"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1602"/>
         <source>Unable to install</source>
         <translation>無法安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1026"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1128"/>
         <source>This package does not have a valid digital signature</source>
         <translation>此安裝包沒有有效的數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="642"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="647"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="722"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="727"/>
         <source>Broken dependencies: %1</source>
         <translation>依賴關係不滿足：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="121"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="125"/>
         <source>Authentication failed</source>
         <translation>配置授權失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="628"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="687"/>
         <source>Unmatched package architecture</source>
         <translation>軟件包架構不匹配</translation>
     </message>
@@ -246,12 +248,12 @@
 <context>
     <name>FileChooseWidget</name>
     <message>
-        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="47"/>
         <source>Drag deb packages here</source>
         <translation>拖拽軟件包到此</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="102"/>
+        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="89"/>
         <source>Select File</source>
         <translation>選擇文件</translation>
     </message>
@@ -259,46 +261,51 @@
 <context>
     <name>MultipleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="33"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="34"/>
         <source>Show details</source>
         <translation>顯示詳細訊息</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="33"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="34"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>收 起</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="168"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="169"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="169"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="170"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="171"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="172"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="473"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="499"/>
+        <source>Install %1 will remove: </source>
+        <translation>將會卸載：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="515"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="479"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="521"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="528"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="573"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
@@ -329,12 +336,12 @@
 <context>
     <name>PackageSelectView</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="19"/>
+        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="22"/>
         <source>Select all</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="20"/>
+        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
@@ -343,27 +350,27 @@
 <context>
     <name>PackagesListDelegate</name>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="60"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="57"/>
         <source>Installing</source>
         <translation>正在安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="64"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="61"/>
         <source>Installed</source>
         <translation>已安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="72"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="69"/>
         <source>Failed</source>
         <translation>安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="68"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="65"/>
         <source>Waiting</source>
         <translation>等待安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="231"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="232"/>
         <source>Same version installed</source>
         <translation>已安裝相同版本</translation>
     </message>
@@ -373,7 +380,7 @@
         <translation>已安裝較新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="237"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="236"/>
         <source>Earlier version installed: %1</source>
         <translation>已安裝較早的版本：%1</translation>
     </message>
@@ -381,7 +388,7 @@
 <context>
     <name>PackagesListView</name>
     <message>
-        <location filename="../src/deb-installer/model/packagelistview.cpp" line="160"/>
+        <location filename="../src/deb-installer/model/packagelistview.cpp" line="161"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
@@ -389,9 +396,9 @@
 <context>
     <name>QApplication</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="30"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="45"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="49"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>收 起</translation>
@@ -419,129 +426,166 @@
         <source>Security Center &gt; Tools &gt; App Security</source>
         <translation>安全中心-安全工具-應用安全</translation>
     </message>
+    <message>
+        <location filename="../src/deb-installer/uab/uab_package.cpp" line="45"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation>系統無玲瓏環境，請先安裝</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="42"/>
+        <source>Unable to install</source>
+        <translation>無法安裝</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="44"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation>安裝包沒有有效的數字簽名，已被禁止安裝/運行，請前往安全中心-安全工具-應用安全進行調整。</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>取 消</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="48"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation>前 往</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="264"/>
+        <source>Will remove: </source>
+        <translation>安裝%1將會卸載：</translation>
+    </message>
 </context>
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="884"/>
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="341"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="826"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="992"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1232"/>
         <source>Reinstall</source>
         <translation>重新安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="829"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="995"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1055"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1236"/>
         <source>Later version installed: %1</source>
         <translation>已安裝較新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="831"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="997"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1056"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1237"/>
         <source>Downgrade</source>
         <translation>安裝舊版本</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="834"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1000"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1060"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1241"/>
         <source>Earlier version installed: %1</source>
         <translation>已安裝較早的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="900"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1137"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1037"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1284"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="181"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="236"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="333"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="337"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>卸 載</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="345"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="349"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="353"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="410"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="702"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="842"/>
         <source>Installed successfully</source>
         <translation>安裝成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="707"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="855"/>
         <source>Uninstalled successfully</source>
         <translation>卸載成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="721"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="874"/>
         <source>Uninstall Failed</source>
         <translation>卸載失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="913"/>
+        <source>Install %1 will remove: </source>
+        <translation>安裝%1將會卸載：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="931"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="756"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="937"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="836"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1002"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1061"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1242"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1042"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1289"/>
         <source>Invalid digital signature</source>
         <translation>數字簽名無效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="169"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="224"/>
         <source>Name: </source>
         <translation>名稱：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="825"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="991"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1050"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
         <source>Same version installed</source>
         <translation>已安裝相同版本</translation>
     </message>
@@ -549,16 +593,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="45"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="536"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="562"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="701"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="631"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="668"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="835"/>
         <source>Show details</source>
         <translation>顯示詳細訊息</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="30"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="48"/>
         <source>Show dependencies</source>
         <translation>顯示依賴包關係</translation>
     </message>
@@ -566,8 +610,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="588"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="706"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="705"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="848"/>
         <source>Show details</source>
         <translation>顯示卸載進程</translation>
     </message>
@@ -597,14 +641,14 @@
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="112"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="129"/>
         <source>Are you sure you want to uninstall %1?
 All dependencies will also be removed</source>
         <translation>您確定要卸載%1 嗎？
 所有依賴也會被一起移除</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="114"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
         <source>Are you sure you want to uninstall %1?
 The system or other applications may not work properly</source>
         <translation>您確定要卸載%1嗎？

--- a/translations/deepin-deb-installer_zh_TW.ts
+++ b/translations/deepin-deb-installer_zh_TW.ts
@@ -1,15 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="zh_TW">
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
 <context>
     <name>AptConfigMessage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="83"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="77"/>
         <source>Enter the number to configure: </source>
         <translation>請輸入序號進行配置：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="88"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="82"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -44,65 +42,73 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="101"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="108"/>
         <source>Package Installer</source>
         <translation>軟體包安裝器</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="109"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="116"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="130"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="540"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="599"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="700"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>正在執行安裝流程，無法打開</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="544"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="603"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>套裝軟體解析失敗，套裝軟體清單包含非法的文件結構！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="546"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="605"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>套裝軟體解析失敗，套裝軟體清單包含非法版本號！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="548"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="607"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>未檢測到安裝包，請檢查安裝目錄！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="634"/>
-        <source>The deb package may be broken</source>
-        <translation>請檢查deb包是否損壞</translation>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="719"/>
+        <source>The %1 package may be broken</source>
+        <translation>請檢查%1包是否損壞</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="642"/>
-        <source>You can only install local deb packages</source>
-        <translation>只能安裝本機的deb包</translation>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="727"/>
+        <source>You can only install local %1 packages</source>
+        <translation>只能安裝本機的%1包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="650"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="735"/>
         <source>No permission to access this folder</source>
-        <translation>沒有權限訪問此資料夾</translation>
+        <translation>沒有權限訪問資料夾</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="664"/>
+        <source>The deb package may be broken</source>
+        <translation type="vanished">請檢查deb包是否損壞</translation>
+    </message>
+    <message>
+        <source>You can only install local deb packages</source>
+        <translation type="vanished">只能安裝本機的deb包</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="751"/>
         <source>Already Added</source>
         <translation>已添加</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="673"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="760"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1文件不存在，請重新選擇文件</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="333"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="680"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="810"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="382"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="767"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="908"/>
         <source>Bulk Install</source>
         <translation>批次安裝</translation>
     </message>
@@ -110,135 +116,131 @@
 <context>
     <name>DebListModel</name>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="87"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="104"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="91"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="108"/>
         <source>Installation failed, please check your network connection</source>
         <translation>安裝失敗，請檢查網路連線</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="89"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="94"/>
         <source>Installation failed, please check for updates in Control Center</source>
         <translation>安裝失敗，請於控制中心檢查更新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="92"/>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="96"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="108"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="100"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="112"/>
         <source>Installation failed, insufficient disk space</source>
         <translation>安裝失敗，磁碟機空間不足</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
         <source>No digital signature</source>
         <translation>無數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="637"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="121"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="717"/>
         <source>Invalid digital signature</source>
         <translation>數位簽章無效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="124"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="630"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1591"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="707"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1603"/>
         <source>The administrator has set policies to prevent installation of this package</source>
         <translation>管理員已限制，該軟體禁止安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="129"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="133"/>
         <source>Installation Failed</source>
         <translation>安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="639"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="719"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1634"/>
-        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
-        <translation>安裝包沒有有效的數位簽章，已被禁止安裝/執行，請前往安全中心-安全工具-應用安全進行調整。</translation>
+        <source>Failed to install %1: no valid digital singature</source>
+        <translation type="vanished">無法安裝%1，安裝包無有效的數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="968"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1070"/>
         <source>Unable to install - no digital signature</source>
         <translation>無法安裝，安裝包無數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1071"/>
         <source>Please go to Control Center to enable developer mode and try again. Proceed?</source>
         <translation>請進入控制中心，開啟開發者模式後，再嘗試繼續安裝。是否前往？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="972"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1637"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1074"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="973"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1638"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1075"/>
         <source>Proceed</source>
         <comment>button</comment>
         <translation>前 往</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="926"/>
         <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1028"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1593"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1130"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1605"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1032"/>
         <source>Failed to install %1: no valid digital signature</source>
         <translation>無法安裝%1，安裝包無有效的數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1066"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1168"/>
         <source>This package does not have a valid digital signature. Continue with the installation?</source>
         <translation>此安裝包沒有有效的數位簽章，是否繼續安裝？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1068"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1170"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1069"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1171"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>繼續</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="924"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1025"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1590"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1633"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1026"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1602"/>
         <source>Unable to install</source>
         <translation>無法安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1026"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1128"/>
         <source>This package does not have a valid digital signature</source>
         <translation>此安裝包沒有有效的數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="642"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="647"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="722"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="727"/>
         <source>Broken dependencies: %1</source>
         <translation>缺少依賴軟體：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="121"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="125"/>
         <source>Authentication failed</source>
         <translation>配置授權失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="628"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="687"/>
         <source>Unmatched package architecture</source>
         <translation>軟體套件結構不符合規範</translation>
     </message>
@@ -246,12 +248,12 @@
 <context>
     <name>FileChooseWidget</name>
     <message>
-        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="47"/>
         <source>Drag deb packages here</source>
         <translation>拖曳軟體包到此</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="102"/>
+        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="89"/>
         <source>Select File</source>
         <translation>選擇檔案</translation>
     </message>
@@ -259,46 +261,51 @@
 <context>
     <name>MultipleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="33"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="34"/>
         <source>Show details</source>
         <translation>顯示詳細訊息</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="33"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="34"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>隱 藏</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="168"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="169"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="169"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="170"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="171"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="172"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="473"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="499"/>
+        <source>Install %1 will remove: </source>
+        <translation>安裝%1將會卸載：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="515"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="479"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="521"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="528"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="573"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
@@ -329,12 +336,12 @@
 <context>
     <name>PackageSelectView</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="19"/>
+        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="22"/>
         <source>Select all</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="20"/>
+        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
@@ -343,27 +350,27 @@
 <context>
     <name>PackagesListDelegate</name>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="60"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="57"/>
         <source>Installing</source>
         <translation>正在安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="64"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="61"/>
         <source>Installed</source>
         <translation>已安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="72"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="69"/>
         <source>Failed</source>
         <translation>安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="68"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="65"/>
         <source>Waiting</source>
         <translation>等待安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="231"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="232"/>
         <source>Same version installed</source>
         <translation>已安裝相同版本</translation>
     </message>
@@ -373,7 +380,7 @@
         <translation>已安裝較新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="237"/>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="236"/>
         <source>Earlier version installed: %1</source>
         <translation>已安裝舊版本：%1</translation>
     </message>
@@ -381,7 +388,7 @@
 <context>
     <name>PackagesListView</name>
     <message>
-        <location filename="../src/deb-installer/model/packagelistview.cpp" line="160"/>
+        <location filename="../src/deb-installer/model/packagelistview.cpp" line="161"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
@@ -389,9 +396,9 @@
 <context>
     <name>QApplication</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="30"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="45"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="49"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>隱 藏</translation>
@@ -419,129 +426,166 @@
         <source>Security Center &gt; Tools &gt; App Security</source>
         <translation>安全中心-安全工具-應用安全</translation>
     </message>
+    <message>
+        <location filename="../src/deb-installer/uab/uab_package.cpp" line="45"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation>系統無玲瓏環境，請先安裝</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="42"/>
+        <source>Unable to install</source>
+        <translation>無法安裝</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="44"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation>安裝包沒有有效的數位簽章，已被禁止安裝/執行，請前往安全中心-安全工具-應用安全進行調整。</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>取 消</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="48"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation>前 往</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="264"/>
+        <source>Will remove: </source>
+        <translation>將會卸載：</translation>
+    </message>
 </context>
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="884"/>
         <source>Collapse</source>
         <translation>隱藏</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="341"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="826"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="992"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1232"/>
         <source>Reinstall</source>
         <translation>重 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="829"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="995"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1055"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1236"/>
         <source>Later version installed: %1</source>
         <translation>已安裝較新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="831"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="997"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1056"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1237"/>
         <source>Downgrade</source>
         <translation>安裝舊版本</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="834"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1000"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1060"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1241"/>
         <source>Earlier version installed: %1</source>
         <translation>已安裝舊版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="900"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1137"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1037"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1284"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="181"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="236"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="333"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="337"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>移 除</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="345"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="349"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="353"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="410"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="702"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="842"/>
         <source>Installed successfully</source>
         <translation>安裝成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="707"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="855"/>
         <source>Uninstalled successfully</source>
         <translation>解除安裝成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="721"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="874"/>
         <source>Uninstall Failed</source>
         <translation>解除安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="913"/>
+        <source>Install %1 will remove: </source>
+        <translation>安裝%1將會卸載：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="931"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="756"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="937"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="836"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1002"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1061"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1242"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1042"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1289"/>
         <source>Invalid digital signature</source>
         <translation>數位簽章無效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="169"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="224"/>
         <source>Name: </source>
         <translation>名稱：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="825"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="991"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1050"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
         <source>Same version installed</source>
         <translation>已安裝相同版本</translation>
     </message>
@@ -549,16 +593,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="45"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="536"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="562"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="701"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="631"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="668"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="835"/>
         <source>Show details</source>
         <translation>顯示詳細訊息</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="30"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="48"/>
         <source>Show dependencies</source>
         <translation>顯示依賴包關係</translation>
     </message>
@@ -566,8 +610,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="588"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="706"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="705"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="848"/>
         <source>Show details</source>
         <translation>顯示卸載進程</translation>
     </message>
@@ -597,14 +641,14 @@
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="112"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="129"/>
         <source>Are you sure you want to uninstall %1?
 All dependencies will also be removed</source>
         <translation>確定解除安裝 %1？
 也會移除所有依賴</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="114"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
         <source>Are you sure you want to uninstall %1?
 The system or other applications may not work properly</source>
         <translation>您確定要移除%1嗎？


### PR DESCRIPTION
As title.
Change the height of the button accroding to the size mode.

Merge form master f04c07f072e3666ab101908d109f33ecd41e9f74

Log: Adapt compact mode.
Bug: https://pms.uniontech.com/bug-view-279783.html
Influence: compact-mode

[fix: add display of packages to be removed](https://github.com/linuxdeepin/deepin-deb-installer/pull/273/commits/ab0b4d49cdc782ee5ce7315f995d607e2cabd694)
1. Backend package removal management:
   - Add interfaces and storage for package removal
   - Update removal info during dependency check
2. Frontend removal package display:
   - Add new data role for removal packages
   - Show removal package hints in install UI

Log: Display warning when installing packages
     would remove existing packages.
Bug: https://pms.uniontech.com/bug-view-275401.html

[chore: update translation](https://github.com/linuxdeepin/deepin-deb-installer/pull/273/commits/3eee541d3e297433acc203e1823dafff7906b7c3)
Update recently changes translation,
include display of uninstalld packages.

Log: Update translation.
Influence: translation