### PR TITLE
feat: adapt new black list config file path

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -2331,17 +2331,7 @@ QString PackagesManager::package(const int index) const
 
 void PackagesManager::getBlackApplications()
 {
-    QFile blackListFile(BLACKFILE);
-    if (blackListFile.exists()) {
-        blackListFile.open(QFile::ReadOnly);
-        QString blackApplications = blackListFile.readAll();
-        blackApplications.replace(" ", "");
-        blackApplications = blackApplications.replace("\n", "");
-        m_blackApplicationList = blackApplications.split(",");
-        blackListFile.close();
-        return;
-    }
-    qWarning() << "Black File not Found";
+    m_blackApplicationList = Utils::parseBlackList();
 }
 
 /**

--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -19,8 +19,6 @@
 
 using namespace QApt;
 
-#define BLACKFILE "/usr/share/udcp/appblacklist.txt"
-
 typedef Result<QString> ConflictResult;
 
 class PackageDependsStatus;

--- a/src/deb-installer/utils/utils.cpp
+++ b/src/deb-installer/utils/utils.cpp
@@ -519,6 +519,32 @@ QString Utils::formatWrapText(const QString &text, int textWidth)
 }
 
 /**
+ * @return parse app black list from config file.
+ */
+QStringList Utils::parseBlackList()
+{
+    static const QString kBlackFileV20 {"/usr/share/udcp/appblacklist.txt"};
+    static const QString kBlackFileV25 {"/var/lib/udcp/appblacklist.txt"};
+    static const int kV25Version = 25;
+
+    const int sysVersion = Dtk::Core::DSysInfo::majorVersion().toInt();
+    QString blackFile = (sysVersion >= kV25Version) ? kBlackFileV25 : kBlackFileV20;
+    QFile blackListFile(blackFile);
+
+    if (blackListFile.exists()) {
+        blackListFile.open(QFile::ReadOnly);
+        QString blackApplications = blackListFile.readAll();
+        blackApplications.replace(" ", "");
+        blackApplications = blackApplications.replace("\n", "");
+        blackListFile.close();
+        return blackApplications.split(",");
+    }
+
+    qInfo() << "Black File not Found, " << blackFile;
+    return {};
+}
+
+/**
  * @brief Mark whether the wine pre-dependency is being installed.
  *        Not thread-safe.
  */

--- a/src/deb-installer/utils/utils.h
+++ b/src/deb-installer/utils/utils.h
@@ -81,6 +81,9 @@ public:
     static bool isDevelopMode();  // Check if develop mode (root)
 
     static QString formatWrapText(const QString &text, int textWidth);
+
+    // get current package black list
+    static QStringList parseBlackList();
 };
 
 class GlobalStatus


### PR DESCRIPTION
As title.
Move parseBlackList() to Utils.

Log: Adapt black list.
Task: https://pms.uniontech.com/task-view-374685.html

## Summary by Sourcery

Refactor the black list configuration file parsing logic to support multiple system versions and centralize the implementation in the Utils class

New Features:
- Add support for different black list configuration file paths based on system version

Enhancements:
- Move black list parsing logic from PackagesManager to Utils class to improve code organization and reusability

Chores:
- Remove hardcoded black list file path definition from PackagesManager