### PR TITLE
chore: update version to 6.5.39

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deb-installer (6.5.39) unstable; urgency=medium
+
+  * fix(i18n): add missing translation for right-click compat install menu
+
+ -- Liu Zheng <liuzheng@uniontech.com>  Tue, 20 May 2026 17:47:00 +0800
+
 deepin-deb-installer (6.5.38) unstable; urgency=medium
 
   * fix(ui): improve tooltip image hover detection in compat hint label


### PR DESCRIPTION
- bump version to 6.5.39

Log : bump version to 6.5.39

## Summary by Sourcery

Bump Debian package metadata for the new 6.5.39 release version.

Build:
- Update Debian packaging changelog to reflect version 6.5.39 release.

Chores:
- Align project versioning metadata with the 6.5.39 release.