### PR TITLE
fix(ui): remove OS name prefix from compat mode uninstall hint

### DIFF
--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -784,7 +784,7 @@ void SingleInstallPage::slotUninstallCurrentPackage()
         m_compatCheckBox->setVisible(false);
         m_compatDescLabel->setVisible(false);
         m_tipsLabel->setTextAndTips(
-            tr("Uninstalling %2 from %1 compatibility mode").arg(kDefaultRootfsOsName).arg(m_pkgNameDescription));
+            tr("Uninstalling %1 from compatibility mode").arg(m_pkgNameDescription));
         m_tipsLabel->setCustomDPalette(DPalette::TextLively);
         m_tipsLabel->setVisible(true);
     }

--- a/translations/deepin-deb-installer_am_ET.ts
+++ b/translations/deepin-deb-installer_am_ET.ts
@@ -499,6 +499,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -590,9 +595,8 @@
         <translation type="vanished">የ%2 የመстанов ምም የ%1 የሞድ ምረጥ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>የ%2 የመመ ምም የ%1 የሞድ ምረጥ</translation>
+        <translation type="vanished">የ%2 የመመ ምም የ%1 የሞድ ምረጥ</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_ar.ts
+++ b/translations/deepin-deb-installer_ar.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">يتم تثبيت %2 في وضع التوافق %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>إلغاء تثبيت %2 من وضع التوافق %1</translation>
+        <translation type="vanished">إلغاء تثبيت %2 من وضع التوافق %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_az.ts
+++ b/translations/deepin-deb-installer_az.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">%1 uyğunluq modunda %2 yükləyirik</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>%1 uyğunluq modundan %2 qalxalayır</translation>
+        <translation type="vanished">%1 uyğunluq modundan %2 qalxalayır</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_bg.ts
+++ b/translations/deepin-deb-installer_bg.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Показване на %2 в режим на съвместимост с %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Премахване на %2 от режим на съвместимост с %1</translation>
+        <translation type="vanished">Премахване на %2 от режим на съвместимост с %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_bn.ts
+++ b/translations/deepin-deb-installer_bn.ts
@@ -512,6 +512,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -603,9 +608,8 @@
         <translation type="vanished">%1 সহযোগিতা মডেল এ %2 ইনস্টল করার প্রচেষ্টা করা হচ্ছে</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>%1 সহযোগিতা মডেল থেকে %2 বাতিল করা হচ্ছে</translation>
+        <translation type="vanished">%1 সহযোগিতা মডেল থেকে %2 বাতিল করা হচ্ছে</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_bo.ts
+++ b/translations/deepin-deb-installer_bo.ts
@@ -503,6 +503,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -587,11 +592,6 @@
     <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
         <source>Confirm to install in compatibility mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
-        <source>Uninstalling %2 from %1 compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/deepin-deb-installer_br.ts
+++ b/translations/deepin-deb-installer_br.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">محاولة تنصيب %2 في وضع التوافق %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>إزالة %2 من وضع التوافق %1</translation>
+        <translation type="vanished">إزالة %2 من وضع التوافق %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_ca.ts
+++ b/translations/deepin-deb-installer_ca.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">S&apos;intenta instal·lar %2 en mode de compatibilitat %1.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Es desinstal·la %2 del mode de compatibilitat %1.</translation>
+        <translation type="vanished">Es desinstal·la %2 del mode de compatibilitat %1.</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_cs.ts
+++ b/translations/deepin-deb-installer_cs.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Pokus o instalaci %2 v režimu kompatibility %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Odinstalovávání %2 z režimu kompatibility %1</translation>
+        <translation type="vanished">Odinstalovávání %2 z režimu kompatibility %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_da.ts
+++ b/translations/deepin-deb-installer_da.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Forsøger at installere %2 i %1 kompatibilitetsmode</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Fjerner %2 fra %1 kompatibilitetsmode</translation>
+        <translation type="vanished">Fjerner %2 fra %1 kompatibilitetsmode</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_de.ts
+++ b/translations/deepin-deb-installer_de.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Versuche %2 im %1-Kompatibilitätsmodus zu installieren.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Deinstalliere %2 aus dem %1-Kompatibilitätsmodus</translation>
+        <translation type="vanished">Deinstalliere %2 aus dem %1-Kompatibilitätsmodus</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>

