### PR TITLE
fix(ui): improve tooltip image hover detection in compat hint label

### DIFF
--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -1511,16 +1511,28 @@ bool SingleInstallPage::eventFilter(QObject *watched, QEvent *event)
 
             QPointF relPos(me->pos().x() - cr.x(), me->pos().y() - cr.y());
             int pos = doc.documentLayout()->hitTest(relPos, Qt::FuzzyHit);
+
+            bool isOverImage = false;
             if (pos != -1) {
                 QTextCursor cursor(&doc);
-                cursor.setPosition(pos);
-                if (cursor.charFormat().isImageFormat()) {
-                    QString tooltipHtml = QString("<div style='max-width:232px;'>%1</div>").arg(m_compatToolTip.toHtmlEscaped());
-                    QToolTip::showText(me->globalPos(), tooltipHtml, m_compatHintLabel);
-                    return true;
+                for (int offset = 0; offset <= 2; ++offset) {
+                    int checkPos = pos + offset;
+                    if (checkPos < doc.characterCount()) {
+                        cursor.setPosition(checkPos);
+                        if (cursor.charFormat().isImageFormat()) {
+                            isOverImage = true;
+                            break;
+                        }
+                    }
                 }
             }
-            QToolTip::hideText();
+
+            if (isOverImage) {
+                QString tooltipHtml = QString("<div style='max-width:232px;'>%1</div>").arg(m_compatToolTip.toHtmlEscaped());
+                QToolTip::showText(me->globalPos(), tooltipHtml, m_compatHintLabel);
+            } else {
+                QToolTip::hideText();
+            }
             return true;
         } else if (event->type() == QEvent::Leave) {
             QToolTip::hideText();


### PR DESCRIPTION
Use offset scanning (0-2) to reliably detect if mouse is over an image in QTextDocument, avoiding missed tooltip due to hitTest precision issues.

使用偏移量扫描（0-2）来更可靠地检测鼠标是否悬停在
QTextDocument中的图片上，避免因hitTest精度问题导致
tooltip无法显示。

Log: 修复兼容模式提示图片悬停检测不灵敏的问题
PMS: BUG-361855
Influence: 兼容模式安装页面的提示图标tooltip显示更可靠，提升用户体验。

## Summary by Sourcery

Bug Fixes:
- Fix unreliable tooltip triggering when hovering over the compatibility mode hint image in the install page.