### PR TITLE
feat: auto-update apt cache on startup when sources change

### DIFF
--- a/src/deb-installer/model/packageanalyzer.cpp
+++ b/src/deb-installer/model/packageanalyzer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,6 +9,7 @@
 #include <QThread>
 #include <QApplication>
 #include <QMetaType>
+#include <QDir>
 
 #include <QApt/Backend>
 #include <QApt/DebFile>
@@ -73,6 +74,62 @@ void PackageAnalyzer::initBackend()
 bool PackageAnalyzer::isBackendReady()
 {
     return backend != nullptr;
+}
+
+QDateTime PackageAnalyzer::getSourcesLastModified() const
+{
+    QDateTime latestModified;
+
+    // 1. 检查主源文件
+    QFileInfo mainSources("/etc/apt/sources.list");
+    if (mainSources.exists()) {
+        latestModified = mainSources.lastModified();
+    }
+
+    // 2. 遍历 sources.list.d 目录下的所有 .list 文件
+    QDir sourcesDir("/etc/apt/sources.list.d");
+    if (sourcesDir.exists()) {
+        QFileInfoList listFiles = sourcesDir.entryInfoList(
+            QStringList() << "*.list",
+            QDir::Files | QDir::NoDotAndDotDot
+        );
+
+        for (const QFileInfo &file : listFiles) {
+            if (!latestModified.isValid() ||
+                file.lastModified() > latestModified) {
+                latestModified = file.lastModified();
+            }
+        }
+    }
+
+    return latestModified;
+}
+
+QDateTime PackageAnalyzer::getCacheLastModified() const
+{
+    QFileInfo cacheFile("/var/cache/apt/pkgcache.bin");
+    if (cacheFile.exists()) {
+        return cacheFile.lastModified();
+    }
+    return QDateTime(); // 返回无效时间
+}
+
+bool PackageAnalyzer::shouldUpdateCache() const
+{
+    // 如果缓存文件不存在，需要更新
+    QDateTime cacheTime = getCacheLastModified();
+    if (!cacheTime.isValid()) {
+        return true;
+    }
+
+    // 如果源文件不存在或无法访问，保守起见不更新
+    QDateTime sourcesTime = getSourcesLastModified();
+    if (!sourcesTime.isValid()) {
+        return false;
+    }
+
+    // 核心判断：源文件的修改时间是否晚于缓存文件
+    return sourcesTime > cacheTime;
 }
 
 QApt::Backend *PackageAnalyzer::backendPtr()

--- a/src/deb-installer/model/packageanalyzer.h
+++ b/src/deb-installer/model/packageanalyzer.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,6 +8,8 @@
 #include "model/packageselectmodel.h"
 
 #include <QObject>
+#include <QDateTime>
+#include <QFileInfo>
 #include <atomic>
 
 namespace QApt {
@@ -39,6 +41,10 @@ public:
     void initBackend();
     bool isBackendReady();
     QApt::Backend *backendPtr();
+
+    // 判断是否需要更新软件包缓存
+    // 基于文件时间戳比较：比较源文件和缓存文件的修改时间
+    bool shouldUpdateCache() const;
 
     //选择阶段
 
@@ -94,6 +100,12 @@ private:
     QString resolvMultiArchAnnotation(const QString &annotation,
                                       const QString &debArch,
                                       int multiArchType) const;
+
+    // 获取APT源文件的最新修改时间
+    QDateTime getSourcesLastModified() const;
+
+    // 获取APT缓存文件的修改时间
+    QDateTime getCacheLastModified() const;
 
     explicit PackageAnalyzer(QObject *parent = nullptr);
     PackageAnalyzer(const PackageAnalyzer &) = delete;

--- a/src/deb-installer/view/pages/backendprocesspage.cpp
+++ b/src/deb-installer/view/pages/backendprocesspage.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -30,6 +30,8 @@ void BackendProcessPage::setDisplayPage(DisplayMode mode)
     if (mode == APT_INIT) {
         allLayout->setCurrentWidget(noProcessWidget);
         noProcessWidget->start();
+    } else if (mode == APT_UPDATE_CACHE) {
+        noProcessWidget->setActionText(tr("Updating package cache..."));
     } else if (mode == READ_PKG) {
         allLayout->setCurrentWidget(processWidget);
         noProcessWidget->stop();

--- a/src/deb-installer/view/pages/backendprocesspage.h
+++ b/src/deb-installer/view/pages/backendprocesspage.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,9 +16,10 @@ class BackendProcessPage : public QWidget
     Q_OBJECT
 public:
     enum DisplayMode {
-        APT_INIT,   //apt初始化
-        READ_PKG,   //读取包数据
-        PROCESS_FIN //处理结束
+        APT_INIT,    // apt初始化
+        APT_UPDATE_CACHE, // 更新缓存
+        READ_PKG,    // 读取包数据
+        PROCESS_FIN  // 处理结束
     };
 
     explicit BackendProcessPage(QWidget *parent = nullptr);

--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -42,6 +42,8 @@
 #include <QJsonObject>
 #include <QFileInfo>
 #include <QtConcurrent/QtConcurrent>
+
+#include <QApt/Transaction>
 
 using QApt::DebFile;
 
@@ -182,7 +184,8 @@ void DebInstaller::initConnections()
         if (inProcess) {
             slotShowPkgProcessBlockPage(BackendProcessPage::APT_INIT, 0, 0);
         } else {
-            slotShowPkgProcessBlockPage(BackendProcessPage::PROCESS_FIN, 0, 0);
+            // 按需更新缓存（非强制）
+            updatePackageCache(false);
         }
     });
 