--- a/translations/deepin-deb-installer_en_US.ts
+++ b/translations/deepin-deb-installer_en_US.ts
@@ -569,9 +569,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Uninstalling %2 from %1 compatibility mode</translation>
+        <translation type="vanished">Uninstalling %2 from %1 compatibility mode</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>
@@ -590,6 +589,11 @@
     <message>
         <source>%2 has been successfully uninstalled from %1 compatibility mode</source>
         <translation type="vanished">%2 has been successfully uninstalled from %1 compatibility mode</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>

--- a/translations/deepin-deb-installer_es.ts
+++ b/translations/deepin-deb-installer_es.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Intentando instalar %2 en modo de compatibilidad %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Desinstalar %2 del modo de compatibilidad %1</translation>
+        <translation type="vanished">Desinstalar %2 del modo de compatibilidad %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_et.ts
+++ b/translations/deepin-deb-installer_et.ts
@@ -513,6 +513,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -604,9 +609,8 @@
         <translation type="vanished">Proovitakse %2 %1 kompatüübilahenduses installida</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>%2 eemaldatakse %1 kompatüübilahendustest</translation>
+        <translation type="vanished">%2 eemaldatakse %1 kompatüübilahendustest</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_fi.ts
+++ b/translations/deepin-deb-installer_fi.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Yritetään asentaa %2 %1 yhteensopivuustilassa</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Poistetaan asennusta %2 %1 yhteensopivuustilasta</translation>
+        <translation type="vanished">Poistetaan asennusta %2 %1 yhteensopivuustilasta</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_fr.ts
+++ b/translations/deepin-deb-installer_fr.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Essai de l&apos;installation de %1 dans %1 en mode compatibilité</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Désinstallation de %2 depuis %1 en mode compatibilité</translation>
+        <translation type="vanished">Désinstallation de %2 depuis %1 en mode compatibilité</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_gl_ES.ts
+++ b/translations/deepin-deb-installer_gl_ES.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">A tentar instalar %2 en modalidade de compatibilidade %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>A desinstalar %2 de modalidade de compatibilidade %1</translation>
+        <translation type="vanished">A desinstalar %2 de modalidade de compatibilidade %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_he.ts
+++ b/translations/deepin-deb-installer_he.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">התקנת %2 במצב תואמה %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>הסרת %2 מהמצב התואמה %1</translation>
+        <translation type="vanished">הסרת %2 מהמצב התואמה %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_hi_IN.ts
+++ b/translations/deepin-deb-installer_hi_IN.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">%2 को %1 संगतता मोड में इंस्टॉल करने की कोशिश कर रहे हैं</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>%2 को %1 संगतता मोड से अनइंस्टॉल कर रहे हैं</translation>
+        <translation type="vanished">%2 को %1 संगतता मोड से अनइंस्टॉल कर रहे हैं</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_hr.ts
+++ b/translations/deepin-deb-installer_hr.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Pokušavam instalirati %2 u režim kompatibilnosti %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Deinstaliramo %2 iz režima kompatibilnosti %1</translation>
+        <translation type="vanished">Deinstaliramo %2 iz režima kompatibilnosti %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_hu.ts
+++ b/translations/deepin-deb-installer_hu.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">A %2 telepítése %1 kompatibilitási módban</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>A %2 eltávolítása %1 kompatibilitási módból</translation>
+        <translation type="vanished">A %2 eltávolítása %1 kompatibilitási módból</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_id.ts
+++ b/translations/deepin-deb-installer_id.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Mencoba menginstal %2 dalam mode kompatibilitas %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Menguninstal %2 dari mode kompatibilitas %1</translation>
+        <translation type="vanished">Menguninstal %2 dari mode kompatibilitas %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_it.ts
+++ b/translations/deepin-deb-installer_it.ts
@@ -503,6 +503,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -587,11 +592,6 @@
     <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
         <source>Confirm to install in compatibility mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
-        <source>Uninstalling %2 from %1 compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/deepin-deb-installer_ja.ts
+++ b/translations/deepin-deb-installer_ja.ts
@@ -503,6 +503,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -587,11 +592,6 @@
     <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
         <source>Confirm to install in compatibility mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
