### PR TITLE
feat(compat): hide settings menu in community edition

### DIFF
--- a/src/deb-installer/model/backend/apt_install_backend.cpp
+++ b/src/deb-installer/model/backend/apt_install_backend.cpp
@@ -37,8 +37,11 @@ bool AptInstallBackend::verifySignature(int index)
     Q_UNUSED(index)
     qCWarning(appLog) << "AptInstallBackend::verifySignature(int) entering";
 
-    SettingDialog dialog;
-    m_model->m_isDigitalVerify = dialog.isDigitalVerified();
+    // 社区版不读取设置，保持 m_isDigitalVerify 默认值 false
+    if (DSysInfo::uosEditionType() != DSysInfo::UosCommunity) {
+        SettingDialog dialog;
+        m_model->m_isDigitalVerify = dialog.isDigitalVerified();
+    }
     int digitalSigntual = Utils::Digital_Verify(m_model->m_packagesManager->package(m_model->m_operatingIndex));
     qCWarning(appLog) << "verifySignature(int) m_isDevelopMode:" << m_model->m_isDevelopMode << " /m_isDigitalVerify:" << m_model->m_isDigitalVerify
                    << " /digitalSigntual:" << digitalSigntual;
@@ -116,8 +119,11 @@ bool AptInstallBackend::verifySignature(const QString &packagePath)
 {
     qCWarning(appLog) << "AptInstallBackend::verifySignature(packagePath) entering for" << packagePath;
 
-    SettingDialog dialog;
-    m_model->m_isDigitalVerify = dialog.isDigitalVerified();
+    // 社区版不读取设置，保持 m_isDigitalVerify 默认值 false
+    if (DSysInfo::uosEditionType() != DSysInfo::UosCommunity) {
+        SettingDialog dialog;
+        m_model->m_isDigitalVerify = dialog.isDigitalVerified();
+    }
     int digitalSigntual = Utils::Digital_Verify(packagePath);
     qCInfo(appLog) << "m_isDevelopMode:" << m_model->m_isDevelopMode << " /m_isDigitalVerify:" << m_model->m_isDigitalVerify
                    << " /digitalSigntual:" << digitalSigntual;

--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -574,8 +574,11 @@ int DebListModel::checkDigitalSignature(const QString &package_path)
         qCDebug(appLog) << "Depends status is break or auth cancel, returning success.";
         return Utils::VerifySuccess;
     }
-    SettingDialog dialog;
-    m_isDigitalVerify = dialog.isDigitalVerified();
+    // 社区版不读取设置，保持 m_isDigitalVerify 默认值 false
+    if (DSysInfo::uosEditionType() != DSysInfo::UosCommunity) {
+        SettingDialog dialog;
+        m_isDigitalVerify = dialog.isDigitalVerified();
+    }
     int digitalSigntual = Utils::Digital_Verify(package_path);  // 判断是否有数字签名
     qCDebug(appLog) << "Digital signature verification result:" << digitalSigntual;
     // 无数字签名：专业版检查Mode属性，社区版走原有开发者模式逻辑
@@ -1452,8 +1455,11 @@ bool DebListModel::checkDigitalSignature()
         qCDebug(appLog) << "Dependency is broken or auth cancelled, skipping signature check";
         return true;
     }
-    SettingDialog dialog;
-    m_isDigitalVerify = dialog.isDigitalVerified();
+    // 社区版不读取设置，保持 m_isDigitalVerify 默认值 false
+    if (DSysInfo::uosEditionType() != DSysInfo::UosCommunity) {
+        SettingDialog dialog;
+        m_isDigitalVerify = dialog.isDigitalVerified();
+    }
     int digitalSigntual = Utils::Digital_Verify(m_packagesManager->package(m_operatingIndex));  // 判断是否有数字签名
     qCInfo(appLog) << "m_isDevelopMode:" << m_isDevelopMode << " /m_isDigitalVerify:" << m_isDigitalVerify
             << " /digitalSigntual:" << digitalSigntual;

--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -126,13 +126,16 @@ void DebInstaller::initUI()
 void DebInstaller::initTitleBar()
 {
     qCDebug(appLog) << "Initializing title bar";
-    // title bar settings
-    QAction *settingAction(new QAction(tr("Settings"), this));
-    DMenu *menu = new DMenu;
-    menu->addAction(settingAction);
     DTitlebar *tb = titlebar();
     if (tb != nullptr) {
-        tb->setMenu(menu);
+        // 社区版不显示设置菜单
+        if (DSysInfo::uosEditionType() != DSysInfo::UosCommunity) {
+            QAction *settingAction(new QAction(tr("Settings"), this));
+            DMenu *menu = new DMenu;
+            menu->addAction(settingAction);
+            tb->setMenu(menu);
+            connect(settingAction, &QAction::triggered, this, &DebInstaller::slotSettingDialogVisiable);
+        }
         tb->setIcon(QIcon::fromTheme("deepin-deb-installer"));
         tb->setTitle("");
         tb->setAutoFillBackground(true);
@@ -141,7 +144,6 @@ void DebInstaller::initTitleBar()
     } else {
         qCWarning(appLog) << "Title bar is null";
     }
-    connect(settingAction, &QAction::triggered, this, &DebInstaller::slotSettingDialogVisiable);
 }
 
 void DebInstaller::initConnections()


### PR DESCRIPTION
Hide the Settings menu entry on UOS Community edition since digital signature verification settings are not applicable. Also skip reading isDigitalVerified from SettingDialog in community edition to keep the default value (false).

社区版下隐藏设置菜单入口，因数字签名验证设置不适用于社区版。
同时在社区版下跳过从 SettingDialog 读取 isDigitalVerified，
保持默认值 false。

Log: 社区版隐藏设置菜单入口并跳过验签配置读取
PMS: TASK-389473
Influence: 社区版下标题栏不再显示设置按钮，签名验证保持默认行为（放行无签名包）。

## Summary by Sourcery

Hide deb-installer settings UI and keep digital signature verification at its default behavior on the UOS Community edition.

New Features:
- Conditionally hide the title bar Settings menu in the deb-installer on non-Community versus Community editions.

Bug Fixes:
- Prevent Community edition from reading and applying digital signature verification preferences so that the default non-verifying behavior is preserved.

Enhancements:
- Gate settings-driven digital signature verification logic on the UOS edition type across backend and model layers.