### PR TITLE
fix: implement path transformation for package selection

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deb-installer (6.5.28) unstable; urgency=medium
+
+  * fix: implement path transformation for package selection
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Fri, 22 Aug 2025 13:05:57 +0800
+
 deepin-deb-installer (6.5.27) unstable; urgency=medium
 
   * feat: Update translations for Lao locale (#350)

--- a/src/deb-installer/view/pages/debinstaller.h
+++ b/src/deb-installer/view/pages/debinstaller.h
@@ -327,6 +327,13 @@ private:
      */
     DdimSt analyzeV10(const QJsonObject &ddimobj, const QString &ddimDir);
 
+    /**
+     * @brief pathTransform 将安装包路径转换为真实路径
+     * @param pathList 路径列表
+     * @return 转换后的路径列表
+     */
+    QStringList pathTransform(const QStringList &pkgList);
+
 private:
     AbstractPackageListModel *m_fileListModel = nullptr;  // model 类
     FileChooseWidget *m_fileChooseWidget = nullptr;       // 文件选择的widget


### PR DESCRIPTION
- Added pathTransform function to convert package paths to their canonical forms.
- Updated PackagesSelected and slotPackagesSelected methods to use transformed paths when appending packages to the model.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-321451.html

## Summary by Sourcery

Implement canonical path transformation for package selection to fix path handling during model insertion

Bug Fixes:
- Ensure package paths are converted to their canonical forms before appending to the model

Enhancements:
- Add pathTransform helper function to produce canonical file paths
- Apply pathTransform in PackagesSelected and slotPackagesSelected methods to feed canonical paths to the model