### PR TITLE
feat: add DFM plugin for compatible mode deb installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -34,6 +34,7 @@ if (QT_DESIRED_VERSION MATCHES 6)
     find_package(QApt-qt6 REQUIRED)
     include_directories(${QApt-qt6_INCLUDE_DIRS})
     set(QAPT_LIB QApt-qt6)
+    add_subdirectory(src/dfmplugin-debinstaller)
 else()
     find_package(QApt REQUIRED)
     include_directories(${QApt_INCLUDE_DIRS})

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: deepin-deb-installer
 Section: utils
 Priority: optional
 Maintainer: Deepin Packages Builder <packages@deepin.com>
-Build-Depends: 
+Build-Depends:
  debhelper (>= 9),
  pkg-config,
  cmake,
@@ -18,19 +18,20 @@ Build-Depends:
  libpolkit-qt6-1-dev,
  libgtest-dev,
  deepin-gettext-tools,
+ dde-file-manager-dev,
 Standards-Version: 4.3.0
 Homepage: https://www.deepin.com/
 
 Package: deepin-deb-installer
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, 
- libqapt3-qt6-runtime, 
- libqapt3-qt6, 
+Depends: ${shlibs:Depends}, ${misc:Depends},
+ libqapt3-qt6-runtime,
+ libqapt3-qt6,
 # deepin-app-store-runtime is available in the community edition.
- deepin-elf-verify | deepin-app-store-runtime, 
+ deepin-elf-verify | deepin-app-store-runtime,
  deepin-elf-sign-tool | deepin-app-store-runtime
 Description: Package Installer helps users install and remove local packages.
- Package Installer is an easy-to-use .deb package management tool 
+ Package Installer is an easy-to-use .deb package management tool
  with a simple interface for users to quickly install customized applications
  not included in App Store supporting bulk installation, version identification
  and auto completion.

--- a/src/dfmplugin-debinstaller/CMakeLists.txt
+++ b/src/dfmplugin-debinstaller/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(dfmplugin-debinstaller)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+
+include(GNUInstallDirs)
+
+if(NOT DEFINED DFM_PLUGIN_DIR)
+    set(DFM_PLUGIN_DIR ${CMAKE_INSTALL_FULL_LIBDIR}/dde-file-manager/plugins)
+endif()
+if(NOT DEFINED DFM_PLUGIN_COMMON_EDGE_DIR)
+    set(DFM_PLUGIN_COMMON_EDGE_DIR ${DFM_PLUGIN_DIR}/common-edge)
+endif()
+
+FILE(GLOB PLUGIN_FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.json"
+)
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Gui)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets)
+find_package(dfm${DTK_VERSION_MAJOR}-framework REQUIRED)
+find_package(dfm${DTK_VERSION_MAJOR}-base REQUIRED)
+
+add_library(${PROJECT_NAME} SHARED ${PLUGIN_FILES})
+
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(${PROJECT_NAME}
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Widgets
+    dfm${DTK_VERSION_MAJOR}-framework
+    dfm${DTK_VERSION_MAJOR}-base
+)
+
+install(TARGETS ${PROJECT_NAME}
+    LIBRARY DESTINATION ${DFM_PLUGIN_COMMON_EDGE_DIR}
+)

