### PR TITLE
chore: Bump version to 6.5.17

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deb-installer (6.5.17) unstable; urgency=medium
+
+  * fix: memory leak (#328)(Bug: 311727)
+
+ -- renbin <renbin@uniontech.com>  Tue, 29 Apr 2025 17:48:33 +0800
+
 deepin-deb-installer (6.5.16) unstable; urgency=medium
 
   * fix: Remove outdated mimetype "application-x-uab"


### PR DESCRIPTION
Bump version to 6.5.17

Log: Bump version to 6.5.17

## Summary by Sourcery

Build:
- Update the Debian changelog to reflect the new version.