@@ -461,13 +464,23 @@ void DebInstaller::slotPackagesSelected(const QStringList &packagesPathList)
             || DebListModel::AuthPop == m_wineAuthStatus
             || DebListModel::AuthConfirm == m_wineAuthStatus
             || DebListModel::AuthDependsErr == m_wineAuthStatus) {
-    } else {
-        // 下一指令第1个包大小较大时，解析操作会阻塞当前线程，导致界面设置的逻辑顺序出现混乱，优先处理界面交互，然后再执行加载
-        qApp->processEvents();
-
-        //开始添加包，将要添加的包传递到后端，添加包由后端处理
-        m_fileListModel->slotAppendPackage(packagesPathList);
+        return;
     }
+
+    // 如果后端已就绪但缓存检查尚未完成，说明在缓存刷新之前
+    // 包就到达了（如双击deb包启动）。此时暂存包路径，
+    // 等待缓存刷新完成后再处理，确保依赖分析使用最新缓存数据。
+    if (PackageAnalyzer::instance().isBackendReady() && !m_cacheCheckDone) {
+        qInfo() << "Cache check pending, deferring package addition until cache is updated";
+        m_pendingPackages = packagesPathList;
+        return;
+    }
+
+    // 下一指令第1个包大小较大时，解析操作会阻塞当前线程，导致界面设置的逻辑顺序出现混乱，优先处理界面交互，然后再执行加载
+    qApp->processEvents();
+
+    //开始添加包，将要添加的包传递到后端，添加包由后端处理
+    m_fileListModel->slotAppendPackage(packagesPathList);
 }
 
 void DebInstaller::slotDdimSelected(const QStringList &ddimFiles)
@@ -923,6 +936,91 @@ void DebInstaller::slotShowHiddenButton()
         if (multiplePage) { //批量安装显示按钮
             multiplePage->afterGetAutherFalse();
         }
