### PR TITLE
fix: add null pointer checks for package objects

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -464,7 +464,7 @@ const ConflictResult PackagesManager::isInstalledConflict(const QString &package
             Conflicts: ImageEnhance
             Replaces: ImageEnhnace
         */
-        if (pkg->name() == info.first) {
+        if (pkg && pkg->name() == info.first) {
             continue;
         }
 

--- a/src/deepin-deb-installer-dev/manager/PackagesManager.cpp
+++ b/src/deepin-deb-installer-dev/manager/PackagesManager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -71,6 +71,10 @@ void PackagesManager::slot_getDependsStatus(int index, DependsStatus dependsStat
 void PackagesManager::slot_getInstallStatus(int index, InstallStatus installStatus)
 {
     Package *pkg = searchByIndex(index);
+    if (!pkg) {
+        qWarning() << "[PackagesManager]<< slot_getInstallStatus" << "Package not found for index:" << index;
+        return;
+    }
     pkg->setPackageInstallStatus(installStatus);
     if (!m_appendFinished) {
         m_appendFinished = true;


### PR DESCRIPTION
Add null pointer protection in isInstalledConflict() before accessing pkg->name(), and in slot_getInstallStatus() before using the result of searchByIndex().

修复 isInstalledConflict() 和 slot_getInstallStatus() 中的包对象空指针解引用问题，避免 SIGSEGV 崩溃。

Log: 修复包对象空指针导致的闪退问题
PMS: BUG-366073
Influence: 修复后安装未在仓库注册的本地 deb 包不再因空指针崩溃，
改为正常处理或给出错误提示。

## Summary by Sourcery

Prevent crashes caused by null package objects when checking installation status and conflicts.

Bug Fixes:
- Handle missing package objects in slot_getInstallStatus() by early-returning with a warning instead of dereferencing a null pointer.
- Guard conflict checks in isInstalledConflict() against null package pointers to avoid SIGSEGV when accessing package names.