### PR TITLE
fix: restore UI state properly after authorization check

### DIFF
--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -1200,6 +1200,9 @@ void SingleInstallPage::showPackageInfo()
 
         // 根据安装状态设置提示文字
         if (installed) {
+            // Ensure tips label is visible when showing status message
+            // (it may have been hidden during uninstall operation)
+            m_tipsLabel->setVisible(true);
             if (installStat == Pkg::PackageInstallStatus::InstalledSameVersion) {
                 qCDebug(appLog) << "Same version installed";
                 m_tipsLabel->setCustomDPalette(DPalette::TextWarning);
@@ -1273,22 +1276,11 @@ void SingleInstallPage::afterGetAutherFalse()
     m_progressFrame->setVisible(false);
     m_btnsFrame->setVisible(true);
 
-    // 根据安装场景显示按钮
-    if (m_operate == Install) {
-        qCDebug(appLog) << "Install operation, show install button";
-        m_installButton->setVisible(true);
-        m_installButton->setFocus();
-    } else if (m_operate == Uninstall) {
-        qCDebug(appLog) << "Uninstall operation, show reinstall and uninstall buttons";
-        m_reinstallButton->setVisible(true);
-        m_uninstallButton->setVisible(true);
-        m_reinstallButton->setFocus();
-    } else if (m_operate == Reinstall) {
-        qCDebug(appLog) << "Reinstall operation, show reinstall and uninstall buttons";
-        m_reinstallButton->setVisible(true);
-        m_uninstallButton->setVisible(true);
-        m_reinstallButton->setFocus();
-    }
+    // Call showPackageInfo() to properly restore UI state including:
+    // - Tips label text (fixes issue #1: prompt text not restored)
+    // - Button visibility state (fixes issue #2: duplicate reinstall buttons)
+    // This ensures consistent state management instead of manually managing buttons here.
+    showPackageInfo();
 
     if (m_showRemovePackages) {
         qCDebug(appLog) << "Show remove packages, show depends button";


### PR DESCRIPTION
1. Ensure tips label is visible when showing package info after
uninstall
   (it may have been hidden during uninstall operation)
2. Replace manual button visibility logic in afterGetAutherFalse() with
a call to
   showPackageInfo(), which restores both tips text and button states
consistently
3. This fixes two issues: #1 – prompt text not restored after unloading
   #2 – duplicate reinstall buttons appearing after authentication
failure

Log: Fixed UI state restoration after authorization failure, ensuring
correct prompt text and button visibility

Influence:
1. Test uninstalling a package, then triggering an auth failure – verify
that
   the tips label is shown and the text is correct (e.g. "same version
installed")
2. Test install/reinstall/uninstall scenarios where authorization fails
–
   verify that the buttons shown are appropriate for the original
operation
3. Check that no duplicate reinstall buttons appear after auth failure
4. Verify that the tips label visibility remains correct during normal
flow

fix: 在授权检查后正确恢复UI状态

1. 确保在显示包信息时提示标签可见（卸载操作后可能被隐藏）
2. 将afterGetAutherFalse()中手动控制按钮可见性的逻辑替换为调用
showPackageInfo()，
   统一恢复提示文本和按钮状态
3. 修复两个问题：#1 – 卸载后提示文本未恢复；#2 – 认证失败后出现重复的重
新安装按钮

Log: 修复授权失败后UI状态恢复，确保提示文字和按钮显示正确

Influence:
1. 测试卸载包后触发认证失败，验证提示标签可见且文字正确（例如"已安装相同
版本"）
2. 测试安装/重新安装/卸载操作中认证失败，验证显示的按钮与原操作匹配
3. 检查认证失败后不会出现重复的重新安装按钮
4. 验证正常流程中提示标签可见性始终正确

BUG: https://pms.uniontech.com/bug-view-362603.html
