### PR TITLE
chore: Bump version to 6.5.15

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deb-installer (6.5.15) unstable; urgency=medium
+
+  * chore: update translations.
+
+ -- renbin <renbin@uniontech.com>  Thu, 17 Apr 2025 09:39:21 +0800
+
 deepin-deb-installer (6.5.14) unstable; urgency=medium
 
   * chore: update translations


### PR DESCRIPTION
Bump version to 6.5.15

Log: Bump version to 6.5.15

## Summary by Sourcery

Chores:
- Bump the project version number in the Debian changelog