### PR TITLE
chore: update version to 6.5.34

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deb-installer (6.5.34) unstable; urgency=medium
+
+  * feat: implement intelligent package cache update
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Fri, 10 Apr 2026 16:29:59 +0800
+
 deepin-deb-installer (6.5.33) unstable; urgency=medium
 
   * feat: add LoongArch compatible mode support


### PR DESCRIPTION
as title

Log: update version

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 6.5.34.