### PR TITLE
fix: memory leak

### DIFF
--- a/src/deb-installer/model/packageanalyzer.cpp
+++ b/src/deb-installer/model/packageanalyzer.cpp
@@ -59,7 +59,7 @@ void PackageAnalyzer::initBackend()
         CompBackend::instance()->initBackend();
     }
 
-    backend = new QApt::Backend;
+    backend.reset(new QApt::Backend);
     bool initSuccess = backend->init();
 
     SingleInstallerApplication::BackendIsRunningInit = false;
@@ -84,12 +84,12 @@ void PackageAnalyzer::initBackend()
 
 bool PackageAnalyzer::isBackendReady()
 {
-    return backend != nullptr;
+    return backend.get() != nullptr;
 }
 
 QApt::Backend *PackageAnalyzer::backendPtr()
 {
-    return backend;
+    return backend.get();
 }
 
 QPair<Pkg::PackageInstallStatus, QString> PackageAnalyzer::packageInstallStatus(const DebIr &ir) const

--- a/src/deb-installer/model/packageanalyzer.h
+++ b/src/deb-installer/model/packageanalyzer.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGEANALYZER_H
 #define PACKAGEANALYZER_H
 
+#include <QSharedPointer>
 #include <QObject>
 
 #include <atomic>
@@ -95,7 +96,7 @@ private:
     PackageAnalyzer operator=(const PackageAnalyzer &) = delete;
 
     QStringList archs;
-    QApt::Backend *backend = nullptr;
+    QSharedPointer<QApt::Backend> backend = nullptr;
     std::atomic_bool backendInInit;
     std::atomic_bool inPkgAnalyze;
     int pkgWaitToAnalyzeTotal = -1;

--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -118,6 +118,7 @@ void DebInstaller::initTitleBar()
     DTitlebar *tb = titlebar();
     if (tb != nullptr) {
         tb->setMenu(menu);
+        menu->setParent(tb);
         tb->setIcon(QIcon::fromTheme("deepin-deb-installer"));
         tb->setTitle("");
         tb->setAutoFillBackground(true);


### PR DESCRIPTION
Log: as title

Bug: https://pms.uniontech.com/bug-view-311727.html

## Summary by Sourcery

Fix potential memory leaks in `PackageAnalyzer` and `DebInstaller`.

Bug Fixes:
- Use `QSharedPointer` to manage the lifecycle of the `QApt::Backend` instance in `PackageAnalyzer`.
- Set the `DTitlebar` as the parent of the `QMenu` in `DebInstaller` to ensure proper object cleanup.