### PR TITLE
fix(compatible): prevent UI reset on restore in compat confirm view

### DIFF
--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -1270,9 +1270,12 @@ void SingleInstallPage::afterGetAutherFalse()
 void SingleInstallPage::showEvent(QShowEvent *e)
 {
     qCDebug(appLog) << "Show event";
-    showPackageInfo();
-    // 每次切换展示当前页面，复位焦点状态
-    resetButtonFocus = true;
+    // 兼容模式确认视图下不重置UI，避免最小化还原后界面状态被覆盖
+    if (!(m_inCompatibleMode && m_compatCheckBox->isVisible())) {
+        showPackageInfo();
+        // 每次切换展示当前页面，复位焦点状态
+        resetButtonFocus = true;
+    }
     QWidget::showEvent(e);
 }
 


### PR DESCRIPTION
Skip showPackageInfo() in showEvent when the compatible mode confirmation view (checkbox) is active, preventing minimize/restore from resetting UI state.

兼容模式确认视图中，showEvent跳过showPackageInfo调用，
避免窗口最小化还原后UI状态被覆盖。

Log: 修复兼容模式确认视图最小化还原后界面错乱
PMS: BUG-361965
Influence: 修复兼容模式安装确认界面最小化还原后，出现上一界面提示信息和按钮的问题。