### PR TITLE
feat: temporarily disable compatibility mode

### DIFF
--- a/src/deb-installer/compatible/compatible_backend.cpp
+++ b/src/deb-installer/compatible/compatible_backend.cpp
@@ -36,6 +36,7 @@ CompatibleBackend *CompatibleBackend::instance()
     return &ins;
 }
 
+#ifndef DISABLE_COMPATIBLE
 bool CompatibleBackend::compatibleValid() const
 {
     return m_init && !m_rootfsList.isEmpty();
@@ -54,6 +55,7 @@ bool CompatibleBackend::recheckCompatibleExists()
 
     return m_compatibleExists;
 }
+#endif
 
 QList<RootfsInfo::Ptr> CompatibleBackend::rootfsList() const
 {
@@ -164,6 +166,10 @@ QHash<QString, CompPkgInfo::Ptr> CompatibleBackend::parseAppListFromRawOutput(co
 
 void CompatibleBackend::initBackend(bool async)
 {
+    if (!compatibleExists()) {
+        return;
+    }
+
     static std::once_flag kCompInitFlag;
     std::call_once(kCompInitFlag, [this, async]() {
         if (async) {

--- a/src/deb-installer/compatible/compatible_backend.h
+++ b/src/deb-installer/compatible/compatible_backend.h
@@ -13,8 +13,19 @@ class QProcess;
 
 namespace Compatible {
 
+/*
+    Warning: Compatibility mode is temporary deprecated, this class is invalid forever. see macro DISABLE_COMPATIBLE.
+             However, there is still a high probability that this module will be enabled later, so the code is retained.
+             To restore it, remove the DISABLE_COMPATIBLE macro.
+ */
+#define DISABLE_COMPATIBLE
+
 // Backend for comaptible mode package manage.
+#ifdef DISABLE_COMPATIBLE
+class QT_DEPRECATED_X("Temporary disable compatibility mode!") CompatibleBackend : public QObject
+#else
 class CompatibleBackend : public QObject
+#endif
 {
     Q_OBJECT
 
@@ -22,11 +33,17 @@ public:
     static CompatibleBackend *instance();
 
     void initBackend(bool async = true);
-    [[nodiscard]] bool compatibleValid() const;
     Q_SIGNAL void compatibleInitFinished();
 
+#ifdef DISABLE_COMPATIBLE
+    [[nodiscard]] bool compatibleValid() const { return false; }
+    [[nodiscard]] bool compatibleExists() const { return false; }
+    bool recheckCompatibleExists() { return false; }
+#else
+    [[nodiscard]] bool compatibleValid() const;
     [[nodiscard]] bool compatibleExists() const;
     bool recheckCompatibleExists();
+#endif
 
     [[nodiscard]] QList<RootfsInfo::Ptr> rootfsList() const;
     [[nodiscard]] QString osName(const QString &rootfsName) const;


### PR DESCRIPTION
- Add DISABLE_COMPATIBLE macro to disable compatibility mode features
- Mark CompatibleBackend class with deprecation warning
- Simplify compatibility check functions to return false when disabled
- Retain original code for potential future re-enablement

Note: Changes are temporary, module may be re-enabled in future releases.

Log: Temporarily disable compatibility mode.