### PR TITLE
fix(ui): show correct error text and button on compat mode sig failure

### DIFF
--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -981,6 +981,20 @@ void SingleInstallPage::slotWorkerFinished()
         if (failCode == Pkg::NoDigitalSignature || failCode == Pkg::DigitalSignatureError) {
             m_backButton->setVisible(false);
             m_infoControlButton->setVisible(false);
+
+            if (m_inCompatibleMode) {
+                // In compatible mode, the confirmButton was hidden earlier; show it for
+                // signature errors so the user can close the window. Also hide the
+                // doneButton which shows "Cancel" from the compat confirm view.
+                m_confirmButton->setVisible(true);
+                m_confirmButton->setText(tr("OK", "button"));
+                m_confirmButton->setFocus();
+                m_doneButton->setVisible(false);
+
+                // Override tips text: PackageFailReasonRole returns the compat-depends
+                // hint ("try compatibility mode") which is wrong for signature errors.
+                m_tipsLabel->setTextAndTips(tr("Invalid digital signature"));
+            }
         }
     } else {
         // 正常情况不会进入此分支，如果进入此分支表明状态错误。


### PR DESCRIPTION
When signature verification fails during compatible mode package append, the main page now shows "Invalid digital signature" with an "OK" button to close the window, instead of the stale compat-depends hint text and a "Cancel" button.

兼容模式签名验证失败时，主界面显示"数字签名无效"错误提示和
"确定"按钮关闭窗口，而非依赖关系提示文本和"取消"按钮。

Log: 修复兼容模式签名验证失败时提示文本和按钮错误
PMS: BUG-362419
Influence: 兼容模式下签名验证失败场景的用户体验修复，提示信息更准确。

## Summary by Sourcery

Update the compatible mode single-install UI to handle digital signature verification failures with appropriate messaging and controls.

Bug Fixes:
- Show an 'Invalid digital signature' error message instead of the compatibility-dependency hint when signature verification fails in compatible mode.
- Display an 'OK' button (and hide the previous 'Cancel' button) so users can properly dismiss the window after a signature failure in compatible mode.