### PR TITLE
chore: update version to 6.5.37

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deb-installer (6.5.37) unstable; urgency=medium
+
+  * fix(context-menu): avoid auto-activating installer service on state query
+
+ -- Liu Zheng <liuzheng@uniontech.com>  Fri, 15 May 2026 19:21:35 +0800
+
 deepin-deb-installer (6.5.36) unstable; urgency=medium
 
   * fix(context-menu): hide compatible install in empty area right-click


### PR DESCRIPTION
- bump version to 6.5.37

Log : bump version to 6.5.37

## Summary by Sourcery

Build:
- Bump packaged version to 6.5.37 in debian/changelog.