### PR TITLE
fix(context-menu): hide compatible install on multi-file selection

### DIFF
--- a/src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp
+++ b/src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp
@@ -87,7 +87,7 @@ bool DebInstallerMenuScene::initialize(const QVariantHash &params)
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
 
-    if (d->isEmptyArea)
+    if (d->isEmptyArea || d->selectFiles.size() != 1)
         return false;
 
     const auto &url = d->selectFiles.first();


### PR DESCRIPTION
Restore selectFiles.size() != 1 check that was accidentally removed in df4618b.

恢复多选文件时隐藏兼容模式安装菜单的检查，该检查在 df4618b 提交中被误删。

Log: 多选deb文件时隐藏兼容模式安装菜单
PMS: BUG-361823
Influence: 多选deb文件右键不再显示"兼容模式安装"选项，仅单选时可用。