+    }
+}
+
+void DebInstaller::slotUpdateCacheFinished()
+{
+    Transaction *transaction = qobject_cast<Transaction *>(sender());
+    if (transaction) {
+        disconnect(transaction, &Transaction::finished, this, &DebInstaller::slotUpdateCacheFinished);
+
+        if (transaction->exitStatus() == QApt::ExitSuccess) {
+            if (auto backend = PackageAnalyzer::instance().backendPtr())
+                backend->reloadCache();
+        }
+        transaction->deleteLater();
+    }
+
+    m_cacheCheckDone = true;
+    slotShowPkgProcessBlockPage(BackendProcessPage::PROCESS_FIN, 0, 0);
+
+    // 缓存更新完成后，处理在缓存检查之前到达的待处理包
+    processPendingPackages();
+}
+
+void DebInstaller::updatePackageCache(bool force)
+{
+    // 如果不是强制更新，先判断是否需要更新
+    if (!force && !PackageAnalyzer::instance().shouldUpdateCache()) {
+        m_cacheCheckDone = true;
+        slotShowPkgProcessBlockPage(BackendProcessPage::PROCESS_FIN, 0, 0);
+        processPendingPackages();
+        return;
+    }
+
+    slotShowPkgProcessBlockPage(BackendProcessPage::APT_UPDATE_CACHE, 0, 0);
+    auto backend = PackageAnalyzer::instance().backendPtr();
+    if (!backend) {
+        m_cacheCheckDone = true;
+        slotShowPkgProcessBlockPage(BackendProcessPage::PROCESS_FIN, 0, 0);
+        processPendingPackages();
+        return;
+    }
+
+    auto transaction = backend->updateCache();
+    if (!transaction) {
+        m_cacheCheckDone = true;
+        slotShowPkgProcessBlockPage(BackendProcessPage::PROCESS_FIN, 0, 0);
+        processPendingPackages();
+        return;
+    }
+
+    transaction->setLocale(".UTF-8");
+    connect(transaction, &Transaction::finished, this, &DebInstaller::slotUpdateCacheFinished);
+
+    // 缓存更新过程中的错误处理（包括鉴权失败）
+    // 当用户取消授权对话框时，transaction 触发 errorOccurred(AuthError)，
+    // 但 finished 信号可能不会随之触发，导致阻塞页面无法自动关闭。
+    // 此处统一处理所有错误：关闭阻塞页面并继续处理待添加的包。
+    connect(transaction, &Transaction::errorOccurred, this, [this](QApt::ErrorCode error) {
+        auto *trans = qobject_cast<Transaction *>(sender());
+        if (!trans)
+            return;
+
+        if (error == QApt::AuthError) {
+            qWarning() << "Cache update canceled by user (auth failed)";
+        }
+
+        // 断开 finished 信号，避免 errorOccurred 和 finished 同时触发导致重复处理
+        disconnect(trans, &Transaction::finished, this, &DebInstaller::slotUpdateCacheFinished);
+        trans->deleteLater();
+
+        m_cacheCheckDone = true;
+        slotShowPkgProcessBlockPage(BackendProcessPage::PROCESS_FIN, 0, 0);
+        processPendingPackages();
+    });
+
+    transaction->run();
+}
+
+void DebInstaller::processPendingPackages()
+{
+    if (!m_pendingPackages.isEmpty()) {
+        QStringList packages = m_pendingPackages;
+        m_pendingPackages.clear();
+        qInfo() << "Processing" << packages.size() << "deferred packages after cache update";
+        slotPackagesSelected(packages);
     }
 }
 

--- a/src/deb-installer/view/pages/debinstaller.h
+++ b/src/deb-installer/view/pages/debinstaller.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -60,6 +60,8 @@ private slots:
      * 添加包时，对包进行处理，去除无效的包，提示已经添加过的包，并根据添加包的数量刷新界面
      */
     void slotPackagesSelected(const QStringList &packages);
+
+    void slotUpdateCacheFinished();
 
     /**
      * @brief slotDdimSelected
@@ -321,6 +323,18 @@ private:
      */
     DdimSt analyzeV10(const QJsonObject &ddimobj, const QString &ddimDir);
 
+    /**
+     * @brief updatePackageCache 更新软件包缓存
+     * @param force 是否强制更新（默认false，按需更新）
+     */
+    void updatePackageCache(bool force = false);
+
+    /**
+     * @brief processPendingPackages 处理在缓存更新前到达的待处理包
+     * 在缓存检查/更新完成后调用，确保包分析使用最新缓存数据。
+     */
+    void processPendingPackages();
+
 private:
     DebListModel        *m_fileListModel      = nullptr;                  //model 类
     FileChooseWidget    *m_fileChooseWidget   = nullptr;           //文件选择的widget
@@ -346,6 +360,9 @@ private:
 
     bool m_packageAppending = false;
     int m_wineAuthStatus = -1; //记录依赖配置授权状态
+
+    QStringList m_pendingPackages;  // 缓存更新前到达的待处理包
+    bool        m_cacheCheckDone = false; // 标记是否已完成缓存检查
 };
 
 #endif  // DEBINSTALLER_H


### PR DESCRIPTION
    Trigger an apt cache update after backend initialization only when the
    source list files have been modified since the last cache was built.
    This ensures dependency resolution is accurate without running apt
    update on every startup, reducing unnecessary network usage.
    
    The update is skipped if:
    - The cache file is newer than all source list files
    - Source list files cannot be read (conservative fallback)
    
    log: auto apt update
    
    task: https://pms.uniontech.com/task-view-390819.html