### PR TITLE
Adding Compiler Flags

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deb-installer (6.5.20) unstable; urgency=medium
+
+  * Add compiler flags. 
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 18 Jun 2025 10:47:29 +0800
+
 deepin-deb-installer (6.5.19) unstable; urgency=medium
 
   * Update version to 6.5.19.

--- a/src/AptInstallDepend/CMakeLists.txt
+++ b/src/AptInstallDepend/CMakeLists.txt
@@ -22,6 +22,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -z relro -z now -z noexecstack -pie")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -z relro -z now -z noexecstack -pie")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -fstack-protector-all")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -fstack-protector-all")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIE")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIE")
 
 # add process directories
 string(REGEX REPLACE "(.*)/(.*)" "\\1" PROJECT_INIT_PATH ${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
Adding Compiler Flags

## Summary by Sourcery

Enable position-independent executable builds by adding the -fPIE flag to both C and C++ compiler configurations

Build:
- Add -fPIE flag to C compiler flags
- Add -fPIE flag to C++ compiler flags