### PR TITLE
fix: uab use absolute path

### DIFF
--- a/src/deb-installer/uab/uab_backend.cpp
+++ b/src/deb-installer/uab/uab_backend.cpp
@@ -79,7 +79,7 @@ UabPkgInfo::Ptr UabBackend::packageFromMetaData(const QString &uabPath, QString 
 
     auto uabPtr = UabBackend::packageFromMetaJson(output);
     if (uabPtr) {
-        uabPtr->filePath = uabPath;
+        uabPtr->filePath = info.absoluteFilePath();
     }
     return uabPtr;
 }


### PR DESCRIPTION
Use absolute path instead of relative path
when install/uninstall UAB package.

Log: UAB use absolute path
Influence: uab-pacakge