### PR TITLE
fix(test): adapt unit tests for Qt6 compilation and runtime

### DIFF
--- a/src/deb-installer/model/packageselectmodel.h
+++ b/src/deb-installer/model/packageselectmodel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -40,8 +40,8 @@ struct DebIr
     QStringList virtualPackages;          // 提供的虚拟包 QApt似乎不支持读Provides项
     QList<QApt::DependencyItem> depends;  // 完整的包依赖
 
-    bool archMatched;  // 是否与当前架构匹配
-    bool isValid;  // 包是否有效（根据以前的老代码，此处如果无效，可以暂时当做未安装处理，由后续的apt安装时进行报错）
+    bool archMatched = false;  // 是否与当前架构匹配
+    bool isValid = false;  // 包是否有效（根据以前的老代码，此处如果无效，可以暂时当做未安装处理，由后续的apt安装时进行报错）
 
     bool operator==(const DebIr &rhs) { return this->md5 == rhs.md5; }
 };

--- a/src/deb-installer/utils/utils.cpp
+++ b/src/deb-installer/utils/utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -71,11 +71,11 @@ QFont Utils::loadFontBySizeAndWeight(const QString &fontFamily, int fontSize, in
 
 void Utils::bindFontBySizeAndWeight(QWidget *widget, const QString &fontFamily, int fontSize, int fontWeight)
 {
-    qCDebug(appLog) << "Binding font to widget:" << widget->objectName() << fontFamily << fontSize << fontWeight;
     if (nullptr == widget) {
         qCWarning(appLog) << "Cannot bind font to null widget";
         return;
     }
+    qCDebug(appLog) << "Binding font to widget:" << widget->objectName() << fontFamily << fontSize << fontWeight;
     QFont font = loadFontBySizeAndWeight(fontFamily, fontSize, fontWeight);
     widget->setFont(font);
 

--- a/src/deb-installer/view/pages/AptConfigMessage.cpp
+++ b/src/deb-installer/view/pages/AptConfigMessage.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -168,6 +168,12 @@ void AptConfigMessage::appendTextEdit(QString processInfo)
     int messageSize = configMessage.size();
     while (num != -1) {
         num = configMessage.indexOf("\\n");  // 获取第一行的下标
+        if (num == -1) {
+            // 没有更多换行符，将剩余内容追加后退出
+            if (configMessage.size() > 0)
+                m_textEdit->appendText(configMessage);
+            break;
+        }
 
         QString strFilter;                      // 存放第一行的数据
         strFilter = configMessage.mid(0, num);  // 截取第一行

--- a/tests/src/model/ut_deblistmodel.cpp
+++ b/tests/src/model/ut_deblistmodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -943,7 +943,7 @@ TEST_F(ut_DebListModel_test, deblistmodel_UT_ConfigReadOutput)
     stub.set(ADDR(Konsole::Pty, receivedData), model_readAllStandardOutput);
     // asan检查 内存泄露
     QString buffer = "11111111";
-    int length = sizeof(buffer);
+    int length = buffer.size();
     bool isCommandExec = false;
     m_debListModel->slotConfigReadOutput(buffer.toStdString().c_str(), length, isCommandExec);
     EXPECT_EQ(Pkg::PackageOperationStatus::Operating,

--- a/tests/src/model/ut_packagelistview.cpp
+++ b/tests/src/model/ut_packagelistview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -88,7 +88,7 @@ TEST_F(ut_packagelistview_Test, packagelistview_UT_setSelection)
 
 TEST_F(ut_packagelistview_Test, packagelistview_UT_mousePressEvent)
 {
-    QMouseEvent mousePressEvent(QEvent::MouseButtonPress, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent mousePressEvent(QEvent::MouseButtonPress, QPointF(10, 10), QPointF(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     m_listview->mousePressEvent(&mousePressEvent);
     EXPECT_TRUE(m_listview->m_bLeftMouse);
 }

--- a/tests/src/view/widgets/ut_infocontrolbutton.cpp
+++ b/tests/src/view/widgets/ut_infocontrolbutton.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -65,7 +65,7 @@ TEST_F(InfoControlButton_Test, InfoControlButton_UT_mouseReleaseEvent)
 {
     m_infoControlBtn->m_expand = true;
     m_infoControlBtn->m_expandTips = "expand";
-    QMouseEvent mouseReleaseEvent(QEvent::MouseButtonRelease, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent mouseReleaseEvent(QEvent::MouseButtonRelease, QPointF(10, 10), QPointF(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     m_infoControlBtn->mouseReleaseEvent(&mouseReleaseEvent);
     EXPECT_FALSE(m_infoControlBtn->m_expand);
     ASSERT_EQ("expand", m_infoControlBtn->m_tipsText->text());

--- a/tests/src/view/widgets/ut_showinstallinfotextedit.cpp
+++ b/tests/src/view/widgets/ut_showinstallinfotextedit.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -98,13 +98,11 @@ TEST_F(ut_showInstallInfoTextEdit_Test, ShowInstallInfoTextEdit_UT_gestureEvent)
 TEST_F(ut_showInstallInfoTextEdit_Test, ShowInstallInfoTextEdit_UT_mouseReleaseEvent)
 {
     QMouseEvent releaseEvent(QEvent::MouseButtonRelease,
-                             QPoint(0, 0),
-                             QPoint(0, 0),
-                             QPoint(0, 0),
+                             QPointF(0, 0),
+                             QPointF(0, 0),
                              Qt::LeftButton,
                              Qt::LeftButton,
-                             Qt::NoModifier,
-                             Qt::MouseEventSynthesizedByQt);
+                             Qt::NoModifier);
     m_infoTextEdit->m_gestureAction = ShowInstallInfoTextEdit::GA_slide;
     m_infoTextEdit->mouseReleaseEvent(&releaseEvent);
     EXPECT_EQ(ShowInstallInfoTextEdit::GA_null, m_infoTextEdit->m_gestureAction);
@@ -112,7 +110,7 @@ TEST_F(ut_showInstallInfoTextEdit_Test, ShowInstallInfoTextEdit_UT_mouseReleaseE
 
 TEST_F(ut_showInstallInfoTextEdit_Test, ShowInstallInfoTextEdit_UT_mouseMoveEvent)
 {
-    QMouseEvent moveEvent(QEvent::MouseMove, QPoint(0, 0), QPoint(10, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent moveEvent(QEvent::MouseMove, QPointF(0, 0), QPointF(10, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     m_infoTextEdit->mouseMoveEvent(&moveEvent);
     ASSERT_EQ(0.0, m_infoTextEdit->m_lastMousepos);
 }
@@ -123,7 +121,7 @@ TEST_F(ut_showInstallInfoTextEdit_Test, ShowInstallInfoTextEdit_UT_mouseMoveEven
     stub.set(ADDR(QMouseEvent, source), stud_source);
 
     m_infoTextEdit->m_gestureAction = ShowInstallInfoTextEdit::GA_slide;
-    QMouseEvent moveEvent(QEvent::MouseMove, QPoint(0, 0), QPoint(10, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent moveEvent(QEvent::MouseMove, QPointF(0, 0), QPointF(10, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     m_infoTextEdit->mouseMoveEvent(&moveEvent);
     ASSERT_EQ(0.0, m_infoTextEdit->m_lastMousepos);
 }


### PR DESCRIPTION
Adapt QMouseEvent constructors to Qt6 signature (QPointF, 6-param). Fix sizeof(QString) misuse causing stack overflow on Qt6. Fix null deref in bindFontBySizeAndWeight before null check. Fix AptConfigMessage while loop mid() out-of-bounds on Qt6. Initialize DebIr bool members to prevent UB from uninitialized reads.

适配单元测试到Qt6环境：修复QMouseEvent构造函数签名、
sizeof(QString)误用、空指针解引用、mid()越界及未初始化成员。

Log: 修复单元测试Qt6编译和运行兼容性
Influence: 单元测试可在Qt6环境下正常编译运行，修复了多处ASAN检测到的内存安全问题。