-        <source>Uninstalling %2 from %1 compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/deepin-deb-installer_ko.ts
+++ b/translations/deepin-deb-installer_ko.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">%1 호환성 모드에서 %2을 설치 중입니다</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>%1 호환성 모드에서 %2을 제거 중입니다</translation>
+        <translation type="vanished">%1 호환성 모드에서 %2을 제거 중입니다</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_lo.ts
+++ b/translations/deepin-deb-installer_lo.ts
@@ -569,9 +569,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>ລື່ມ %2ຈາກແບບຄັນອັກ %1</translation>
+        <translation type="vanished">ລື່ມ %2ຈາກແບບຄັນອັກ %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>
@@ -590,6 +589,11 @@
     <message>
         <source>%2 has been successfully uninstalled from %1 compatibility mode</source>
         <translation type="vanished">ອົງປະຕິບັດທັງ່ %2 ເຊົ້າແລ້ວໄດ້ຖືກແບ່ງບອກອອກຈາກຢຸດທາງ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>

--- a/translations/deepin-deb-installer_lt.ts
+++ b/translations/deepin-deb-installer_lt.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Bandyta įdiegti %2 %1 kompatybumo režime</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Pašalina %2 iš %1 kompatybumo režimo</translation>
+        <translation type="vanished">Pašalina %2 iš %1 kompatybumo režimo</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_mn.ts
+++ b/translations/deepin-deb-installer_mn.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Дара %1 хүчинчлэлтийн үед %2-г нэмж хийж байна</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>%2-г %1 хүчинчлэлтийн үед устгаж байна</translation>
+        <translation type="vanished">%2-г %1 хүчинчлэлтийн үед устгаж байна</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_ms.ts
+++ b/translations/deepin-deb-installer_ms.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Mencuba memasang %2 dalam mod kompatibiliti %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Menguninstall %2 dari mod kompatibiliti %1</translation>
+        <translation type="vanished">Menguninstall %2 dari mod kompatibiliti %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_ne.ts
+++ b/translations/deepin-deb-installer_ne.ts
@@ -513,6 +513,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -604,9 +609,8 @@
         <translation type="vanished">%1 संगति मोडमा %2 स्थापित गर्दै</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>%1 संगति मोडबाट %2 हटाउनु</translation>
+        <translation type="vanished">%1 संगति मोडबाट %2 हटाउनु</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_nl.ts
+++ b/translations/deepin-deb-installer_nl.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Probeer %2 in de %1-compatibiliteitsmodus te installeren</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Bezig met verwijderen van %2 uit de %1-compatibiliteitsmodus…</translation>
+        <translation type="vanished">Bezig met verwijderen van %2 uit de %1-compatibiliteitsmodus…</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_pa.ts
+++ b/translations/deepin-deb-installer_pa.ts
@@ -512,6 +512,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -603,9 +608,8 @@
         <translation type="vanished">محاولة تثبيت %2 في وضع التوافق %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>إلغاء تثبيت %2 من وضع التوافق %1</translation>
+        <translation type="vanished">إلغاء تثبيت %2 من وضع التوافق %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_pl.ts
+++ b/translations/deepin-deb-installer_pl.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Próba zainstalowania %2 w trybie kompatybilności %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Odinstalowywanie %2 z trybu kompatybilności %1</translation>
+        <translation type="vanished">Odinstalowywanie %2 z trybu kompatybilności %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_pt.ts
+++ b/translations/deepin-deb-installer_pt.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Tentando instalar %2 no modo de compatibilidade %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Desinstalando %2 do modo de compatibilidade %1</translation>
+        <translation type="vanished">Desinstalando %2 do modo de compatibilidade %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_pt_BR.ts
+++ b/translations/deepin-deb-installer_pt_BR.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Tentando instalar %2 em %1 pelo modo de compatibilidade</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Desinstalando %2 de %1 pelo modo de compatibilidade</translation>
+        <translation type="vanished">Desinstalando %2 de %1 pelo modo de compatibilidade</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_ru.ts
+++ b/translations/deepin-deb-installer_ru.ts
@@ -519,6 +519,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -614,9 +619,8 @@
         <translation type="vanished">Попытка установки %2 в режиме совместимости %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Удаление %2 из режима совместимости %1</translation>
+        <translation type="vanished">Удаление %2 из режима совместимости %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_sk.ts
+++ b/translations/deepin-deb-installer_sk.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Skúša sa inštalovať %2 v režime kompatibility %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Odstanovanie %2 z režimu kompatibility %1</translation>
+        <translation type="vanished">Odstanovanie %2 z režimu kompatibility %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_sl.ts
+++ b/translations/deepin-deb-installer_sl.ts
@@ -514,6 +514,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -605,9 +610,8 @@
         <translation type="vanished">Namesto je %2 v kompatibilnostnem načinu %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Odstranjevanje %2 iz kompatibilnostnega načina %1</translation>
