### PR TITLE
 fix: handle empty package version in conflict resolution

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -541,7 +541,8 @@ const ConflictResult PackagesManager::isConflictSatisfy(const QString &arch,
                         if (replace.packageName() == name) { //包名符合
                             auto replaceType = replace.relationType(); //提取版本号规则
                             auto versionCompare = Package::compareVersion(installed_version, replace.packageVersion()); //比较版本号
-                            if (dependencyVersionMatch(versionCompare, replaceType)) { //如果版本号符合要求，即判定replace成立
+                            if (replace.packageVersion().isEmpty() || 
+                                dependencyVersionMatch(versionCompare, replaceType)) {
                                 conflict_yes = false;
                                 break;
                             }


### PR DESCRIPTION
## Summary by Sourcery

Gate environment variable injection behind the DENABLE_VIRTUAL_PACKAGE_ENHANCE flag and allow empty replacement versions to satisfy package conflict checks

Bug Fixes:
- Treat empty replace.packageVersion() as a valid match to resolve package conflicts in isConflictSatisfy

Enhancements:
- Wrap SUDO_USER environment insertion in install/uninstall flows with DENABLE_VIRTUAL_PACKAGE_ENHANCE guard