### PR TITLE
fix(compat): check arch mismatch before force compatible mode

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -251,6 +251,13 @@ PackageDependsStatus PackagesManager::checkDependsStatus(const QString &package_
         return dependsStatus;
     }
 
+    if (isArchErrorQstring(package_path)) {
+        qCDebug(appLog) << "Architecture error, returning arch break status.";
+        dependsStatus.status = Pkg::DependsStatus::ArchBreak;
+        dependsStatus.package = debFile.packageName();
+        return dependsStatus;
+    }
+
     if (s_forceCompatible) {
         auto compPkgPtr = CompBackend::instance()->containsPackage(debFile.packageName());
         if (compPkgPtr && compPkgPtr->installed()) {
@@ -262,14 +269,6 @@ PackageDependsStatus PackagesManager::checkDependsStatus(const QString &package_
         qCInfo(appLog) << "Force compatible mode for package:" << debFile.packageName();
         s_forceCompatible = false;
         return dependsStatus;
-    }
-
-    if (isArchErrorQstring(package_path)) {
-        qCDebug(appLog) << "Architecture error, returning arch break status.";
-        dependsStatus.status = Pkg::DependsStatus::ArchBreak;  // 添加ArchBreak错误。
-        dependsStatus.package = debFile.packageName();
-        QString packageName = debFile.packageName();
-        return PackageDependsStatus::_break(packageName);
     }
 
     // conflicts
@@ -1111,6 +1110,14 @@ PackageDependsStatus PackagesManager::getPackageDependsStatus(const int index)
         return dependsStatus;
     }
 
+    if (isArchError(index)) {
+        qCDebug(appLog) << "Package is in arch error:" << debFile.packageName();
+        dependsStatus.status = Pkg::DependsStatus::ArchBreak;  // 添加ArchBreak错误。
+        dependsStatus.package = debFile.packageName();
+        m_packageMd5DependsStatus.insert(currentPackageMd5, dependsStatus);  // 更换依赖的存储方式
+        return dependsStatus;
+    }
+
     if (s_forceCompatible) {
         auto compPkgPtr = CompBackend::instance()->containsPackage(debFile.packageName());
         if (compPkgPtr && compPkgPtr->installed()) {
@@ -1122,14 +1129,6 @@ PackageDependsStatus PackagesManager::getPackageDependsStatus(const int index)
         m_packageMd5DependsStatus.insert(currentPackageMd5, dependsStatus);
         qCInfo(appLog) << "Force compatible mode for package:" << debFile.packageName();
         s_forceCompatible = false;
-        return dependsStatus;
-    }
-
-    if (isArchError(index)) {
-        qCDebug(appLog) << "Package is in arch error:" << debFile.packageName();
-        dependsStatus.status = Pkg::DependsStatus::ArchBreak;  // 添加ArchBreak错误。
-        dependsStatus.package = debFile.packageName();
-        m_packageMd5DependsStatus.insert(currentPackageMd5, dependsStatus);  // 更换依赖的存储方式
         return dependsStatus;
     }
 


### PR DESCRIPTION
Move isArchError() check before s_forceCompatible check in both getPackageDependsStatus() and checkDependsStatus() to ensure architecture validation is not skipped when entering compat mode via right-click menu.

在 getPackageDependsStatus() 和 checkDependsStatus() 中将 isArchError() 检查移至 s_forceCompatible 之前，确保通过
右键菜单进入兼容模式时架构校验不被跳过。

Log: 兼容模式安装架构不匹配包时应提示架构错误
PMS: BUG-364455
Influence: 通过右键菜单兼容模式安装架构不匹配的deb包时，现在会正确提示架构不匹配错误，与普通安装流程行为一致。

## Summary by Sourcery

Bug Fixes:
- Prevent architecture validation from being skipped when installing deb packages via forced compatibility mode, aligning compat installs with normal install behavior.