### PR TITLE
fix: 空值判断

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -523,7 +523,7 @@ const ConflictResult PackagesManager::isConflictSatisfy(const QString &arch,
             const auto result = Package::compareVersion(installed_version, conflict_version);
 
             // not match, ok
-            if (!dependencyVersionMatch(result, type)) {
+            if (conflict_version.isEmpty() || !dependencyVersionMatch(result, type)) {
                 package = nullptr;
                 continue;
             }


### PR DESCRIPTION
log: 修复因冲突包无法安装的问题

## Summary by Sourcery

Bug Fixes:
- Skip conflict checks when the conflict version string is empty to avoid installation failures due to unmet conflict requirements.