### PR TITLE
fix: enable keep auth / add install check

### DIFF
--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -927,7 +927,7 @@ void DebListModel::installDebs()
     }
 
     // for immutable system, if immutable is enabled, the normal installation process will not be entered
-    if (ImmBackend::instance()->immutableEnabled()) {
+    if (dependsStat.canInstall() && ImmBackend::instance()->immutableEnabled()) {
         if (installImmutablePackage()) {
             refreshOperatingPackageStatus(Pkg::Operating);
         } else {
@@ -1731,7 +1731,10 @@ void DebListModel::ensureCompatibleProcessor()
         connect(
             m_compProcessor.data(), &Compatible::CompatibleProcessController::processOutput, this, [this](const QString &output) {
                 Q_EMIT signalAppendOutputInfo(output);
-                if (m_compProcessor->needTemplates()) {
+
+                if (configWindow->isVisible()) {
+                    configWindow->appendTextEdit(output);
+                } else if (m_compProcessor->needTemplates()) {
                     configWindow->appendTextEdit(output);
                     configWindow->show();
                 }
@@ -1806,7 +1809,10 @@ void DebListModel::ensureImmutableProcessor()
         connect(
             m_immProcessor.data(), &Immutable::ImmutableProcessController::processOutput, this, [this](const QString &output) {
                 Q_EMIT signalAppendOutputInfo(output);
-                if (m_immProcessor->needTemplates()) {
+
+                if (configWindow->isVisible()) {
+                    configWindow->appendTextEdit(output);
+                } else if (m_immProcessor->needTemplates()) {
                     configWindow->appendTextEdit(output);
                     configWindow->show();
                 }

--- a/translations/policy/com.deepin.pkexec.aptInstallDepend.policy
+++ b/translations/policy/com.deepin.pkexec.aptInstallDepend.policy
@@ -14,7 +14,7 @@
     <defaults>
       <allow_any>no</allow_any>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
     <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/deepin-deb-installer-dependsInstall</annotate>
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>


### PR DESCRIPTION
Keep auth when multi-packages installation;
Enhance installation check, if packge not support to install, deepin-immutable-ctl is not called.

Log: Enable keep auth and enhance installation check.
Influence: immutable