### PR TITLE
chore: update version to 6.5.33

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deb-installer (6.5.33) unstable; urgency=medium
+
+  * feat: add LoongArch compatible mode support
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Thu, 09 Apr 2026 13:47:02 +0800
+
 deepin-deb-installer (6.5.32) unstable; urgency=medium
 
   * fix: enhance package installation process for immutable systems


### PR DESCRIPTION
as title

Log: update version

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 6.5.33 release.