### PR TITLE
fix(ui): show correct error on compat mode install failure

### DIFF
--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -896,6 +896,14 @@ QString DebListModel::packageFailedReason(const int idx) const
         return tr("Unmatched package architecture");  // 判断是否架构冲突
     }
 
+    // When the operation has actually failed, the dependency status may be stale
+    // (e.g. CompatibleIntalled from a prior detection). Return the real error directly.
+    if (m_packageOperateStatus.contains(md5) &&
+        m_packageOperateStatus[md5] == Pkg::PackageOperationStatus::Failed) {
+        qCDebug(appLog) << "Package operation failed, returning worker error string directly";
+        return workerErrorString(m_packageFailCode[md5], m_packageFailReason[md5]);
+    }
+
     // need refactor, move to Deb::DebPackage
     int status = dependStatus.status;
     if (Pkg::CompatibleNotInstalled == status) {


### PR DESCRIPTION
When compat install fails on an already-installed package, check operation status first and return actual error instead of stale dependency status message like "Earlier version installed".

兼容模式安装失败时，优先检查操作状态返回真实错误，
而非显示过时的依赖状态信息如"已安装较早的版本"。

Log: 修复兼容模式安装失败显示错误提示的问题
Influence: 兼容模式下安装失败的包现在会显示正确的失败原因，而非误导性的版本信息。

## Summary by Sourcery

Bug Fixes:
- Fix compat-mode deb package installs showing stale dependency messages like 'Earlier version installed' when the operation has actually failed.