### PR TITLE
feat: add LoongArch compatible mode support

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -36,6 +36,10 @@ static const QString g_Tagi386 = "i386";
 static const QString g_TagDeepinWine = "deepin-wine";
 static const QString g_DeepinWineHelper = "deepin-wine-helper";
 
+// LoongArch compatible-mode arch names
+static const QString g_ArchLoong64 = "loong64";       // Debian LoongArch port native arch
+static const QString g_ArchLoongarch64 = "loongarch64"; // legacy arch name used by older packages
+
 /**
  * @brief 检测传入软件包架构是否支持多架构
  */
@@ -45,6 +49,21 @@ bool archMultiSupport(const QString &arch)
     bool result = "native" == arch || "all" == arch || "any" == arch;
     qCDebug(appLog) << "Multi-arch supported:" << result;
     return result;
+}
+
+/**
+ * @brief PackagesManager::isLoongArchCompatible
+ *
+ * Returns true when \a pkgArch is "loongarch64" and \a sysArch is "loong64".
+ * These two names represent the same ISA: loong64 is the Debian port name while
+ * loongarch64 is the legacy name used by some older pre-packaged binaries.
+ * Such packages cannot be installed natively by dpkg on a loong64 host, but they
+ * can be handled through the compatible-mode rootfs, so we must NOT treat them as
+ * an architecture error — instead we redirect them to compatible-mode installation.
+ */
+bool PackagesManager::isLoongArchCompatible(const QString &sysArch, const QString &pkgArch)
+{
+    return (sysArch == g_ArchLoong64 && pkgArch == g_ArchLoongarch64);
 }
 
 /**
@@ -447,6 +466,14 @@ bool PackagesManager::isArchError(const int idx)
         return false;
     }
 
+    // loongarch64 packages on a loong64 system are handled by compatible mode, not an error
+    const QString nativeArch = backend->nativeArchitecture();
+    if (isLoongArchCompatible(nativeArch, arch)) {
+        qCDebug(appLog) << "Package arch" << arch << "is compatible with system arch" << nativeArch
+                        << ", skipping arch error check";
+        return false;
+    }
+
     bool architectures = !backend->architectures().contains(deb.architecture());
     qCDebug(appLog) << "Architecture error status:" << architectures;
 
@@ -473,6 +500,14 @@ bool PackagesManager::isArchErrorQstring(const QString &package_name)
 
     if ("all" == arch || "any" == arch) {
         qCDebug(appLog) << "Architecture is 'all' or 'any', no error.";
+        return false;
+    }
+
+    // loongarch64 packages on a loong64 system are handled by compatible mode, not an error
+    const QString nativeArch = backend->nativeArchitecture();
+    if (isLoongArchCompatible(nativeArch, arch)) {
+        qCDebug(appLog) << "Package arch" << arch << "is compatible with system arch" << nativeArch
+                        << ", skipping arch error check";
         return false;
     }
 
@@ -573,8 +608,10 @@ PackagesManager::isInstalledConflict(const QString &packageName, const QString &
             Conflicts: ImageEnhance
             Replaces: ImageEnhnace
         */
