### PR TITLE
fix(ui): fix compat mode reinstall failure after auth cancel

### DIFF
--- a/src/deb-installer/model/backend/compatible_install_backend.cpp
+++ b/src/deb-installer/model/backend/compatible_install_backend.cpp
@@ -135,7 +135,6 @@ void CompatibleInstallBackend::ensureProcessor()
                         if (Pkg::ConfigAuthCancel == pkgPtr->errorCode()) {
                             m_model->m_workerStatus = AbstractPackageListModel::WorkerPrepare;
                             Q_EMIT m_model->signalAuthCancel();
-                            m_model->refreshOperatingPackageStatus(Pkg::Failed);
                             return;
                         }
                     }

--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -2145,10 +2145,8 @@ void DebListModel::ensureCompatibleProcessor()
                     }
 
                     if (Pkg::ConfigAuthCancel == pkgPtr->errorCode()) {
-                        // notify UI reset, cancel current flow
                         m_workerStatus = WorkerPrepare;
                         Q_EMIT signalAuthCancel();
-                        refreshOperatingPackageStatus(Pkg::Failed);
                         return;
                     }
                 }
@@ -2226,10 +2224,8 @@ void DebListModel::ensureImmutableProcessor()
                     }
 
                     if (Pkg::ConfigAuthCancel == pkgPtr->errorCode()) {
-                        // notify UI reset, cancel current flow
                         m_workerStatus = WorkerPrepare;
                         Q_EMIT signalAuthCancel();
-                        refreshOperatingPackageStatus(Pkg::Failed);
                         return;
                     }
                 }

--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -704,13 +704,24 @@ void SingleInstallPage::slotReinstall()
             tr("Installing in compatibility mode %1").arg(m_pkgNameDescription));
         m_tipsLabel->setCustomDPalette(DPalette::TextLively);
         m_tipsLabel->setVisible(true);
+
+        // Ensure targetRootfs is set when slotReinstall is called directly
+        // (e.g. after auth cancel via afterGetAutherFalse), bypassing the
+        // compat confirm flow where setData(targetRootfs) normally happens.
+        auto idx = m_packagesModel->index(0);
+        if (idx.data(DebListModel::CompatibleTargetRootfsRole).toString().isEmpty()) {
+            m_packagesModel->setData(idx, kDefaultRootfs, AbstractPackageListModel::CompatibleTargetRootfsRole);
+        }
     }
 
     // 重置包的工作状态
     m_operate = Reinstall;
 
     // 开始安装
-    m_packagesModel->slotInstallPackages();
+    if (!m_packagesModel->slotInstallPackages()) {
+        Q_EMIT signalBacktoFileChooseWidget();
+        return;
+    }
 }
 
 void SingleInstallPage::slotInstall()


### PR DESCRIPTION
Auth cancel handler set package status to Failed after signalAuthCancel triggered resetInstallStatus, overwriting the cleaned Prepare state. Also, slotReinstall bypassed the compat confirm flow leaving targetRootfs empty, causing installDebs to fall through to apt backend.

授权取消回调在 resetInstallStatus 之后将包状态覆盖为
Failed，且 slotReinstall 绕过确认流程导致 targetRootfs
为空，安装回退到 apt 后端而失败。

Log: 修复兼容模式授权取消后重装失败的问题
PMS: BUG-362603
Influence: 修复后兼容模式下卸载授权取消，点击重新安装按钮能正确走兼容安装流程完成重装。