### PR TITLE
fix: support url

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -1525,7 +1525,17 @@ void PackagesManager::appendPackage(QStringList packages)
 {
     if (packages.isEmpty())  // 当前放进来的包列表为空（可能拖入的是文件夹）
         return;
+
+    // convert url path (if valid) to local path.
+    for (auto &package : packages) {
+        QUrl url(package);
+        if (url.isLocalFile()) {
+            package = url.toLocalFile();
+        }
+    }
+
     checkInvalid(packages);
+
     if (1 == packages.size()) {
         appendNoThread(packages, packages.size());
     } else {
@@ -1568,7 +1578,7 @@ void PackagesManager::checkInvalid(const QStringList &packages)
         }
         pkgSize << size;
     }
-    // m_validPackageCount==1,可能有效包都是重复包，需要最终根据md5值来判定
+
     QSet<QByteArray> pkgMd5;  // 最后通过md5来区分是否是重复包
     if (1 == m_validPackageCount && validCount > 1) {
         for (auto package : packages) {

--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -540,7 +540,13 @@ void DebInstaller::slotDdimSelected(const QStringList &ddimFiles)
     bool jsonError = false;
     bool versionError = false;
     bool haveDeb = false;
-    for (auto eachFile : ddimFiles) {
+    for (auto item : ddimFiles) {
+        QString eachFile = item;
+        QUrl url(item);
+        if (url.isLocalFile()) {
+            eachFile = url.toLocalFile();
+        }
+        
         // 0.打开文件
         if (eachFile.endsWith(".deb")) {  // 直接排除掉deb包
             haveDeb = true;


### PR DESCRIPTION
Convert url to local path.

Log: support url.
Bug: https://pms.uniontech.com/bug-view-312003.html

## Summary by Sourcery

Add support for converting URL paths to local file paths when installing packages

Bug Fixes:
- Fix handling of URL-based file paths by converting them to local file paths before package installation

Enhancements:
- Improve file path handling to support URLs in package installation process