### PR TITLE
fix: correct package removal logic for Breaks/Conflicts dependencies

### DIFF
--- a/src/deb-installer/utils/deb_package.cpp
+++ b/src/deb-installer/utils/deb_package.cpp
@@ -11,6 +11,35 @@
 
 namespace Deb {
 
+bool needRemoveByVersion(const QString &installed_version, const QString &conflict_version, QApt::RelationType type)
+{
+    // 如果版本条件为空，则需要移除
+    if (conflict_version.isEmpty()) {
+        return true;
+    }
+
+    // 比较版本号
+    const int result = QApt::Package::compareVersion(installed_version, conflict_version);
+
+    // 根据关系类型判断是否需要移除
+    switch (type) {
+    case QApt::LessOrEqual:
+        return result <= 0;
+    case QApt::GreaterOrEqual:
+        return result >= 0;
+    case QApt::LessThan:
+        return result < 0;
+    case QApt::GreaterThan:
+        return result > 0;
+    case QApt::Equals:
+        return result == 0;
+    case QApt::NotEqual:
+        return result != 0;
+    default:
+        return true;
+    }
+}
+
 DebPackage::DebPackage(const QString &debFilePath)
     : m_debFilePtr(QSharedPointer<QApt::DebFile>::create(debFilePath))
 {
@@ -103,7 +132,7 @@ void DebPackage::setMarkedPackages(const QStringList &installDepends)
     for (const QApt::DependencyItem &item : selfRemovePackages) {
         for (const QApt::DependencyInfo &info : item) {
             QApt::Package *package = backend->package(info.packageName());
-            if (package && package->isInstalled()) {
+            if (package && package->isInstalled() && needRemoveByVersion(package->installedVersion(), info.packageVersion(), info.relationType())) {
                 m_removePackages << package->name();
             }
         }


### PR DESCRIPTION
1. Version check for package removal:
   - Add version comparison logic in setMarkedPackages method
   - Only add packages to removal list when version conditions are met
2. Improve dependency handling:
   - Fix incorrect handling of Breaks/Conflicts relationships
   - Ensure proper version comparison for all relation types

Log: Fix incorrect "Will remove" warning when installing packages
     with Breaks/Conflicts dependencies where installed version
     is higher than specified version.

Bug: https://pms.uniontech.com/bug-view-311145.html

## Summary by Sourcery

Improve package removal logic for Breaks/Conflicts dependencies by adding comprehensive version comparison checks

Bug Fixes:
- Fix incorrect package removal handling for Breaks/Conflicts dependencies by implementing detailed version comparison logic

Enhancements:
- Enhance dependency version checking to support multiple comparison operators (less than, greater than, equal, etc.)
- Implement more granular version comparison for package removal decisions