### PR TITLE
fix: wrong linked package name

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -1651,7 +1651,7 @@ QString PackagesManager::dealPackagePath(const QString &packagePath)
     if (tempPath.contains(" ")) {
         QApt::DebFile p(tempPath);
         if (p.isValid()) {
-            tempPath = SymbolicLink(tempPath, p.packageName());
+            tempPath = SymbolicLink(tempPath, p.packageName() + ".deb");
             qWarning() << "PackagesManager:"
                        << "There are spaces in the path, add a soft link" << tempPath;
         }


### PR DESCRIPTION
The old commit create soft-link to package if
the path contains space.
But not set the suffix `.deb`, cause the latest
APT can not recognize the package.

Log: fix a package path error.
Bug: https://pms.uniontech.com/bug-view-309051.html