### PR TITLE
fix(context-menu): hide compatible install in empty area right-click

### DIFF
--- a/src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp
+++ b/src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp
@@ -73,16 +73,12 @@ bool DebInstallerMenuScene::initialize(const QVariantHash &params)
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
 
-    if (d->isEmptyArea) {
-        if (!isInstallerRunning())
-            return false;
-    } else if (d->selectFiles.size() != 1) {
+    if (d->isEmptyArea)
         return false;
-    } else {
-        const auto &url = d->selectFiles.first();
-        if (!url.isLocalFile() || !url.toLocalFile().endsWith(".deb"))
-            return false;
-    }
+
+    const auto &url = d->selectFiles.first();
+    if (!url.isLocalFile() || !url.toLocalFile().endsWith(".deb"))
+        return false;
 
     return AbstractMenuScene::initialize(params);
 }


### PR DESCRIPTION
Always return false when right-clicking on empty area to prevent the "Install in compatible mode" option from appearing.

修复空白区域右键时兼容模式安装选项不应显示的问题。

PMS: TASK-389473
Log: 修复空白区域右键仍显示兼容模式安装选项的问题
Influence: 兼容模式安装菜单项仅在右键点击单个.deb文件时显示，空白区域右键不再出现。

## Summary by Sourcery

Bug Fixes:
- Hide the compatible install menu entry when right-clicking on an empty area in the deb installer view.