### PR TITLE
fix(install): abort installation when deb file no longer exists

### DIFF
--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -445,6 +445,14 @@ bool DebListModel::slotInstallPackages()
     initRowStatus();  // 初始化包的操作状态
     qCDebug(appLog) << "Initialized package operating status";
 
+    // Check if the package file still exists before proceeding with signature verification.
+    // The file may have been renamed or moved after the installer was opened.
+    if (!recheckPackagePath(m_packagesManager->package(m_operatingIndex))) {
+        qCWarning(appLog) << "Package file no longer exists, aborting installation";
+        m_workerStatus = WorkerPrepare;
+        return false;
+    }
+
     // 检查当前应用是否在黑名单中
     // 非开发者模式且数字签名验证失败
     if (checkBlackListApplication() || !m_aptBackend->verifySignature(m_operatingIndex)) {
@@ -1135,6 +1143,13 @@ void DebListModel::installDebs()
         m_currentTransaction = m_aptBackend->m_currentTransaction;
         return;
     }
+
+    // Install failed (e.g. deb file no longer exists at stored path)
+    qCWarning(appLog) << "Apt install backend returned false for index" << m_operatingIndex;
+    refreshOperatingPackageStatus(Pkg::Failed);
+    m_packageFailCode.insert(m_operatingPackageMd5, Pkg::UnknownError);
+    m_packageFailReason.insert(m_operatingPackageMd5, tr("Installation failed"));
+    bumpInstallIndex();
 }
 
 void DebListModel::digitalVerifyFailed(Pkg::ErrorCode errorCode)
@@ -1535,6 +1550,7 @@ bool DebListModel::checkDigitalSignature()
 void DebListModel::installNextDeb()
 {
     qCDebug(appLog) << "Entering installNextDeb for operating index" << m_operatingStatusIndex;
+
     // If package is first package or install to compatible mode, not need reset status.
     bool isFirstPackageAndCached = (0 == m_operatingStatusIndex) && m_packagesManager->cachedPackageDependStatus(m_operatingStatusIndex);
     if (!isFirstPackageAndCached) {

--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -1064,6 +1064,8 @@ void DebInstaller::slotReset()
     m_fileListModel->reset();         // 重置model
     Q_EMIT packagesCleared();
 
+    enableCloseAndExit();  // 确保关闭按钮可用
+
     // 删除所有的页面
     if (!m_lastPage.isNull() && m_lastPage != m_fileChooseWidget) {
         m_lastPage->deleteLater();

--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -746,7 +746,11 @@ void SingleInstallPage::slotInstall()
     m_operate = Install;
 
     // 开始安装
-    m_packagesModel->slotInstallPackages();
+    if (!m_packagesModel->slotInstallPackages()) {
+        // Package file no longer exists, go back to the initial file choose page.
+        Q_EMIT signalBacktoFileChooseWidget();
+        return;
+    }
 }
 
 void SingleInstallPage::slotUninstallCurrentPackage()


### PR DESCRIPTION
Check package file existence before signature verification to prevent invalid install flow when the file has been renamed or moved.

修复打开deb包后重命名文件导致安装流程异常的问题，
在签名校验前校验文件存在性，失败时回到初始页面并提示用户。

Log: 修复重命名deb包后安装失败且提示异常的问题
PMS: BUG-311901
Influence: 打开deb包后重命名文件再点击安装，会提示文件不存在并回到初始页面，不再弹出签名错误或卡在进度条界面。