-        if (pkg->name() == info.first) {
-            // qCDebug(appLog) << "Conflict with self, ignoring:" << pkg->name();
+        // Use packageName as fallback when pkg is null (package not found in local repo)
+        const QString currentPkgName = pkg ? pkg->name() : packageName;
+        if (currentPkgName == info.first) {
+            // qCDebug(appLog) << "Conflict with self, ignoring:" << currentPkgName;
             continue;
         }
 
@@ -1162,7 +1199,15 @@ PackageDependsStatus PackagesManager::getPackageDependsStatus(const int index)
         if (!isWineApplication && SingleInstallerApplication::mode != SingleInstallerApplication::DdimChannel) {
             auto compPkgPtr = CompBackend::instance()->containsPackage(debFile.packageName());
 
-            if (compPkgPtr && compPkgPtr->installed()) {
+            // On loong64 systems, loongarch64 packages must always go through compatible mode
+            // regardless of dependency status, because dpkg cannot install them natively.
+            Backend *aptBackend = PackageAnalyzer::instance().backendPtr();
+            const QString nativeArch = aptBackend ? aptBackend->nativeArchitecture() : QString();
+            if (isLoongArchCompatible(nativeArch, debFile.architecture())) {
+                qCInfo(appLog) << "loongarch64 package on loong64 system, forcing CompatibleNotInstalled"
+                               << "for package:" << debFile.packageName();
+                dependsStatus.status = Pkg::DependsStatus::CompatibleNotInstalled;
+            } else if (compPkgPtr && compPkgPtr->installed()) {
                 dependsStatus.status = Pkg::DependsStatus::CompatibleIntalled;
             } else if (dependsStatus.isBreak()) {
                 // check if current system install the package.

--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -176,6 +176,22 @@ public:
      */
     bool isArchError(const int idx);
     bool isArchErrorQstring(const QString &package_name);
+
+    /**
+     * @brief isLoongArchCompatible Check if a loongarch64 package should be redirected
+     *        to compatible mode installation on a loong64 system.
+     *
+     * loong64 (the Debian LoongArch port name) and loongarch64 (the legacy arch name
+     * used by older toolchains / packages) refer to the same ISA. A loongarch64 .deb
+     * cannot be installed natively on a loong64 system via dpkg, but it can be
+     * installed through the compatible-mode rootfs.
+     *
+     * @param sysArch  Native system architecture reported by the apt backend (e.g. "loong64")
+     * @param pkgArch  Architecture field of the .deb package (e.g. "loongarch64")
+     * @return true when the package should bypass the arch-error check and be
+     *         redirected to compatible-mode installation.
+     */
+    static bool isLoongArchCompatible(const QString &sysArch, const QString &pkgArch);
 
     /**
      * @brief packageInstallStatus 获取指定index的包的安装状态

--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,6 +8,7 @@
 #include "utils/utils.h"
 #include "utils/deb_package.h"
 #include "compatible/compatible_backend.h"
+#include "model/packageanalyzer.h"
 #include "utils/ddlog.h"
 
 #include <QApplication>

--- a/src/deepin-deb-installer-dev/status/PackageStatus.cpp
+++ b/src/deepin-deb-installer-dev/status/PackageStatus.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -337,6 +337,15 @@ bool PackageStatus::isArchError(const QString &packagePath)
 
     if (arch == "all" || arch == "any") {
         qCDebug(devLog) << "Arch is 'all' or 'any', no error.";
+        return false;
+    }
+
+    // loongarch64 packages on a loong64 system are redirected to compatible mode, not an error
+    // loong64 = Debian LoongArch port native arch; loongarch64 = legacy arch name in older packages
+    const QString nativeArch = backend->nativeArchitecture();
+    if (nativeArch == QLatin1String("loong64") && arch == QLatin1String("loongarch64")) {
+        qCDebug(devLog) << "Package arch" << arch << "is compatible with system arch" << nativeArch
+                        << ", skipping arch error check";
         return false;
     }
 


### PR DESCRIPTION
1. Added support for loongarch64 packages on loong64 systems through
compatible mode
2. Implemented isLoongArchCompatible() function to detect compatible
architecture pairs
3. Modified arch error checking to bypass compatible architecture
combinations
4. Added logic to automatically redirect compatible packages to
compatible-mode installation
5. Updated both packagesmanager.cpp and PackageStatus.cpp for consistent
behavior

The changes enable proper handling of loongarch64 packages on loong64
systems. Since loong64 (Debian port name) and loongarch64 (legacy name)
represent the same ISA, packages with loongarch64 architecture cannot
be installed natively via dpkg but can be handled through compatible-
mode rootfs. This prevents false architecture errors and ensures proper
installation routing.

Log: Added support for loongarch64 packages on loong64 systems via
compatible mode

Influence:
1. Test installing loongarch64 packages on loong64 systems - should use
compatible mode
2. Verify architecture error detection still works for truly
incompatible packages
3. Test mixed architecture scenarios with both compatible and
incompatible packages
4. Verify package dependency resolution works correctly with compatible
mode packages
5. Test installation flow for loongarch64 packages on non-loong64
systems (should show arch error)
6. Verify logging output for compatible architecture detection

feat: 添加龙芯架构兼容模式支持

1. 添加对 loong64 系统上 loongarch64 软件包的兼容模式支持
2. 实现 isLoongArchCompatible() 函数检测兼容架构组合
3. 修改架构错误检查逻辑，绕过兼容架构组合
4. 添加自动将兼容包重定向到兼容模式安装的逻辑
5. 更新 packagesmanager.cpp 和 PackageStatus.cpp 确保行为一致

这些更改使得 loong64 系统能够正确处理 loongarch64 软件包。由于
loong64（Debian 端口名称）和 loongarch64（旧版名称）代表相同的指令集架
构，具有 loongarch64 架构的软件包无法通过 dpkg 原生安装，但可以通过兼容
模式 rootfs 处理。这避免了错误的架构错误提示并确保正确的安装路由。

Log: 新增对 loong64 系统上 loongarch64 软件包的兼容模式支持

Influence:
1. 测试在 loong64 系统上安装 loongarch64 软件包 - 应使用兼容模式
2. 验证架构错误检测对于真正不兼容的包仍然有效
3. 测试同时包含兼容和不兼容包的混合架构场景
4. 验证兼容模式软件包的依赖关系解析是否正确
5. 测试在非 loong64 系统上安装 loongarch64 软件包（应显示架构错误）
6. 验证兼容架构检测的日志输出
