### PR TITLE
fix(ui): make compat mode hint icon follow system theme

### DIFF
--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -514,17 +514,10 @@ void SingleInstallPage::initPkgInstallProcessView(int fontinfosize)
     m_compatHintLabel->setWordWrap(true);
     m_compatHintLabel->setTextFormat(Qt::RichText);
     m_compatHintLabel->setAlignment(Qt::AlignCenter);
-    const QString compatHintText = tr("If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.");
+    m_compatHintText = tr("If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.");
     m_compatToolTip = tr("UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.");
-    // 将图标 pixmap 转为 base64 data URI 嵌入富文本，使图标随文本换行到最后一行末尾
-    QByteArray iconData;
-    QBuffer iconBuf(&iconData);
-    iconBuf.open(QIODevice::WriteOnly);
-    Dtk::Gui::DDciIcon tipsIcon(QString(":/icons/deepin/uab/tips.dci"));
-    tipsIcon.pixmap(qApp->devicePixelRatio(), 16, Dtk::Gui::DDciIcon::Light).save(&iconBuf, "PNG");
-    m_compatHintLabel->setText(compatHintText
-        + QString(" <img src=\"data:image/png;base64,%1\" width=\"16\" height=\"16\" style=\"vertical-align:middle;\"/>")
-              .arg(QString(iconData.toBase64())));
+    updateCompatHintIcon();
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &SingleInstallPage::updateCompatHintIcon);
     m_compatHintLabel->setMouseTracking(true);
     m_compatHintLabel->installEventFilter(this);
     m_compatHintLabel->setVisible(false);
@@ -1465,6 +1458,25 @@ bool SingleInstallPage::dependsError(int status) const
 {
     qCDebug(appLog) << "Depends error check";
     return status != Pkg::DependsOk && status != Pkg::DependsAvailable;
+}
+
+void SingleInstallPage::updateCompatHintIcon()
+{
+    const auto theme = DGuiApplicationHelper::instance()->themeType();
+    Dtk::Gui::DDciIcon tipsIcon(QString(":/icons/deepin/uab/tips.dci"));
+    const auto iconTheme = (theme == DGuiApplicationHelper::DarkType) ? Dtk::Gui::DDciIcon::Dark : Dtk::Gui::DDciIcon::Light;
+
+    DDciIconPalette dciPalette = DDciIconPalette::fromQPalette(DPaletteHelper::instance()->palette(m_compatHintLabel));
+    QPixmap px = tipsIcon.pixmap(qApp->devicePixelRatio(), 16, iconTheme, DDciIcon::Normal, dciPalette);
+
+    QByteArray iconData;
+    QBuffer iconBuf(&iconData);
+    iconBuf.open(QIODevice::WriteOnly);
+    px.save(&iconBuf, "PNG");
+
+    m_compatHintLabel->setText(m_compatHintText
+        + QString(" <img src=\"data:image/png;base64,%1\" width=\"16\" height=\"16\" style=\"vertical-align:middle;\"/>")
+              .arg(QString(iconData.toBase64())));
 }
 
 void SingleInstallPage::DealDependResult(int authStatus, QString dependName)

--- a/src/deb-installer/view/pages/singleinstallpage.h
+++ b/src/deb-installer/view/pages/singleinstallpage.h
@@ -188,6 +188,11 @@ private:
 
     bool dependsError(int status) const;
 
+    /**
+     * @brief updateCompatHintIcon 根据当前主题重新渲染 tips.dci 图标并更新提示标签
+     */
+    void updateCompatHintIcon();
+
 private slots:
 
     /**
@@ -307,6 +312,7 @@ private:
     static constexpr const char *kDefaultRootfs = "uos-rootfs-20";
     static constexpr const char *kDefaultRootfsOsName = "UOS 20";
     DLabel *m_compatHintLabel = nullptr;
+    QString m_compatHintText;
     QString m_compatToolTip;
     DCheckBox *m_compatCheckBox = nullptr;
     DLabel *m_compatDescLabel = nullptr;


### PR DESCRIPTION
The tips.dci icon uses alpha8 format, requiring DDciIconPalette for proper colorization. Pass theme-aware palette via DDciIconPalette::fromQPalette() and connect themeTypeChanged.

兼容模式提示图标使用alpha8格式，需要DDciIconPalette正确着色。
通过DDciIconPalette::fromQPalette()传入主题调色板，并连接
themeTypeChanged信号实现主题切换自动更新。

Log: 修复兼容模式提示图标不跟随系统深浅主题变化
PMS: BUG-362547
Influence: 兼容模式安装界面的提示图标现在会跟随系统深浅色主题自动切换颜色

## Summary by Sourcery

Ensure the compatibility mode hint icon follows the current system theme and updates dynamically on theme changes.

Bug Fixes:
- Fix the compatibility mode hint icon not updating its colors when the system light/dark theme changes.

Enhancements:
- Centralize rendering of the compatibility mode hint icon into a reusable method that applies theme-aware icon palettes.