--- a/src/dfmplugin-debinstaller/debinstallerplugin.cpp
+++ b/src/dfmplugin-debinstaller/debinstallerplugin.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "debinstallerplugin.h"
+#include "menu/debinstallermenuscene.h"
+
+#include <QTranslator>
+
+inline constexpr char kParentScene[] { "ExtendMenu" };
+
+using namespace dfmbase;
+using namespace dfmplugin_debinstaller;
+
+void DebInstallerPlugin::initialize()
+{
+    auto translator = new QTranslator(this);
+    Q_UNUSED(translator->load(QLocale(), "deepin-deb-installer", "_",
+                              "/usr/share/deepin-deb-installer/translations"));
+    QCoreApplication::installTranslator(translator);
+
+    if (DPF_NAMESPACE::LifeCycle::isAllPluginsStarted()) {
+        bindMenuScene();
+    } else {
+        connect(dpfListener, &DPF_NAMESPACE::Listener::pluginsStarted,
+                this, &DebInstallerPlugin::bindMenuScene, Qt::DirectConnection);
+    }
+}
+
+bool DebInstallerPlugin::start()
+{
+    return true;
+}
+
+void DebInstallerPlugin::bindMenuScene()
+{
+    dpfSlotChannel->push("dfmplugin_menu", "slot_MenuScene_RegisterScene",
+                         DebInstallerMenuCreator::name(), new DebInstallerMenuCreator);
+
+    bool ret = dpfSlotChannel->push("dfmplugin_menu", "slot_MenuScene_Contains",
+                                    QString(kParentScene))
+                       .toBool();
+    if (ret) {
+        dpfSlotChannel->push("dfmplugin_menu", "slot_MenuScene_Bind",
+                             DebInstallerMenuCreator::name(), QString(kParentScene));
+    } else {
+        dpfSignalDispatcher->subscribe("dfmplugin_menu", "signal_MenuScene_SceneAdded",
+                                       this, &DebInstallerPlugin::onMenuSceneAdded);
+    }
+}
+
+void DebInstallerPlugin::onMenuSceneAdded(const QString &scene)
+{
+    if (scene == kParentScene) {
+        dpfSlotChannel->push("dfmplugin_menu", "slot_MenuScene_Bind",
+                             DebInstallerMenuCreator::name(), QString(kParentScene));
+        dpfSignalDispatcher->unsubscribe("dfmplugin_menu", "signal_MenuScene_SceneAdded",
+                                         this, &DebInstallerPlugin::onMenuSceneAdded);
+    }
+}

--- a/src/dfmplugin-debinstaller/debinstallerplugin.h
+++ b/src/dfmplugin-debinstaller/debinstallerplugin.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DEBINSTALLERPLUGIN_H
+#define DEBINSTALLERPLUGIN_H
+
+#include <dfm-framework/dpf.h>
+
+namespace dfmplugin_debinstaller {
+
+class DebInstallerPlugin : public dpf::Plugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.deepin.plugin.common" FILE "debinstallerplugin.json")
+
+    DPF_EVENT_NAMESPACE(dfmplugin_debinstaller)
+
+public:
+    void initialize() override;
+    bool start() override;
+
+private Q_SLOTS:
+    void bindMenuScene();
+    void onMenuSceneAdded(const QString &scene);
+};
+
+}   // namespace dfmplugin_debinstaller
+
+#endif   // DEBINSTALLERPLUGIN_H

--- a/src/dfmplugin-debinstaller/debinstallerplugin.json
+++ b/src/dfmplugin-debinstaller/debinstallerplugin.json
@@ -1,0 +1,15 @@
+{
+    "Name" : "dfmplugin-debinstaller",
+    "Version" : "1.0.0",
+    "CompatVersion" : "1.0.0",
+    "Vendor" : "UnionTech Software Technology Co., Ltd.",
+    "Copyright" : "Copyright (C) 2025 UnionTech Software Technology Co., Ltd.",
+    "License" : [
+    ],
+    "Category" : "",
+    "Description" : "Add compatible mode install menu item for deb packages in file manager.",
+    "UrlLink" : "https://www.deepin.org",
+    "Depends" : [
+        {"Name" : "dfmplugin-core", "Version": "1.0.0"}
+    ]
+}

