### PR TITLE
fix: add display of packages to be removed

### DIFF
--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -28,6 +28,10 @@ class DebListModel;
 class DealDependThread;
 class AddPackageThread;
 
+namespace Deb {
+class DebPackage;
+}; // namespace Deb
+
 /**
  * @brief init_backend 初始化后端
  * @return 初始化完成的后端指针
@@ -91,6 +95,9 @@ public:
      * @param package_path 包名字
      */
     QString checkPackageValid(const QStringList &package_path);
+
+    QStringList removePackages(const QByteArray &md5) const;
+
 public slots:
     /**
      * @brief DealDependResult 处理wine依赖下载结果的槽函数
@@ -199,6 +206,8 @@ public:
      * @return  指定包所有的需要下载的依赖
      */
     const QStringList packageAvailableDepends(const int index);
+
+    QStringList debFileAvailableDepends(const QString &filePath);
 
     /**
      * @brief getPackageDependsStatus 获取指定包的依赖的状态
@@ -477,6 +486,8 @@ private:
                                       const DebFile &debFile,
                                       const QHash<QString, DependencyInfo> &dependInfoMap);
 
+    void refreshPackageMarkedInfo(const QByteArray &md5, const QString &filePath);
+
 private:
     QMap<QByteArray, int> m_errorIndex;  // wine依赖错误的包的下标 QMap<MD5, DebListModel::DependsAuthStatus>
 
@@ -503,6 +514,13 @@ private:
      * 2.使用之前的方式会导致所有包的依赖状态错乱
      */
     QMap<QByteArray, PackageDependsStatus> m_packageMd5DependsStatus;
+
+    /**
+       @brief The key is md5, the value is the dependent info of the package,
+            marked packages NewInstall/ToUpgrade/ToRemove...
+            If the status of other packages is not changed, the value is nullptr.
+     */
+    QMap<QByteArray, QSharedPointer<Deb::DebPackage>> m_markedDepends;
 
     /**
      * @brief m_packageInstallStatus 包安装状态的Map

--- a/src/deb-installer/model/abstract_package_list_model.h
+++ b/src/deb-installer/model/abstract_package_list_model.h
@@ -34,6 +34,7 @@ public:
 
         PackageTypeRole,           // is uab or deb package, sa Pkg::PackageType
         PackageDependsDetailRole,  // details for unfinished depends, empty if no errors occur, sa Pkg::DependsPair
+        PackageRemoveDependsRole,  // package will be remove if current install
 
         CompatibleRootfsRole,        // compatible mode only, provides current compatible rootfs name
         CompatibleTargetRootfsRole,  // target rootfs name

--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -316,7 +316,10 @@ QVariant DebListModel::data(const QModelIndex &index, int role) const
                 return pkgPtr->compatible()->targetRootfs;
             }
             break;
-
+        case PackageRemoveDependsRole: {
+            const QByteArray md5 = m_packagesManager->getPackageMd5(currentRow);
+            return m_packagesManager->removePackages(md5);
+        }
         case Qt::SizeHintRole:  // 设置当前index的大小
             return QSize(0, 48);
         case Qt::ToolTipRole:

--- a/src/deb-installer/model/packageslistdelegate.cpp
+++ b/src/deb-installer/model/packageslistdelegate.cpp
@@ -256,6 +256,15 @@ void PackagesListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         forground.setColor(palette.color(colorGroup, DPalette::TextWarning));  // 安装失败或依赖错误
     }
 
+    // No other error, show will remove packages
+    if (dependsStat != Pkg::CompatibleIntalled && dependsStat != Pkg::CompatibleNotInstalled) {
+        QStringList removePackages = index.data(DebListModel::PackageRemoveDependsRole).toStringList();
+        if (!removePackages.isEmpty()) {
+            forground.setColor(palette.color(colorGroup, DPalette::TextWarning));
+            info_str = QObject::tr("Will remove: ") + removePackages.join(' ');
+        }
+    }
+
     // 当前选中 设置高亮
     if (option.state & DStyle::State_Enabled) {
         if (option.state & DStyle::State_Selected) {

--- a/src/deb-installer/utils/deb_package.h
+++ b/src/deb-installer/utils/deb_package.h
@@ -44,6 +44,11 @@ public:
 
     bool containsTemplates();
 
+    // depends info
+    bool containRemovePackages() const;
+    void setMarkedPackages(const QStringList &installDepends);
+    QStringList removePackages() const;
+
     // error
     void setError(int code, const QString &string);
     [[nodiscard]] int errorCode() const;
@@ -62,6 +67,8 @@ private:
     Pkg::PackageInstallStatus m_installStatus{Pkg::NotInstalled};
 
     PackageDependsStatus m_dependsStatus;
+
+    QStringList m_removePackages;
 
     int m_errorCode{Pkg::NoError};  // sa Pkg::ErrorCode and QApt::ErrorCode
     QString m_errorString;

--- a/src/deb-installer/view/pages/multipleinstallpage.cpp
+++ b/src/deb-installer/view/pages/multipleinstallpage.cpp
@@ -449,6 +449,8 @@ void MultipleInstallPage::slotHiddenCancelButton()
     m_appsListView->setRightMenuShowStatus(false);  // 安装开始时，不允许调用右键菜单
     m_backButton->setVisible(false);                // 隐藏返回按钮
     m_installButton->setVisible(false);             // 隐藏安装按钮
+
+    m_showDependsButton->shrinkContent();
     m_showDependsButton->setVisible(false);
 }
 
@@ -486,10 +488,30 @@ void MultipleInstallPage::slotDependPackages(Pkg::DependsPair dependPackages, bo
 
     // 依赖关系满足或者正在下载wine依赖，则不显示依赖关系
     m_showDependsView->clearText();
-    if (!(dependPackages.second.size() > 0 && !installWineDepends)) {
-        m_showDependsButton->setVisible(false);
+    m_showDependsButton->setVisible(false);
+
+    if (installWineDepends) {
         return;
     }
+    if (dependPackages.second.isEmpty()) {
+        // depends ok or available, show package that will be remove after install
+        QModelIndex index = m_appsListView->currentIndex();
+        const QStringList removePackages = index.data(DebListModel::PackageRemoveDependsRole).toStringList();
+        if (!removePackages.isEmpty()) {
+            QString removeInfo = tr("Install %1 will remove: ").arg(index.data(DebListModel::PackageNameRole).toString());
+            removeInfo.append('\n');
+            removeInfo.append(removePackages.join('\n'));
+            removeInfo.append('\n');
+
+            m_showDependsView->appendText(removeInfo);
+            m_showDependsButton->setVisible(true);
+
+            m_tipsLabel->setText(removeInfo.simplified());
+        }
+
+        return;
+    }
+
     m_showDependsButton->setVisible(true);
     if (dependPackages.first.size() > 0) {
         m_showDependsView->appendText(tr("Dependencies in the repository"));

--- a/src/deb-installer/view/pages/singleinstallpage.h
+++ b/src/deb-installer/view/pages/singleinstallpage.h
@@ -299,7 +299,8 @@ private:
     DCommandLinkButton *m_pLoadingLabel = nullptr;  // 依赖安装提示信息
     int dependAuthStatu = -1;                       // 存储依赖授权状态
 
-    bool resetButtonFocus = true;  // 展示包信息前，复位焦点状态，切换后第一次显示有效
+    bool resetButtonFocus = true;       // 展示包信息前，复位焦点状态，切换后第一次显示有效
+    bool m_showRemovePackages = false;  // current package need show remove packages
 
     // for comaptible mode
     bool m_inCompatibleMode = false;  // current pacakge in comaptbile mode;

--- a/src/deb-installer/view/widgets/infocontrolbutton.cpp
+++ b/src/deb-installer/view/widgets/infocontrolbutton.cpp
@@ -137,6 +137,13 @@ void InfoControlButton::setExpandTips(const QString text)
     m_tipsText->setText(m_expandTips);  // 设置提示语
 }
 
+void InfoControlButton::shrinkContent()
+{
+    if (m_expand) {
+        onMouseRelease();
+    }
+}
+
 void InfoControlButton::setShrinkTips(const QString text)
 {
     m_shrinkTips = text;                // 保存提示语

--- a/src/deb-installer/view/widgets/infocontrolbutton.h
+++ b/src/deb-installer/view/widgets/infocontrolbutton.h
@@ -34,6 +34,8 @@ public:
      */
     void setExpandTips(const QString text);
 
