### PR TITLE
chore: Bump version to 6.5.13

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-deb-installer (6.5.13) unstable; urgency=medium
+
+  * chore: update desktop file
+  * feat: adapt new black list config file path(Task: 374685)
+
+ -- renbin <renbin@uniontech.com>  Wed, 02 Apr 2025 15:44:58 +0800
+
 deepin-deb-installer (6.5.12) unstable; urgency=medium
 
   * fix: wrong linked package name(Bug: 309051)


### PR DESCRIPTION
Bump version to 6.5.13

Log: Bump version to 6.5.13

## Summary by Sourcery

Chores:
- Bump the project version number in the Debian changelog