### PR TITLE
fix: init rootfs first and bump version to 6.5.7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deb-installer (6.5.7) unstable; urgency=medium
+
+  * fix: init rootfs first
+
+ -- renbin <renbin@uniontech.com>  Thu, 20 Feb 2025 20:50:21 +0800
+
 deepin-deb-installer (6.5.6) unstable; urgency=medium
 
   * fix: no install log output(Bug: 303125)

--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -330,7 +330,6 @@ void SingleInstallPage::initCompatibleRootfs()
         return;
     }
 
-    // TODO: not support app check now!
     if (!CompBackend::instance()->supportAppCheck()) {
         auto rootfsList = CompBackend::instance()->rootfsList();
         for (const auto &rootfs : rootfsList) {
@@ -367,7 +366,9 @@ void SingleInstallPage::initCompatibleRootfs()
 
                         m_compatibleLabel->setVisible(true);
                         m_compatibleBox->setVisible(true);
+                        m_backButton->setVisible(true);
 
+                        showPackageInfo();
                     } else {
                         // Quit compatible mode if no support rootfs
                         m_inCompatibleMode = false;


### PR DESCRIPTION
[fix: init rootfs first](https://github.com/linuxdeepin/deepin-deb-installer/commit/9674805f560924ff9dc509c2a90ca72c76c5784d) 

Compatible app check is not ready,
but we need a way to init rootfs.
This is a temporay changes.

Log: adapt compatible mode.

[chore: bump version to 6.5.7](https://github.com/linuxdeepin/deepin-deb-installer/commit/e2d6b6319cd70d1bb26dffffd4d84048d1cdd537) 

Bump version to 6.5.7

Log: bump version to 6.5.7