### PR TITLE
fix(i18n): add missing translation for right-click compat install menu

### DIFF
--- a/translations/deepin-deb-installer_am_ET.ts
+++ b/translations/deepin-deb-installer_am_ET.ts
@@ -747,6 +747,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>ተመሳሳይ ሁነታ ማስገባት</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_ar.ts
+++ b/translations/deepin-deb-installer_ar.ts
@@ -754,6 +754,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>تثبيت في الوضع المتوافق</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_ast.ts
+++ b/translations/deepin-deb-installer_ast.ts
@@ -683,6 +683,14 @@ del modu de compatibilidad %1?</translation>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Instalar en mou compatible</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="47"/>

--- a/translations/deepin-deb-installer_az.ts
+++ b/translations/deepin-deb-installer_az.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Uyğun rejimdə quraşdır</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_bg.ts
+++ b/translations/deepin-deb-installer_bg.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Инсталиране в съвместим режим</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_bn.ts
+++ b/translations/deepin-deb-installer_bn.ts
@@ -756,6 +756,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>সামঞ্জস্যপূর্ণ মোডে ইনস্টল করুন</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_bo.ts
+++ b/translations/deepin-deb-installer_bo.ts
@@ -743,6 +743,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>མཐུན་ཆོས་ཡི་གནས་ཚུལ་ཁྱེར་ནས་གཞི་སྒྲིག་བྱ་པ།</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_br.ts
+++ b/translations/deepin-deb-installer_br.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Staliañ er mod kevveraat</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_ca.ts
+++ b/translations/deepin-deb-installer_ca.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Instal·la en mode compatible</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_cs.ts
+++ b/translations/deepin-deb-installer_cs.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Instalovat v kompatibilním režimu</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_da.ts
+++ b/translations/deepin-deb-installer_da.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Installer i kompatibel tilstand</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_de.ts
+++ b/translations/deepin-deb-installer_de.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Im Kompatibilitätsmodus installieren</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_en_US.ts
+++ b/translations/deepin-deb-installer_en_US.ts
@@ -753,6 +753,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Install in compatible mode</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_es.ts
+++ b/translations/deepin-deb-installer_es.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Instalar en modo compatible</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_et.ts
+++ b/translations/deepin-deb-installer_et.ts
@@ -757,6 +757,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Paigalda ühilduvas režiimis</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_fi.ts
+++ b/translations/deepin-deb-installer_fi.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Asenna yhteensopivassa tilassa</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_fr.ts
+++ b/translations/deepin-deb-installer_fr.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Installer en mode compatible</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_gl_ES.ts
+++ b/translations/deepin-deb-installer_gl_ES.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Instalar en modo compatible</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_he.ts
+++ b/translations/deepin-deb-installer_he.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>התקנה במצב תאימות</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_hi_IN.ts
+++ b/translations/deepin-deb-installer_hi_IN.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>संगत मोड में इंस्टॉल करें</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_hr.ts
+++ b/translations/deepin-deb-installer_hr.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Instaliraj u kompatibilnom načinu</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_hu.ts
+++ b/translations/deepin-deb-installer_hu.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Telepítés kompatibilis módban</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_id.ts
+++ b/translations/deepin-deb-installer_id.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Instal dalam mode kompatibel</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_it.ts
+++ b/translations/deepin-deb-installer_it.ts
@@ -743,6 +743,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Installa in modalità compatibile</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_ja.ts
+++ b/translations/deepin-deb-installer_ja.ts
@@ -743,6 +743,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>互換モードでインストール</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_ko.ts
+++ b/translations/deepin-deb-installer_ko.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>호환 모드로 설치</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_lo.ts
+++ b/translations/deepin-deb-installer_lo.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>ຕິດຕັ້ງໃນໂໝດທີ່ກົງກັນ</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_lt.ts
+++ b/translations/deepin-deb-installer_lt.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Įdiegti suderinamumo režimu</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_mn.ts
+++ b/translations/deepin-deb-installer_mn.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Нийцтэй горимд суулгах</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_ms.ts
+++ b/translations/deepin-deb-installer_ms.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Pasang dalam mod serasi</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_ne.ts
+++ b/translations/deepin-deb-installer_ne.ts
@@ -756,6 +756,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>अनुकूल मोडमा स्थापना गर्नुहोस्</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_nl.ts
+++ b/translations/deepin-deb-installer_nl.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Installeren in compatibele modus</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_pa.ts
+++ b/translations/deepin-deb-installer_pa.ts
@@ -756,6 +756,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>ਅਨੁਕੂਲ ਮੋਡ ਵਿੱਚ ਇੰਸਟੌਲ ਕਰੋ</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_pl.ts
+++ b/translations/deepin-deb-installer_pl.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Zainstaluj w trybie zgodności</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_pt.ts
+++ b/translations/deepin-deb-installer_pt.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Instalar em modo compatível</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_pt_BR.ts
+++ b/translations/deepin-deb-installer_pt_BR.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Instalar em modo compatível</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_ru.ts
+++ b/translations/deepin-deb-installer_ru.ts
@@ -773,6 +773,14 @@ from %1 compatibility mode?</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Установить в режиме совместимости</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_sk.ts
+++ b/translations/deepin-deb-installer_sk.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Inštalovať v kompatibilnom režime</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_sl.ts
+++ b/translations/deepin-deb-installer_sl.ts
@@ -758,6 +758,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Namesti v združljivem načinu</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_sq.ts
+++ b/translations/deepin-deb-installer_sq.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Instalo në mënyrë përputhëse</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_sr.ts
+++ b/translations/deepin-deb-installer_sr.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Инсталирај у компатибилном режиму</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_tr.ts
+++ b/translations/deepin-deb-installer_tr.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Uyumlu modda yükle</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_ug.ts
+++ b/translations/deepin-deb-installer_ug.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>ماس كېلىدىغان ھالەتتە ئورنىتىش</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_uk.ts
+++ b/translations/deepin-deb-installer_uk.ts
@@ -755,6 +755,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Встановити в режимі сумісності</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_vi.ts
+++ b/translations/deepin-deb-installer_vi.ts
@@ -758,6 +758,14 @@ All dependencies will also be removed</source>
     </message>
 </context>
 <context>
+    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
+    <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
+        <source>Install in compatible mode</source>
+        <translation>Cài đặt ở chế độ tương thích</translation>
+    </message>
+</context>
+<context>
     <name>main</name>
     <message>
         <location filename="../src/deb-installer/main.cpp" line="48"/>

--- a/translations/deepin-deb-installer_zh_CN.ts
+++ b/translations/deepin-deb-installer_zh_CN.ts
@@ -754,8 +754,9 @@ All dependencies will also be removed</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation type="vanished">兼容模式安装</translation>
+        <translation>兼容模式安装</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_zh_HK.ts
+++ b/translations/deepin-deb-installer_zh_HK.ts
@@ -754,8 +754,9 @@ All dependencies will also be removed</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation type="vanished">相容模式安裝</translation>
+        <translation>相容模式安裝</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_zh_TW.ts
+++ b/translations/deepin-deb-installer_zh_TW.ts
@@ -754,8 +754,9 @@ All dependencies will also be removed</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation type="vanished">相容模式安裝</translation>
+        <translation>相容模式安裝</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Restore vanished translations for zh_CN/zh_HK/zh_TW and add DebInstallerMenuScene context with translations for all other locales.

恢复右键菜单"兼容模式安装"的翻译，为所有语言文件补充缺失的翻译条目。

Log: 补充右键菜单兼容模式安装的翻译
Influence: 修复后右键菜单"Install in compatible mode"在各语言环境下均可正确显示翻译文本。