+    void shrinkContent();
+
 public:
     /**
      * @brief linkButton 返回当前使用的CommandLinkButton

--- a/translations/deepin-deb-installer.ts
+++ b/translations/deepin-deb-installer.ts
@@ -4,12 +4,12 @@
 <context>
     <name>AptConfigMessage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="83"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="77"/>
         <source>Enter the number to configure: </source>
         <translation>Enter the number to configure: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="88"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="82"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -54,38 +54,38 @@
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="600"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="701"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="599"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="700"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Installing other packages... Please open it later.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="604"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="603"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Parsing failed: An illegal file structure was found in the manifest file!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="606"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="605"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Parsing failed: An illegal version number was found in the manifest file!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="608"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="607"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>No deb packages found. Please check the folder.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="720"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="719"/>
         <source>The %1 package may be broken</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="728"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="727"/>
         <source>You can only install local %1 packages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="736"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="735"/>
         <source>No permission to access this folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -98,19 +98,19 @@
         <translation type="vanished">You can only install local deb packages</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="752"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="751"/>
         <source>Already Added</source>
         <translation>Already Added</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="761"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="760"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 does not exist, please reselect</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="383"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="903"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="382"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="767"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="908"/>
         <source>Bulk Install</source>
         <translation>Bulk Install</translation>
     </message>
@@ -118,48 +118,63 @@
 <context>
     <name>DebListModel</name>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="89"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="106"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="91"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="108"/>
         <source>Installation failed, please check your network connection</source>
         <translation>Installation failed, please check your network connection</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="92"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="94"/>
         <source>Installation failed, please check for updates in Control Center</source>
         <translation>Installation failed, please check for updates in Control Center</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="94"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="98"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="110"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="96"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="100"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="112"/>
         <source>Installation failed, insufficient disk space</source>
         <translation>Installation failed, insufficient disk space</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="115"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
         <source>No digital signature</source>
         <translation>No digital signature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="119"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="628"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="121"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="717"/>
         <source>Invalid digital signature</source>
         <translation>Invalid digital signature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="125"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="621"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1540"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="707"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1603"/>
         <source>The administrator has set policies to prevent installation of this package</source>
         <translation>The administrator has set policies to prevent installation of this package</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="131"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="133"/>
         <source>Installation Failed</source>
         <translation>Installation Failed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="630"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="695"/>
+        <source>current system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="698"/>
+        <source>%2 has been installed in %1, please uninstall this package before installing it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="704"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="719"/>
         <source>Failed to install %1</source>
         <translation>Failed to install %1</translation>
     </message>
@@ -168,81 +183,81 @@
         <translation type="vanished">Failed to install %1: no valid digital singature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="963"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1070"/>
         <source>Unable to install - no digital signature</source>
         <translation>Unable to install - no digital signature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="964"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1071"/>
         <source>Please go to Control Center to enable developer mode and try again. Proceed?</source>
         <translation>Please go to Control Center to enable developer mode and try again. Proceed?</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="967"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1074"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="968"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1075"/>
         <source>Proceed</source>
         <comment>button</comment>
         <translation>Proceed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="921"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1023"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1542"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1028"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1130"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1605"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="925"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1032"/>
         <source>Failed to install %1: no valid digital signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1061"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1168"/>
         <source>This package does not have a valid digital signature. Continue with the installation?</source>
         <translation>This package does not have a valid digital signature. Continue with the installation?</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1063"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1170"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1064"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1171"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="919"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1020"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1539"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1026"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1602"/>
         <source>Unable to install</source>
         <translation>Unable to install</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1021"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1128"/>
         <source>This package does not have a valid digital signature</source>
         <translation>This package does not have a valid digital signature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="633"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="638"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="722"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="727"/>
         <source>Broken dependencies: %1</source>
         <translation>Broken dependencies: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="123"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="125"/>
         <source>Authentication failed</source>
         <translation>Authentication failed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="619"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="687"/>
         <source>Unmatched package architecture</source>
         <translation>Unmatched package architecture</translation>
     </message>
@@ -292,17 +307,22 @@
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="479"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="499"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="515"/>
         <source>Dependencies in the repository</source>
         <translation>Dependencies in the repository</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="485"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="521"/>
         <source>Missing dependencies</source>
         <translation>Missing dependencies</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="537"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="573"/>
         <source>Installing dependencies: %1</source>
         <translation>Installing dependencies: %1</translation>
     </message>
@@ -394,8 +414,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="48"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="49"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Collapse</translation>
@@ -450,129 +470,165 @@
         <comment>button</comment>
         <translation type="unfinished">Proceed</translation>
     </message>
+    <message>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="264"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="884"/>
         <source>Collapse</source>
         <translation>Collapse</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="347"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="866"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1053"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1232"/>
         <source>Reinstall</source>
         <translation>Reinstall</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="870"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1057"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1055"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1236"/>
         <source>Later version installed: %1</source>
         <translation>Later version installed: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="871"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1058"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1056"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1237"/>
         <source>Downgrade</source>
         <translation>Downgrade</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="875"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1062"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1060"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1241"/>
         <source>Earlier version installed: %1</source>
         <translation>Earlier version installed: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="953"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1137"/>
         <source>Installing dependencies: %1</source>
         <translation>Installing dependencies: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1100"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1284"/>
         <source>Failed to install %1</source>
         <translation>Failed to install %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="186"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="236"/>
         <source>Version: </source>
         <translation>Version: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="339"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="178"/>
+        <source>Select a compatibility mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Install</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="343"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Remove</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="351"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="355"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="359"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="410"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="705"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="643"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="681"/>
+        <source>Trying to install %2 in %1 compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="718"/>
+        <source>Uninstalling %2 from %1 compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="838"/>
+        <source>%2 was successfully installed to %1 compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="842"/>
         <source>Installed successfully</source>
         <translation>Installed successfully</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="711"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="851"/>
+        <source>%2 has been successfully uninstalled from %1 compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="855"/>
         <source>Uninstalled successfully</source>
         <translation>Uninstalled successfully</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="728"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="874"/>
         <source>Uninstall Failed</source>
         <translation>Uninstall Failed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="758"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="913"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="931"/>
         <source>Dependencies in the repository</source>
         <translation>Dependencies in the repository</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="937"/>
         <source>Missing dependencies</source>
         <translation>Missing dependencies</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="876"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1063"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1061"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1242"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Update</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1105"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1289"/>
         <source>Invalid digital signature</source>
         <translation type="unfinished">Invalid digital signature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="174"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="224"/>
         <source>Name: </source>
         <translation>Name: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="865"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1050"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
         <source>Same version installed</source>
         <translation>Same version installed</translation>
     </message>
@@ -580,16 +636,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="540"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="565"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="631"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="668"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="835"/>
         <source>Show details</source>
         <translation>Show details</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="48"/>
         <source>Show dependencies</source>
         <translation>Show dependencies</translation>
     </message>
@@ -597,8 +653,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="590"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="710"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="705"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="848"/>
         <source>Show details</source>
         <translation>Show details</translation>
     </message>
@@ -628,18 +684,24 @@
         <translation>Confirm</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="111"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="129"/>
         <source>Are you sure you want to uninstall %1?
 All dependencies will also be removed</source>
         <translation>Are you sure you want to uninstall %1?
 All dependencies will also be removed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="113"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
         <source>Are you sure you want to uninstall %1?
 The system or other applications may not work properly</source>
         <translation>Are you sure you want to uninstall %1?
 The system or other applications may not work properly</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="169"/>
+        <source>Are you sure you want to uninstall %2 
+from %1 compatibility mode?</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_zh_CN.ts
+++ b/translations/deepin-deb-installer_zh_CN.ts
@@ -2,12 +2,12 @@
 <context>
     <name>AptConfigMessage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="83"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="77"/>
         <source>Enter the number to configure: </source>
         <translation>请输入序号进行配置：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="88"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="82"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
@@ -52,38 +52,38 @@
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="600"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="701"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="599"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="700"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>正在执行安装流程，无法打开</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="604"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="603"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>软件包解析失败，软件包清单包含非法的文件结构！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="606"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="605"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>软件包解析失败，软件包清单包含非法版本号！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="608"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="607"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>未检测到安装包，请检查安装目录！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="720"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="719"/>
         <source>The %1 package may be broken</source>
         <translation>请检查%1包是否损坏</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="728"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="727"/>
         <source>You can only install local %1 packages</source>
         <translation>只能安装本地的%1包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="736"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="735"/>
         <source>No permission to access this folder</source>
         <translation>没有权限访问文件夹</translation>
     </message>
@@ -96,19 +96,19 @@
         <translation type="vanished">只能安装本地的deb包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="752"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="751"/>
         <source>Already Added</source>
         <translation>已添加</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="761"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="760"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1文件不存在，请重新选择文件</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="383"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="903"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="382"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="767"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="908"/>
         <source>Bulk Install</source>
         <translation>批量安装</translation>
     </message>
@@ -116,48 +116,63 @@
 <context>
     <name>DebListModel</name>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="89"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="106"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="91"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="108"/>
         <source>Installation failed, please check your network connection</source>
         <translation>安装失败，请检查您的网络连接</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="92"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="94"/>
         <source>Installation failed, please check for updates in Control Center</source>
         <translation>安装失败，请在控制中心检查更新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="94"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="98"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="110"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="96"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="100"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="112"/>
         <source>Installation failed, insufficient disk space</source>
         <translation>安装失败，磁盘空间不足</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="115"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
         <source>No digital signature</source>
         <translation>无数字签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="119"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="628"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="121"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="717"/>
         <source>Invalid digital signature</source>
         <translation>数字签名无效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="125"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="621"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1540"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="707"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1603"/>
         <source>The administrator has set policies to prevent installation of this package</source>
         <translation>管理员已限制，该软件禁止安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="131"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="133"/>
         <source>Installation Failed</source>
         <translation>安装失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="630"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="695"/>
+        <source>current system</source>
+        <translation>当前系统环境</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="698"/>
+        <source>%2 has been installed in %1, please uninstall this package before installing it</source>
+        <translation>已在%1中安装%2, 请先卸载后再安装此包</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="704"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation>依赖关系不满足,请尝试使用兼容模式安装该应用</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="719"/>
         <source>Failed to install %1</source>
         <translation>%1安装失败</translation>
     </message>
@@ -166,81 +181,81 @@
         <translation type="vanished">无法安装%1，安装包无有效的数字签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="963"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1070"/>
         <source>Unable to install - no digital signature</source>
         <translation>无法安装，安装包无数字签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="964"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1071"/>
         <source>Please go to Control Center to enable developer mode and try again. Proceed?</source>
         <translation>请进入控制中心，开启开发者模式后，再尝试继续安装。是否前往？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="967"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1074"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="968"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1075"/>
         <source>Proceed</source>
         <comment>button</comment>
         <translation>前 往</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="921"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1023"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1542"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1028"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1130"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1605"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="925"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1032"/>
         <source>Failed to install %1: no valid digital signature</source>
         <translation>无法安装%1，安装包无有效的数字签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1061"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1168"/>
         <source>This package does not have a valid digital signature. Continue with the installation?</source>
         <translation>此安装包没有有效的数字签名，是否继续安装？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1063"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1170"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1064"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1171"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>继续</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="919"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1020"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1539"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1026"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1602"/>
         <source>Unable to install</source>
         <translation>无法安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1021"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1128"/>
         <source>This package does not have a valid digital signature</source>
         <translation>此安装包没有有效的数字签名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="633"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="638"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="722"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="727"/>
         <source>Broken dependencies: %1</source>
         <translation>依赖关系不满足：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="123"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="125"/>
         <source>Authentication failed</source>
         <translation>配置授权失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="619"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="687"/>
         <source>Unmatched package architecture</source>
         <translation>软件包架构不匹配</translation>
     </message>
@@ -290,17 +305,22 @@
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="479"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="499"/>
+        <source>Install %1 will remove: </source>
+        <translation>安装%1将会卸载：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="515"/>
         <source>Dependencies in the repository</source>
         <translation>仓库中存在的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="485"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="521"/>
         <source>Missing dependencies</source>
         <translation>仓库中缺失的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="537"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="573"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安装依赖：%1</translation>
     </message>
@@ -392,8 +412,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="48"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="49"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>收 起</translation>
@@ -448,129 +468,165 @@
         <comment>button</comment>
         <translation>前 往</translation>
     </message>
+    <message>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="264"/>
+        <source>Will remove: </source>
+        <translation>将会卸载：</translation>
+    </message>
 </context>
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="884"/>
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="347"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="866"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1053"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1232"/>
         <source>Reinstall</source>
         <translation>重新安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="870"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1057"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1055"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1236"/>
         <source>Later version installed: %1</source>
         <translation>已安装较新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="871"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1058"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1056"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1237"/>
         <source>Downgrade</source>
         <translation>安装旧版本</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="875"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1062"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1060"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1241"/>
         <source>Earlier version installed: %1</source>
         <translation>已安装较早的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="953"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1137"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安装依赖：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1100"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1284"/>
         <source>Failed to install %1</source>
         <translation>%1安装失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="186"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="236"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="339"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="178"/>
+        <source>Select a compatibility mode:</source>
+        <translation>选择兼容模式：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="343"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>卸 载</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="351"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="355"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="359"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="410"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="705"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="643"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="681"/>
+        <source>Trying to install %2 in %1 compatibility mode</source>
+        <translation>正在尝试使用%1兼容模式安装%2</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="718"/>
+        <source>Uninstalling %2 from %1 compatibility mode</source>
+        <translation>正在从%1兼容模式卸载%2</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="838"/>
+        <source>%2 was successfully installed to %1 compatibility mode</source>
+        <translation>%2已成功安装到%1兼容模式</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="842"/>
         <source>Installed successfully</source>
         <translation>安装成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="711"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="851"/>
+        <source>%2 has been successfully uninstalled from %1 compatibility mode</source>
+        <translation>%2已从%1兼容模式成功卸载</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="855"/>
         <source>Uninstalled successfully</source>
         <translation>卸载成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="728"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="874"/>
         <source>Uninstall Failed</source>
         <translation>卸载失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="758"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="913"/>
+        <source>Install %1 will remove: </source>
+        <translation>安装%1将会卸载：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="931"/>
         <source>Dependencies in the repository</source>
         <translation>仓库中存在的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="937"/>
         <source>Missing dependencies</source>
         <translation>仓库中缺失的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="876"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1063"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1061"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1242"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1105"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1289"/>
         <source>Invalid digital signature</source>
         <translation>数字签名无效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="174"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="224"/>
         <source>Name: </source>
         <translation>名称：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="865"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1050"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
         <source>Same version installed</source>
         <translation>已安装相同版本</translation>
     </message>
@@ -578,16 +634,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="540"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="565"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="631"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="668"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="835"/>
         <source>Show details</source>
         <translation>显示详细信息</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="48"/>
         <source>Show dependencies</source>
         <translation>显示依赖包关系</translation>
     </message>
@@ -595,8 +651,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="590"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="710"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="705"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="848"/>
         <source>Show details</source>
         <translation>显示卸载进程</translation>
     </message>
@@ -626,18 +682,25 @@
         <translation>确定卸载</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="111"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="129"/>
         <source>Are you sure you want to uninstall %1?
 All dependencies will also be removed</source>
         <translation>您确定要卸载%1 吗？
 所有依赖也会被一起移除</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="113"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
         <source>Are you sure you want to uninstall %1?
 The system or other applications may not work properly</source>
         <translation>您确定要卸载%1吗？
 卸载此软件可能会导致系统或其他软件无法正常使用</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="169"/>
+        <source>Are you sure you want to uninstall %2 
+from %1 compatibility mode?</source>
+        <translation>您确定要从%1兼容模式
+卸载%2吗？</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_zh_HK.ts
+++ b/translations/deepin-deb-installer_zh_HK.ts
@@ -2,12 +2,12 @@
 <context>
     <name>AptConfigMessage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="83"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="77"/>
         <source>Enter the number to configure: </source>
         <translation>請輸入序號進行配置：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="88"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="82"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -52,38 +52,38 @@
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="600"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="701"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="599"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="700"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>正在執行安裝流程，無法打開</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="604"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="603"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>軟件包解析失敗，軟件包清單包含非法的文件結構！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="606"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="605"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>軟件包解析失敗，軟件包清單包含非法版本號！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="608"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="607"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>未檢測到安裝包，請檢查安裝目錄！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="720"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="719"/>
         <source>The %1 package may be broken</source>
         <translation>請檢查%1包是否損壞</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="728"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="727"/>
         <source>You can only install local %1 packages</source>
         <translation>只能安裝本地的%1包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="736"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="735"/>
         <source>No permission to access this folder</source>
         <translation>沒有權限訪問文件夾</translation>
     </message>
@@ -96,19 +96,19 @@
         <translation type="vanished">只能安裝本地的deb包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="752"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="751"/>
         <source>Already Added</source>
         <translation>已添加</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="761"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="760"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1文件不存在，請重新選擇文件</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="383"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="903"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="382"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="767"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="908"/>
         <source>Bulk Install</source>
         <translation>批量安裝</translation>
     </message>
@@ -116,48 +116,63 @@
 <context>
     <name>DebListModel</name>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="89"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="106"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="91"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="108"/>
         <source>Installation failed, please check your network connection</source>
         <translation>安裝失敗，請檢查您的網絡連接</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="92"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="94"/>
         <source>Installation failed, please check for updates in Control Center</source>
         <translation>安裝失敗，請在控制中心檢查更新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="94"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="98"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="110"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="96"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="100"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="112"/>
         <source>Installation failed, insufficient disk space</source>
         <translation>安裝失敗，磁盤空間不足</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="115"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
         <source>No digital signature</source>
         <translation>無數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="119"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="628"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="121"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="717"/>
         <source>Invalid digital signature</source>
         <translation>數字簽名無效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="125"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="621"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1540"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="707"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1603"/>
         <source>The administrator has set policies to prevent installation of this package</source>
         <translation>管理員已限制，該軟件禁止安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="131"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="133"/>
         <source>Installation Failed</source>
         <translation>安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="630"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="695"/>
+        <source>current system</source>
+        <translation>當前系統環境</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="698"/>
+        <source>%2 has been installed in %1, please uninstall this package before installing it</source>
+        <translation>已在%1中安裝%2，請先卸載後再安裝此包</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="704"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation>依賴關係不滿足，請嘗試使用兼容模式安裝該應用</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="719"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
@@ -166,81 +181,81 @@
         <translation type="vanished">無法安裝%1，安裝包無有效的數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="963"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1070"/>
         <source>Unable to install - no digital signature</source>
         <translation>無法安裝，安裝包無數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="964"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1071"/>
         <source>Please go to Control Center to enable developer mode and try again. Proceed?</source>
         <translation>請進入控制中心，開啟開發者模式後，再嘗試繼續安裝。是否前往？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="967"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1074"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="968"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1075"/>
         <source>Proceed</source>
         <comment>button</comment>
         <translation>前 往</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="921"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1023"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1542"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1028"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1130"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1605"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="925"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1032"/>
         <source>Failed to install %1: no valid digital signature</source>
         <translation>無法安裝%1，安裝包無有效的數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1061"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1168"/>
         <source>This package does not have a valid digital signature. Continue with the installation?</source>
         <translation>此安裝包沒有有效的數字簽名，是否繼續安裝？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1063"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1170"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1064"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1171"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>繼續</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="919"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1020"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1539"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1026"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1602"/>
         <source>Unable to install</source>
         <translation>無法安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1021"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1128"/>
         <source>This package does not have a valid digital signature</source>
         <translation>此安裝包沒有有效的數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="633"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="638"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="722"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="727"/>
         <source>Broken dependencies: %1</source>
         <translation>依賴關係不滿足：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="123"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="125"/>
         <source>Authentication failed</source>
         <translation>配置授權失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="619"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="687"/>
         <source>Unmatched package architecture</source>
         <translation>軟件包架構不匹配</translation>
     </message>
@@ -290,17 +305,22 @@
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="479"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="499"/>
+        <source>Install %1 will remove: </source>
+        <translation>安裝%1將會卸載：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="515"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="485"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="521"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="537"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="573"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
@@ -392,8 +412,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="48"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="49"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>收 起</translation>
@@ -448,129 +468,165 @@
         <comment>button</comment>
         <translation>前 往</translation>
     </message>
+    <message>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="264"/>
+        <source>Will remove: </source>
+        <translation>將會卸載：</translation>
+    </message>
 </context>
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="884"/>
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="347"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="866"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1053"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1232"/>
         <source>Reinstall</source>
         <translation>重新安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="870"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1057"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1055"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1236"/>
         <source>Later version installed: %1</source>
         <translation>已安裝較新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="871"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1058"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1056"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1237"/>
         <source>Downgrade</source>
         <translation>安裝舊版本</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="875"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1062"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1060"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1241"/>
         <source>Earlier version installed: %1</source>
         <translation>已安裝較早的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="953"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1137"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1100"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1284"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="186"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="236"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="339"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="178"/>
+        <source>Select a compatibility mode:</source>
+        <translation>選擇兼容模式：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="343"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>卸 載</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="351"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="355"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="359"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="410"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="705"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="643"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="681"/>
+        <source>Trying to install %2 in %1 compatibility mode</source>
+        <translation>正在嘗試使用%1兼容模式安裝%2</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="718"/>
+        <source>Uninstalling %2 from %1 compatibility mode</source>
+        <translation>正在從%1兼容模式卸載%2</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="838"/>
+        <source>%2 was successfully installed to %1 compatibility mode</source>
+        <translation>%2已成功安裝到%1兼容模式</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="842"/>
         <source>Installed successfully</source>
         <translation>安裝成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="711"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="851"/>
+        <source>%2 has been successfully uninstalled from %1 compatibility mode</source>
+        <translation>%2已從%1兼容模式成功卸載</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="855"/>
         <source>Uninstalled successfully</source>
         <translation>卸載成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="728"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="874"/>
         <source>Uninstall Failed</source>
         <translation>卸載失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="758"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="913"/>
+        <source>Install %1 will remove: </source>
+        <translation>安裝%1將會卸載：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="931"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="937"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="876"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1063"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1061"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1242"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1105"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1289"/>
         <source>Invalid digital signature</source>
         <translation>數字簽名無效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="174"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="224"/>
         <source>Name: </source>
         <translation>名稱：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="865"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1050"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
         <source>Same version installed</source>
         <translation>已安裝相同版本</translation>
     </message>
@@ -578,16 +634,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="540"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="565"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="631"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="668"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="835"/>
         <source>Show details</source>
         <translation>顯示詳細訊息</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="48"/>
         <source>Show dependencies</source>
         <translation>顯示依賴包關係</translation>
     </message>
@@ -595,8 +651,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="590"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="710"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="705"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="848"/>
         <source>Show details</source>
         <translation>顯示卸載進程</translation>
     </message>
@@ -626,18 +682,25 @@
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="111"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="129"/>
         <source>Are you sure you want to uninstall %1?
 All dependencies will also be removed</source>
         <translation>您確定要卸載%1 嗎？
 所有依賴也會被一起移除</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="113"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
         <source>Are you sure you want to uninstall %1?
 The system or other applications may not work properly</source>
         <translation>您確定要卸載%1嗎？
 卸載此軟件可能會導致系統或其他軟件無法正常使用</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="169"/>
+        <source>Are you sure you want to uninstall %2 
+from %1 compatibility mode?</source>
+        <translation>您確定要從%1兼容模式
+卸載%2嗎？</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_zh_TW.ts
+++ b/translations/deepin-deb-installer_zh_TW.ts
@@ -2,12 +2,12 @@
 <context>
     <name>AptConfigMessage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="83"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="77"/>
         <source>Enter the number to configure: </source>
         <translation>請輸入序號進行配置：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="88"/>
+        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="82"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -52,38 +52,38 @@
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="600"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="701"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="599"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="700"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>正在執行安裝流程，無法打開</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="604"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="603"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>套裝軟體解析失敗，套裝軟體清單包含非法的文件結構！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="606"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="605"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>套裝軟體解析失敗，套裝軟體清單包含非法版本號！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="608"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="607"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>未檢測到安裝包，請檢查安裝目錄！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="720"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="719"/>
         <source>The %1 package may be broken</source>
         <translation>請檢查%1包是否損壞</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="728"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="727"/>
         <source>You can only install local %1 packages</source>
         <translation>只能安裝本機的%1包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="736"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="735"/>
         <source>No permission to access this folder</source>
         <translation>沒有權限訪問資料夾</translation>
     </message>
@@ -96,19 +96,19 @@
         <translation type="vanished">只能安裝本機的deb包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="752"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="751"/>
         <source>Already Added</source>
         <translation>已添加</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="761"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="760"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1文件不存在，請重新選擇文件</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="383"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="903"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="382"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="767"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="908"/>
         <source>Bulk Install</source>
         <translation>批次安裝</translation>
     </message>
@@ -116,48 +116,63 @@
 <context>
     <name>DebListModel</name>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="89"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="106"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="91"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="108"/>
         <source>Installation failed, please check your network connection</source>
         <translation>安裝失敗，請檢查網路連線</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="92"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="94"/>
         <source>Installation failed, please check for updates in Control Center</source>
         <translation>安裝失敗，請於控制中心檢查更新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="94"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="98"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="110"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="96"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="100"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="112"/>
         <source>Installation failed, insufficient disk space</source>
         <translation>安裝失敗，磁碟機空間不足</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="115"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
         <source>No digital signature</source>
         <translation>無數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="119"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="628"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="121"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="717"/>
         <source>Invalid digital signature</source>
         <translation>數位簽章無效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="125"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="621"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1540"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="707"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1603"/>
         <source>The administrator has set policies to prevent installation of this package</source>
         <translation>管理員已限制，該軟體禁止安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="131"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="133"/>
         <source>Installation Failed</source>
         <translation>安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="630"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="695"/>
+        <source>current system</source>
+        <translation>當前系統環境</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="698"/>
+        <source>%2 has been installed in %1, please uninstall this package before installing it</source>
+        <translation>已在%1中安裝%2，請先卸載後再安裝此包</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="704"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation>依賴關係不滿足，請嘗試使用相容模式安裝該應用</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="719"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
@@ -166,81 +181,81 @@
         <translation type="vanished">無法安裝%1，安裝包無有效的數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="963"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1070"/>
         <source>Unable to install - no digital signature</source>
         <translation>無法安裝，安裝包無數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="964"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1071"/>
         <source>Please go to Control Center to enable developer mode and try again. Proceed?</source>
         <translation>請進入控制中心，開啟開發者模式後，再嘗試繼續安裝。是否前往？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="967"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1074"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="968"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1075"/>
         <source>Proceed</source>
         <comment>button</comment>
         <translation>前 往</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="921"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1023"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1542"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1028"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1130"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1605"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="925"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1032"/>
         <source>Failed to install %1: no valid digital signature</source>
         <translation>無法安裝%1，安裝包無有效的數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1061"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1168"/>
         <source>This package does not have a valid digital signature. Continue with the installation?</source>
         <translation>此安裝包沒有有效的數位簽章，是否繼續安裝？</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1063"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1170"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1064"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1171"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>繼續</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="919"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1020"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1539"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1026"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1127"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1602"/>
         <source>Unable to install</source>
         <translation>無法安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1021"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1128"/>
         <source>This package does not have a valid digital signature</source>
         <translation>此安裝包沒有有效的數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="633"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="638"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="722"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="727"/>
         <source>Broken dependencies: %1</source>
         <translation>缺少依賴軟體：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="123"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="125"/>
         <source>Authentication failed</source>
         <translation>配置授權失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="619"/>
+        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="687"/>
         <source>Unmatched package architecture</source>
         <translation>軟體套件結構不符合規範</translation>
     </message>
@@ -290,17 +305,22 @@
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="479"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="499"/>
+        <source>Install %1 will remove: </source>
+        <translation>安裝%1將會卸載：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="515"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="485"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="521"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="537"/>
+        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="573"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
@@ -392,8 +412,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="48"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="49"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>隱 藏</translation>
@@ -448,129 +468,165 @@
         <comment>button</comment>
         <translation>前 往</translation>
     </message>
+    <message>
+        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="264"/>
+        <source>Will remove: </source>
+        <translation>將會卸載：</translation>
+    </message>
 </context>
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="884"/>
         <source>Collapse</source>
         <translation>隱藏</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="347"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="866"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1053"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1232"/>
         <source>Reinstall</source>
         <translation>重 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="870"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1057"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1055"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1236"/>
         <source>Later version installed: %1</source>
         <translation>已安裝較新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="871"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1058"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1056"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1237"/>
         <source>Downgrade</source>
         <translation>安裝舊版本</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="875"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1062"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1060"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1241"/>
         <source>Earlier version installed: %1</source>
         <translation>已安裝舊版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="953"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1137"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1100"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1284"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="186"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="236"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="339"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="178"/>
+        <source>Select a compatibility mode:</source>
+        <translation>選擇相容模式：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="343"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>移 除</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="351"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="355"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="359"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="410"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="705"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="643"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="681"/>
+        <source>Trying to install %2 in %1 compatibility mode</source>
+        <translation>正在嘗試使用%1相容模式安裝%2</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="718"/>
+        <source>Uninstalling %2 from %1 compatibility mode</source>
+        <translation>正在從%1相容模式卸載%2</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="838"/>
+        <source>%2 was successfully installed to %1 compatibility mode</source>
+        <translation>%2已成功安裝到%1相容模式</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="842"/>
         <source>Installed successfully</source>
         <translation>安裝成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="711"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="851"/>
+        <source>%2 has been successfully uninstalled from %1 compatibility mode</source>
+        <translation>%2已從%1相容模式成功卸載</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="855"/>
         <source>Uninstalled successfully</source>
         <translation>解除安裝成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="728"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="874"/>
         <source>Uninstall Failed</source>
         <translation>解除安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="758"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="913"/>
+        <source>Install %1 will remove: </source>
+        <translation>安裝%1將會卸載：</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="931"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="937"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="876"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1063"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1061"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1242"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1105"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1289"/>
         <source>Invalid digital signature</source>
         <translation>數位簽章無效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="174"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="224"/>
         <source>Name: </source>
         <translation>名稱：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="865"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1050"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
         <source>Same version installed</source>
         <translation>已安裝相同版本</translation>
     </message>
@@ -578,16 +634,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="46"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="540"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="565"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="631"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="668"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="835"/>
         <source>Show details</source>
         <translation>顯示詳細訊息</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="31"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="47"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="48"/>
         <source>Show dependencies</source>
         <translation>顯示依賴包關係</translation>
     </message>
@@ -595,8 +651,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="590"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="710"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="705"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="848"/>
         <source>Show details</source>
         <translation>顯示卸載進程</translation>
     </message>
@@ -626,18 +682,25 @@
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="111"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="129"/>
         <source>Are you sure you want to uninstall %1?
 All dependencies will also be removed</source>
         <translation>確定解除安裝 %1？
 也會移除所有依賴</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="113"/>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
         <source>Are you sure you want to uninstall %1?
 The system or other applications may not work properly</source>
         <translation>您確定要移除%1嗎？
 移除此軟體可能會導致系統或其他軟體無法正常使用</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="169"/>
+        <source>Are you sure you want to uninstall %2 
+from %1 compatibility mode?</source>
+        <translation>您確定要從%1相容模式
+卸載%2嗎？</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
[fix: add display of packages to be removed](https://github.com/linuxdeepin/deepin-deb-installer/commit/f5810c80f461b85fdda47f649608a44ecc33a92f) 

1. Backend package removal management:
   - Add interfaces and storage for package removal
   - Update removal info during dependency check
2. Frontend removal package display:
   - Add new data role for removal packages
   - Show removal package hints in install UI

Log: Display warning when installing packages
     would remove existing packages.
Bug: https://pms.uniontech.com/bug-view-275401.html

[chore: update translation](https://github.com/linuxdeepin/deepin-deb-installer/commit/9e797aae328bcb7a17643c281ff72650bbf00401) 

Update recently changes translation,
include compatibility mode and display of uninstalld packages.

Log: Update translation.
Influence: translation