### PR TITLE
fix(packagesmanager): prioritize installed reverse providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ resources/images/icon22.svg
 .roo/
 .ruru/
 .roomodes
+AGENTS.md
+.claude
+.trellis

--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -2456,6 +2456,25 @@ Package *PackagesManager::packageWithArch(const QString &packageName, const QStr
     if (!package)
         package = backend->package(packageName);
 
+    if (package) {
+        // 检查反向提供者：如果当前包未安装，但某个提供者已安装，优先使用已安装的提供者
+        QString installedVersion = package->installedVersion();
+        if (installedVersion.isEmpty()) {
+            const auto &reprvList = package->reverseProvidesList();
+            for (const auto &rep : reprvList) {
+                Package *provider = backend->package(rep);
+                if (provider && !provider->installedVersion().isEmpty()) {
+                    // 检查提供者的架构是否有效
+                    if (checkPackageArchValid(provider, packageName, suggestArch)) {
+                        qCInfo(appLog) << "Using installed reverse provider" << rep
+                                      << "instead of" << packageName;
+                        return provider;
+                    }
+                }
+            }
+        }
+    }
+
     if (checkPackageArchValid(package, packageName, suggestArch))
         return package;
     for (QString arch : backend->architectures()) {


### PR DESCRIPTION
If a requested package is not installed, check the reverse provides list
for an already installed provider. If a valid provider is found, return
it instead of the uninstalled package to ensure correct dependency
resolution.

Also update .gitignore to exclude tool configuration directories.

Bug: https://pms.uniontech.com/bug-view-358267.html

## Summary by Sourcery

Prioritize already-installed reverse provider packages during dependency resolution and update repository ignore rules.

Bug Fixes:
- Ensure dependency resolution selects an installed reverse provider when the requested package itself is not installed but has valid installed providers.

Chores:
- Extend .gitignore to exclude additional tool configuration directories.