+        <translation type="vanished">Odstranjevanje %2 iz kompatibilnostnega načina %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_sq.ts
+++ b/translations/deepin-deb-installer_sq.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Po provohet të instalohet %2 nën mënyrën përputhje %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Po çinstalohet %2 nga mënyra përputhje %1</translation>
+        <translation type="vanished">Po çinstalohet %2 nga mënyra përputhje %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_sr.ts
+++ b/translations/deepin-deb-installer_sr.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Покушавајући да инсталирамо %2 у режиму компатибилности %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Деинсталирање %2 из режима компатибилности %1</translation>
+        <translation type="vanished">Деинсталирање %2 из режима компатибилности %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_tr.ts
+++ b/translations/deepin-deb-installer_tr.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">%1&apos;in uyumluluk modunda %2 yüklenmeye çalışılıyor</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>%1&apos;in uyumluluk modundan %2 kaldırılıyor</translation>
+        <translation type="vanished">%1&apos;in uyumluluk modundan %2 kaldırılıyor</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_ug.ts
+++ b/translations/deepin-deb-installer_ug.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">%2 %1 تېسىم ئەھۋالىنى ئۇچرىنىڭ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>%2 %1 تېسىم ئەھۋالىنى ئۇچرىنىڭ</translation>
+        <translation type="vanished">%2 %1 تېسىم ئەھۋالىنى ئۇچرىنىڭ</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_uk.ts
+++ b/translations/deepin-deb-installer_uk.ts
@@ -511,6 +511,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -602,9 +607,8 @@
         <translation type="vanished">Намагаємося встановити %2 у режимі сумісності з %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Вилучаємо %2 з режиму сумісності %1</translation>
+        <translation type="vanished">Вилучаємо %2 з режиму сумісності %1</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>

--- a/translations/deepin-deb-installer_vi.ts
+++ b/translations/deepin-deb-installer_vi.ts
@@ -514,6 +514,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
@@ -605,9 +610,8 @@
         <translation type="vanished">Đang cố gắng cài đặt %2 trong chế độ tương thích %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Gỡ cài đặt %2 từ chế độ tương thích %1</translation>
+        <translation type="vanished">Gỡ cài đặt %2 từ chế độ tương thích %1</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_zh_CN.ts
+++ b/translations/deepin-deb-installer_zh_CN.ts
@@ -505,6 +505,11 @@
         <translation>重新安装</translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation>正在从兼容模式卸载%1</translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation>%1已成功安装到兼容模式</translation>
@@ -598,9 +603,8 @@
         <translation>正在使用兼容模式安装%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>正在从%1兼容模式卸载%2</translation>
+        <translation type="vanished">正在从%1兼容模式卸载%2</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_zh_HK.ts
+++ b/translations/deepin-deb-installer_zh_HK.ts
@@ -505,6 +505,11 @@
         <translation>重新安裝</translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation>正在從兼容模式卸載%1</translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation>%1已成功安裝到兼容模式</translation>
@@ -598,9 +603,8 @@
         <translation>正在使用兼容模式安裝%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>正在從%1兼容模式卸載%2</translation>
+        <translation type="vanished">正在從%1兼容模式卸載%2</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>

--- a/translations/deepin-deb-installer_zh_TW.ts
+++ b/translations/deepin-deb-installer_zh_TW.ts
@@ -505,6 +505,11 @@
         <translation>重 裝</translation>
     </message>
     <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation>正在從相容模式卸載%1</translation>
+    </message>
+    <message>
         <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation>%1已成功安裝到相容模式</translation>
@@ -598,9 +603,8 @@
         <translation>正在使用相容模式安裝%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>正在從%1相容模式移除%2</translation>
+        <translation type="vanished">正在從%1相容模式移除%2</translation>
     </message>
     <message>
         <source>%2 was successfully installed to %1 compatibility mode</source>


### PR DESCRIPTION
Remove "UOS 20" prefix from the uninstall tip in compatibility mode, so it shows "正在从兼容模式卸载xxx" instead of
"正在从UOS 20兼容模式卸载xxx".

移除兼容模式卸载提示中的系统名称前缀，使提示信息更简洁。

Log: 去掉兼容模式卸载提示中的UOS 20前缀
PMS: BUG-362597
Influence: 兼容模式卸载时提示文本由"正在从UOS 20兼容模式卸载xxx"变为"正在从兼容模式卸载xxx"，其余语言翻译文件同步更新。