--- a/src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp
+++ b/src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "debinstallermenuscene.h"
+#include "debinstallermenuscene_p.h"
+
+#include <dfm-base/dfm_menu_defines.h>
+
+#include <QUrl>
+#include <QProcess>
+#include <QStandardPaths>
+
+inline constexpr char kCompatibleInstall[] { "compatible-install" };
+inline constexpr char kOpenWithActionID[] { "open-with" };
+
+using namespace dfmplugin_debinstaller;
+DFMBASE_USE_NAMESPACE
+
+AbstractMenuScene *DebInstallerMenuCreator::create()
+{
+    return new DebInstallerMenuScene();
+}
+
+DebInstallerMenuScenePrivate::DebInstallerMenuScenePrivate(DebInstallerMenuScene *qq)
+    : q(qq)
+{
+}
+
+DebInstallerMenuScene::DebInstallerMenuScene(QObject *parent)
+    : AbstractMenuScene(parent),
+      d(new DebInstallerMenuScenePrivate(this))
+{
+    d->predicateName[kCompatibleInstall] = tr("Install in compatible mode");
+}
+
+DebInstallerMenuScene::~DebInstallerMenuScene()
+{
+}
+
+QString DebInstallerMenuScene::name() const
+{
+    return DebInstallerMenuCreator::name();
+}
+
+bool DebInstallerMenuScene::initialize(const QVariantHash &params)
+{
+    if (QStandardPaths::findExecutable("deepin-compatible-ctl").isEmpty())
+        return false;
+
+    d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
+    d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
+
+    // only show for single deb file selection, not empty area
+    if (d->isEmptyArea || d->selectFiles.size() != 1)
+        return false;
+
+    const auto &url = d->selectFiles.first();
+    if (!url.isLocalFile() || !url.toLocalFile().endsWith(".deb"))
+        return false;
+
+    return AbstractMenuScene::initialize(params);
+}
+
+AbstractMenuScene *DebInstallerMenuScene::scene(QAction *action) const
+{
+    if (action == nullptr)
+        return nullptr;
+
+    if (!d->predicateAction.key(action).isEmpty())
+        return const_cast<DebInstallerMenuScene *>(this);
+
+    return AbstractMenuScene::scene(action);
+}
+
+bool DebInstallerMenuScene::create(QMenu *parent)
+{
+    if (!parent)
+        return false;
+
+    auto act = parent->addAction(d->predicateName.value(kCompatibleInstall));
+    d->predicateAction[kCompatibleInstall] = act;
+    act->setProperty(ActionPropertyKey::kActionID, kCompatibleInstall);
+
+    return AbstractMenuScene::create(parent);
+}
+
+void DebInstallerMenuScene::updateState(QMenu *parent)
+{
+    if (!parent)
+        return;
+
+    auto targetAction = d->predicateAction.value(kCompatibleInstall);
+    if (!targetAction)
+        return AbstractMenuScene::updateState(parent);
+
+    // disable if deb installer is already running
+    QProcess proc;
+    proc.start("pidof", { "deepin-deb-installer" });
+    proc.waitForFinished(1000);
+    targetAction->setEnabled(proc.exitCode() != 0);
+
+    // remove our action first
+    parent->removeAction(targetAction);
+
+    // find "open-with" action and insert our action after it
+    auto actions = parent->actions();
+    bool inserted = false;
+
+    for (auto it = actions.begin(); it != actions.end(); ++it) {
+        auto actId = (*it)->property(ActionPropertyKey::kActionID).toString();
+        if (actId == kOpenWithActionID) {
+            ++it;   // advance past "open-with"
+            // insert before the next action (or append if open-with was last)
+            if (it != actions.end()) {
+                parent->insertAction(*it, targetAction);
+            } else {
+                parent->addAction(targetAction);
+            }
+            inserted = true;
+            break;
+        }
+    }
+
+    // fallback: if "open-with" not found, append at end
+    if (!inserted)
+        parent->addAction(targetAction);
+
+    AbstractMenuScene::updateState(parent);
+}
+
+bool DebInstallerMenuScene::triggered(QAction *action)
+{
+    auto actionId = action->property(ActionPropertyKey::kActionID).toString();
+    if (!d->predicateAction.contains(actionId))
+        return AbstractMenuScene::triggered(action);
+
+    if (actionId == kCompatibleInstall) {
+        QString debPath = d->selectFiles.first().toLocalFile();
+        return QProcess::startDetached("deepin-deb-installer", { "--compatible", debPath });
+    }
+
+    return true;
+}

--- a/src/dfmplugin-debinstaller/menu/debinstallermenuscene.h
+++ b/src/dfmplugin-debinstaller/menu/debinstallermenuscene.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DEBINSTALLERMENUSCENE_H
+#define DEBINSTALLERMENUSCENE_H
+
+#include <dfm-base/interfaces/abstractmenuscene.h>
+#include <dfm-base/interfaces/abstractscenecreator.h>
+
+namespace dfmplugin_debinstaller {
+
+class DebInstallerMenuCreator : public DFMBASE_NAMESPACE::AbstractSceneCreator
+{
+public:
+    static QString name()
+    {
+        return "DebInstallerMenu";
+    }
+    DFMBASE_NAMESPACE::AbstractMenuScene *create() override;
+};
+
+class DebInstallerMenuScenePrivate;
+class DebInstallerMenuScene : public DFMBASE_NAMESPACE::AbstractMenuScene
+{
+    Q_OBJECT
+public:
+    explicit DebInstallerMenuScene(QObject *parent = nullptr);
+    ~DebInstallerMenuScene() override;
+
+    QString name() const override;
+    bool initialize(const QVariantHash &params) override;
+    AbstractMenuScene *scene(QAction *action) const override;
+    bool create(QMenu *parent) override;
+    void updateState(QMenu *parent) override;
+    bool triggered(QAction *action) override;
+
+private:
+    QScopedPointer<DebInstallerMenuScenePrivate> d;
+};
+
+}   // namespace dfmplugin_debinstaller
+
+#endif   // DEBINSTALLERMENUSCENE_H

