### PR TITLE
fix: no install log output

### DIFF
--- a/src/deb-installer/process/Pty.cpp
+++ b/src/deb-installer/process/Pty.cpp
@@ -593,8 +593,15 @@ void Pty::setSessionId(int sessionId)
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 void Pty::setupChildProcess()
+#else
+void Pty::setupChildProcessImpl()
 {
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     KPtyProcess::setupChildProcess();
+#else
+    KPtyProcess::setupChildProcessImpl();
+#endif
 
     // reset all signal handlers
     // this ensures that terminal applications respond to

--- a/src/deb-installer/process/Pty.h
+++ b/src/deb-installer/process/Pty.h
@@ -196,9 +196,11 @@ Q_OBJECT
     /******** Modify by nt001000 renfeixiang 2020-05-14:修改 增加参数区别remove和purge卸载命令 End***************/
 
   protected:
-  #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
       void setupChildProcess() override;
-  #endif
+#else
+      void setupChildProcessImpl() override;
+#endif
 
   private slots:
     // called when data is received from the terminal process

--- a/src/deb-installer/process/kptyprocess.cpp
+++ b/src/deb-installer/process/kptyprocess.cpp
@@ -46,6 +46,11 @@ KPtyProcess::KPtyProcess(QObject *parent) :
     d->pty->open();
     connect(this, SIGNAL(stateChanged(QProcess::ProcessState)),
             SLOT(_k_onStateChanged(QProcess::ProcessState)));
+
+    // use setChildProcessModifier() replace setupChildProcess()
+    setChildProcessModifier([this](){
+        setupChildProcessImpl();
+    });
 }
 
 KPtyProcess::KPtyProcess(int ptyMasterFd, QObject *parent) :
@@ -57,6 +62,11 @@ KPtyProcess::KPtyProcess(int ptyMasterFd, QObject *parent) :
     d->pty->open(ptyMasterFd);
     connect(this, SIGNAL(stateChanged(QProcess::ProcessState)),
             SLOT(_k_onStateChanged(QProcess::ProcessState)));
+
+    // use setChildProcessModifier() replace setupChildProcess()
+    setChildProcessModifier([this](){
+        setupChildProcessImpl();
+    });
 }
 
 KPtyProcess::~KPtyProcess()
@@ -121,6 +131,8 @@ KPtyDevice *KPtyProcess::pty() const
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 void KPtyProcess::setupChildProcess()
+#else
+void KPtyProcess::setupChildProcessImpl()
 {
     Q_D(KPtyProcess);
 
@@ -139,7 +151,9 @@ void KPtyProcess::setupChildProcess()
     if (d->ptyChannels & StderrChannel)
         dup2(d->pty->slaveFd(), 2);
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     KProcess::setupChildProcess();
+#endif
 }
 #endif
 

--- a/src/deb-installer/process/kptyprocess.h
+++ b/src/deb-installer/process/kptyprocess.h
@@ -146,6 +146,9 @@ protected:
      */
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     void setupChildProcess() override;
+#else
+    // use setChildProcessModifier() set setupChildProcessImpl()
+    virtual void setupChildProcessImpl();
 #endif
 
 private:


### PR DESCRIPTION
channel setting function is blocked after Qt6 adaptation, use setChildProcessModifier() replace setupChildProcess().

Log: Fix no install log output.
Bug: https://pms.uniontech.com/bug-view-303125.html