--- a/src/dfmplugin-debinstaller/menu/debinstallermenuscene_p.h
+++ b/src/dfmplugin-debinstaller/menu/debinstallermenuscene_p.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DEBINSTALLERMENUSCENE_P_H
+#define DEBINSTALLERMENUSCENE_P_H
+
+#include <QMenu>
+
+namespace dfmplugin_debinstaller {
+
+class DebInstallerMenuScene;
+class DebInstallerMenuScenePrivate
+{
+public:
+    explicit DebInstallerMenuScenePrivate(DebInstallerMenuScene *qq);
+
+public:
+    DebInstallerMenuScene *q;
+
+    QList<QUrl> selectFiles;
+    bool isEmptyArea { false };
+    QMap<QString, QAction *> predicateAction;
+    QMap<QString, QString> predicateName;
+};
+
+}   // namespace dfmplugin_debinstaller
+
+#endif   // DEBINSTALLERMENUSCENE_P_H


### PR DESCRIPTION
1. Add new DDE File Manager plugin (dfmplugin-debinstaller) to provide
"Install in compatible mode" context menu for .deb files
2. Create plugin structure with CMakeLists.txt, plugin metadata, and
menu scene implementation
3. Implement DebInstallerMenuScene with conditional display logic:
only shows for single .deb file selection when deepin-compatible-ctl
is available
4. Add menu positioning logic to insert action after "open-with" menu
item
5. Implement action trigger to launch deepin-deb-installer with
--compatible flag
6. Add runtime check to disable menu when deb installer is already
running
7. Update debian/control with dde-file-manager-dev build dependency
8. Integrate plugin into Qt6 build path only (conditional on
QT_DESIRED_VERSION MATCHES 6)
9. Include i18n support with QTranslator loading from application
translation directory

Log: Added "Install in compatible mode" context menu in file manager for
deb packages

Influence:
1. Test context menu appearance for single .deb file selection in file
manager
2. Verify menu does NOT appear for multiple file selections or empty
areas
3. Verify menu does NOT appear when deepin-compatible-ctl is not
installed
4. Verify menu is disabled when deepin-deb-installer process is already
running
5. Test menu positioning appears after "Open With" option in context
menu
6. Test clicking menu item launches deepin-deb-installer with
--compatible flag and correct deb path
7. Verify menu does NOT appear for non-.deb files
8. Test plugin loads correctly in Qt6 build environment only
9. Verify i18n translation loads for menu text "Install in compatible
mode"

feat: 添加文件管理器插件支持兼容模式安装 deb 包

1. 新增 DDE 文件管理器插件 (dfmplugin-debinstaller)，为 .deb 文件提供"以
兼容模式安装"右键菜单
2. 创建插件结构，包括 CMakeLists.txt、插件元数据和菜单场景实现
3. 实现 DebInstallerMenuScene 条件显示逻辑：仅在 deepin-compatible-ctl
可用且选中单个 .deb 文件时显示
4. 添加菜单位置逻辑，将操作项插入到"打开方式"菜单项之后
5. 实现操作触发逻辑，启动 deepin-deb-installer 并传入 --compatible 参数
6. 添加运行时检查，当 deb 安装器已在运行时禁用菜单
7. 更新 debian/control，添加 dde-file-manager-dev 构建依赖
8. 仅在 Qt6 构建路径中集成插件（基于 QT_DESIRED_VERSION MATCHES 6 条件）
9. 包含国际化支持，从应用程序翻译目录加载 QTranslator

Log: 在文件管理器中新增 deb 包"以兼容模式安装"右键菜单

Influence:
1. 测试文件管理器中单个 .deb 文件选中时的右键菜单显示
2. 验证多文件选中或空白区域不显示该菜单
3. 验证未安装 deepin-compatible-ctl 时不显示该菜单
4. 验证 deepin-deb-installer 进程已在运行时菜单被禁用
5. 测试菜单位置是否正确显示在"打开方式"选项之后
6. 测试点击菜单项是否能正确启动 deepin-deb-installer 并传入 --compatible
参数和正确的 deb 路径
7. 验证非 .deb 文件不显示该菜单
8. 测试插件仅在 Qt6 构建环境中正确加载
9. 验证菜单文本"以兼容模式安装"的国际化翻译加载

TASK: https://pms.uniontech.com/task-view-389473.html
