### PR TITLE
fix(compat): titlebar只在checkbox确认界面显示兼容模式安装

### DIFF
--- a/src/deb-installer/singleInstallerApplication.cpp
+++ b/src/deb-installer/singleInstallerApplication.cpp
@@ -83,6 +83,8 @@ void SingleInstallerApplication::activateWindow()
 void SingleInstallerApplication::InstallerDeb(const QStringList &debPathList)
 {
     qCInfo(appLog) << "InstallerDeb called with" << debPathList.size() << "packages";
+    // 复位兼容标志，防止同一实例内"先兼容安装、后普通安装"时标志串味
+    s_forceCompatible = false;
     if (!debPathList.isEmpty())
         setHasPackages(true);
     if (mode == DdimChannel) {
@@ -105,6 +107,9 @@ void SingleInstallerApplication::InstallerDeb(const QStringList &debPathList)
 void SingleInstallerApplication::InstallerDebCompatible(const QStringList &debPathList)
 {
     qCInfo(appLog) << "InstallerDebCompatible called with" << debPathList.size() << "packages";
+    // 同步 app 级标志，避免 D-Bus 单实例转发路径下 s_forceCompatible 为过期值
+    // （老实例在 parseCmdLine 时未带 --compatible，s_forceCompatible 默认为 false）
+    s_forceCompatible = true;
     if (!debPathList.isEmpty()) {
         setHasPackages(true);
         PackagesManager::setForceCompatible(true);

--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -1145,27 +1145,26 @@ void DebInstaller::refreshSingle()
         m_lastPage->deleteLater();  // 清除widgets缓存
     }
     // 安装器中只有一个包，刷新单包安装页面
-    // 刷新成单包安装界面时，删除标题
+    // 重置标题栏（依赖不满足的界面不显示兼容模式标题，只在 checkbox 确认界面才显示）
     titlebar()->setTitle(QString());
 
-    // check if single package in compatible mode
-    const QModelIndex singleIdx = m_fileListModel->index(0);
-    const int compatStat = singleIdx.data(DebListModel::PackageDependsStatusRole).toInt();
-    if (Pkg::CompatibleNotInstalled == compatStat || Pkg::CompatibleIntalled == compatStat) {
-        const QString compatTitle = tr("Compatible Mode Install");
-        titlebar()->setTitle(compatTitle);
-        for (auto *label : titlebar()->findChildren<QLabel *>()) {
-            if (label->text() == compatTitle) {
-                QFont f = label->font();
-                f.setBold(true);
-                label->setFont(f);
-                break;
-            }
-        }
-    }
-
+    // 先创建 SingleInstallPage，在其构造函数中 initUI() 会立即调用 showCompatConfirmView()
+    // 所以必须先连接信号，确保 showCompatConfirmView() 发出的 signalSetTitlebarText 能被捕获
     SingleInstallPage *singlePage = new SingleInstallPage(m_fileListModel);
     singlePage->setObjectName("SingleInstallPage");
+    connect(singlePage, &SingleInstallPage::signalSetTitlebarText, this, [this](const QString &text) {
+        titlebar()->setTitle(text);
+        if (!text.isEmpty()) {
+            for (QLabel *label : titlebar()->findChildren<QLabel *>()) {
+                if (label->text() == text) {
+                    QFont f = label->font();
+                    f.setBold(true);
+                    label->setFont(f);
+                    break;
+                }
+            }
+        }
+    });
     connect(singlePage, &SingleInstallPage::signalBacktoFileChooseWidget, this, &DebInstaller::slotReset);
     connect(singlePage, &SingleInstallPage::signalRequestUninstallConfirm, this, &DebInstaller::slotShowUninstallConfirmPage);
 
@@ -1174,6 +1173,8 @@ void DebInstaller::refreshSingle()
 
     // 兼容模式下禁止拖入追加包，避免从兼容模式单安装页面切换到批量安装页面
     // Log: task-389473 屏蔽兼容模式下添加更多包的入口
+    const QModelIndex idx = m_fileListModel->index(0);
+    const int compatStat = idx.data(DebListModel::PackageDependsStatusRole).toInt();
     const bool compatMode = (compatStat == Pkg::CompatibleNotInstalled || compatStat == Pkg::CompatibleIntalled);
 
     // 重置安装器拖入的状态与工作的状态

--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "singleinstallpage.h"
+#include "singleInstallerApplication.h"
 #include "model/deblistmodel.h"
 #include "view/widgets/workerprogress.h"
 #include "utils/utils.h"
@@ -106,6 +107,14 @@ void SingleInstallPage::initUI()
     // update show info, must call before refresh depends
     showPackageInfo();
     connect(m_packagesModel, &AbstractPackageListModel::dataChanged, this, [this]() { showPackageInfo(); });
+
+    // 右键菜单"兼容模式安装"入口（--compatible 强制兼容）：直接进入 checkbox 二次确认视图，跳过第一视图
+    // 双击 deb 自动识别为兼容的不受 s_forceCompatible 影响，仍走原第一视图
+    // 注意：不能在构造函数中直接调用 showCompatConfirmView()，因为此时信号还未连接
+    // 使用 QTimer::singleShot 延迟到事件循环处理，确保 showCompatConfirmView() 发出的信号能被 DebInstaller 捕获
+    if (SingleInstallerApplication::s_forceCompatible && m_inCompatibleMode) {
+        QTimer::singleShot(0, this, [this]() { showCompatConfirmView(); });
+    }
     qCDebug(appLog) << "UI initialized";
 }
 
@@ -1249,6 +1258,10 @@ void SingleInstallPage::showCompatConfirmView()
     m_confirmButton->setVisible(true);
     m_confirmButton->setFocus();
     m_btnsLayout->setSpacing(20);
+
+    // 通知父窗口设置 titlebar 为兼容模式安装
+    const QString compatTitle = tr("Compatible Mode Install");
+    Q_EMIT signalSetTitlebarText(compatTitle);
 }
 
 void SingleInstallPage::setEnableButton(bool bEnable)

--- a/src/deb-installer/view/pages/singleinstallpage.h
+++ b/src/deb-installer/view/pages/singleinstallpage.h
@@ -79,6 +79,12 @@ signals:
      */
     void signalRequestUninstallConfirm() const;
 
+    /**
+     * @brief signalSetTitlebarText 设置 titlebar 标题文本
+     * @param text 标题文本，为空时清除标题
+     */
+    void signalSetTitlebarText(const QString &text) const;
+
 private:
     /**
      * @brief The current operate

--- a/translations/deepin-deb-installer.ts
+++ b/translations/deepin-deb-installer.ts
@@ -4,115 +4,99 @@
 <context>
     <name>AptConfigMessage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
         <source>Enter the number to configure: </source>
-        <translation>Enter the number to configure: </translation>
+        <translation type="vanished">Enter the number to configure: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation>OK</translation>
+        <translation type="vanished">OK</translation>
     </message>
 </context>
 <context>
     <name>BackendProcessPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
         <source>Loading packages...</source>
-        <translation>Loading packages...</translation>
+        <translation type="vanished">Loading packages...</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
         <source>%1/%2 loaded</source>
-        <translation>%1/%2 loaded</translation>
+        <translation type="vanished">%1/%2 loaded</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
         <source>Initializing...</source>
-        <translation>Initializing...</translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
-        <source>Updating package cache...</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">Initializing...</translation>
     </message>
 </context>
 <context>
     <name>DdimErrorPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
         <source>OK</source>
-        <translation>OK</translation>
+        <translation type="vanished">OK</translation>
     </message>
 </context>
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Package Installer</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Installing other packages... Please open it later.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Parsing failed: An illegal file structure was found in the manifest file!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Parsing failed: An illegal version number was found in the manifest file!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>No deb packages found. Please check the folder.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Already Added</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 does not exist, please reselect</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Bulk Install</translation>
     </message>
@@ -120,60 +104,36 @@
 <context>
     <name>DebListModel</name>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="113"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="136"/>
         <source>Installation failed, please check your network connection</source>
-        <translation>Installation failed, please check your network connection</translation>
+        <translation type="vanished">Installation failed, please check your network connection</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="117"/>
         <source>Installation failed, please check for updates in Control Center</source>
-        <translation>Installation failed, please check for updates in Control Center</translation>
+        <translation type="vanished">Installation failed, please check for updates in Control Center</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="120"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="126"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="142"/>
         <source>Installation failed, insufficient disk space</source>
-        <translation>Installation failed, insufficient disk space</translation>
+        <translation type="vanished">Installation failed, insufficient disk space</translation>
     </message>
     <message>
         <source>No digital signature</source>
         <translation type="vanished">No digital signature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="148"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="153"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="962"/>
         <source>Invalid digital signature</source>
-        <translation>Invalid digital signature</translation>
+        <translation type="vanished">Invalid digital signature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="161"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="947"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
         <source>The administrator has set policies to prevent installation of this package</source>
-        <translation>The administrator has set policies to prevent installation of this package</translation>
+        <translation type="vanished">The administrator has set policies to prevent installation of this package</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="168"/>
         <source>Installation Failed</source>
-        <translation>Installation Failed</translation>
+        <translation type="vanished">Installation Failed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="940"/>
-        <source>Broken dependencies, try installing the app in compatibility mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="943"/>
-        <source>Compatibility mode installation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="965"/>
         <source>Failed to install %1</source>
-        <translation>Failed to install %1</translation>
+        <translation type="vanished">Failed to install %1</translation>
     </message>
     <message>
         <source>Unable to install - no digital signature</source>
@@ -184,250 +144,190 @@
         <translation type="vanished">Please go to Control Center to enable developer mode and try again. Proceed?</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation>Cancel</translation>
+        <translation type="vanished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
         <source>Proceed</source>
         <comment>button</comment>
-        <translation>Proceed</translation>
+        <translation type="vanished">Proceed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation>OK</translation>
+        <translation type="vanished">OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="930"/>
         <source>Same version installed</source>
-        <translation type="unfinished">Same version installed</translation>
+        <translation type="obsolete">Same version installed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="932"/>
         <source>Later version installed: %1</source>
-        <translation type="unfinished">Later version installed: %1</translation>
+        <translation type="obsolete">Later version installed: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="934"/>
         <source>Earlier version installed: %1</source>
-        <translation type="unfinished">Earlier version installed: %1</translation>
+        <translation type="obsolete">Earlier version installed: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
-        <source>Installation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
-        <source>Failed to install %1: no valid digital signature</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
         <source>This package does not have a valid digital signature. Continue with the installation?</source>
-        <translation>This package does not have a valid digital signature. Continue with the installation?</translation>
+        <translation type="vanished">This package does not have a valid digital signature. Continue with the installation?</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
         <source>Cancel</source>
-        <translation>Cancel</translation>
+        <translation type="vanished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
         <source>Continue</source>
         <comment>button</comment>
-        <translation>Continue</translation>
+        <translation type="vanished">Continue</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
         <source>Unable to install</source>
-        <translation>Unable to install</translation>
+        <translation type="vanished">Unable to install</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
         <source>This package does not have a valid digital signature</source>
-        <translation>This package does not have a valid digital signature</translation>
+        <translation type="vanished">This package does not have a valid digital signature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="969"/>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="975"/>
         <source>Broken dependencies: %1</source>
-        <translation>Broken dependencies: %1</translation>
+        <translation type="vanished">Broken dependencies: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="158"/>
         <source>Authentication failed</source>
-        <translation>Authentication failed</translation>
+        <translation type="vanished">Authentication failed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="896"/>
         <source>Unmatched package architecture</source>
-        <translation>Unmatched package architecture</translation>
+        <translation type="vanished">Unmatched package architecture</translation>
     </message>
 </context>
 <context>
     <name>FileChooseWidget</name>
     <message>
-        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
         <source>Drag deb packages here</source>
-        <translation>Drag deb packages here</translation>
+        <translation type="vanished">Drag deb packages here</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
         <source>Select File</source>
-        <translation>Select File</translation>
+        <translation type="vanished">Select File</translation>
     </message>
 </context>
 <context>
     <name>MultipleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
         <source>Show details</source>
-        <translation>Show details</translation>
+        <translation type="vanished">Show details</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
         <source>Collapse</source>
         <comment>button</comment>
-        <translation>Collapse</translation>
+        <translation type="vanished">Collapse</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
         <source>Install</source>
         <comment>button</comment>
-        <translation>Install</translation>
+        <translation type="vanished">Install</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
         <source>Done</source>
         <comment>button</comment>
-        <translation>Done</translation>
+        <translation type="vanished">Done</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
         <source>Back</source>
         <comment>button</comment>
-        <translation>Back</translation>
+        <translation type="vanished">Back</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
-        <source>Install %1 will remove: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
         <source>Dependencies in the repository</source>
-        <translation>Dependencies in the repository</translation>
+        <translation type="vanished">Dependencies in the repository</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
         <source>Missing dependencies</source>
-        <translation>Missing dependencies</translation>
+        <translation type="vanished">Missing dependencies</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
         <source>Installing dependencies: %1</source>
-        <translation>Installing dependencies: %1</translation>
+        <translation type="vanished">Installing dependencies: %1</translation>
     </message>
 </context>
 <context>
     <name>PackageSelectItem</name>
     <message>
-        <location filename="../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
         <source>Same version installed</source>
-        <translation>Same version installed</translation>
+        <translation type="vanished">Same version installed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
         <source>Earlier version installed: %1</source>
-        <translation>Earlier version installed: %1</translation>
+        <translation type="vanished">Earlier version installed: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
         <source>Later version installed: %1</source>
-        <translation>Later version installed: %1</translation>
+        <translation type="vanished">Later version installed: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
         <source>Unmatched package architecture</source>
-        <translation>Unmatched package architecture</translation>
+        <translation type="vanished">Unmatched package architecture</translation>
     </message>
 </context>
 <context>
     <name>PackageSelectView</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
         <source>Select all</source>
-        <translation>Select all</translation>
+        <translation type="vanished">Select all</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
         <source>Install</source>
         <comment>button</comment>
-        <translation>Install</translation>
+        <translation type="vanished">Install</translation>
     </message>
 </context>
 <context>
     <name>PackagesListDelegate</name>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
         <source>Installing</source>
-        <translation>Installing</translation>
+        <translation type="vanished">Installing</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
         <source>Installed</source>
-        <translation>Installed</translation>
+        <translation type="vanished">Installed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
         <source>Failed</source>
-        <translation>Failed</translation>
+        <translation type="vanished">Failed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
         <source>Waiting</source>
-        <translation>Waiting</translation>
+        <translation type="vanished">Waiting</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
         <source>Same version installed</source>
-        <translation>Same version installed</translation>
+        <translation type="vanished">Same version installed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
         <source>Later version installed: %1</source>
-        <translation>Later version installed: %1</translation>
+        <translation type="vanished">Later version installed: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
         <source>Earlier version installed: %1</source>
-        <translation>Earlier version installed: %1</translation>
+        <translation type="vanished">Earlier version installed: %1</translation>
     </message>
 </context>
 <context>
     <name>PackagesListView</name>
     <message>
-        <location filename="../src/deb-installer/model/packagelistview.cpp" line="189"/>
         <source>Delete</source>
-        <translation>Delete</translation>
+        <translation type="vanished">Delete</translation>
     </message>
 </context>
 <context>
     <name>QApplication</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Collapse</translation>
@@ -436,234 +336,208 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
         <source>Basic</source>
-        <translation>Basic</translation>
+        <translation type="vanished">Basic</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
         <source>Check digital signatures if the developer mode is enabled</source>
-        <translation>Check digital signatures if the developer mode is enabled</translation>
+        <translation type="vanished">Check digital signatures if the developer mode is enabled</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
-        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
-        <source>Security Center &gt; Tools &gt; App Security</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/uab/uab_package.cpp" line="54"/>
-        <source>The system has not installed Linglong environment, please install it first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
         <source>Unable to install</source>
-        <translation type="unfinished">Unable to install</translation>
+        <translation type="obsolete">Unable to install</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
-        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
-        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished">Cancel</translation>
+        <translation type="obsolete">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
         <source>Proceed</source>
         <comment>button</comment>
-        <translation type="unfinished">Proceed</translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
-        <source>Will remove: </source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Proceed</translation>
     </message>
 </context>
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Collapse</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Reinstall</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Later version installed: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Downgrade</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Earlier version installed: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Installing dependencies: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Failed to install %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Version: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Install</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Remove</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
-        <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Installed successfully</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Uninstalled successfully</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Uninstall Failed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Dependencies in the repository</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Missing dependencies</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Update</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation type="unfinished">Invalid digital signature</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Name: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Same version installed</translation>
     </message>
@@ -671,16 +545,15 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Show details</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Show dependencies</translation>
     </message>
@@ -688,8 +561,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Show details</translation>
     </message>
@@ -697,75 +570,52 @@
 <context>
     <name>Uab::UabPackageListModel</name>
     <message>
-        <location filename="../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
         <source>Installation Failed</source>
-        <translation>Installation Failed</translation>
+        <translation type="vanished">Installation Failed</translation>
     </message>
 </context>
 <context>
     <name>UninstallConfirmPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
         <source>Show related packages</source>
-        <translation>Show related packages</translation>
+        <translation type="vanished">Show related packages</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
         <source>Collapse</source>
         <comment>button</comment>
-        <translation>Collapse</translation>
+        <translation type="vanished">Collapse</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation>Cancel</translation>
+        <translation type="vanished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
         <source>Confirm</source>
-        <translation>Confirm</translation>
+        <translation type="vanished">Confirm</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
         <source>Are you sure you want to uninstall %1?
 All dependencies will also be removed</source>
-        <translation>Are you sure you want to uninstall %1?
+        <translation type="vanished">Are you sure you want to uninstall %1?
 All dependencies will also be removed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
         <source>Are you sure you want to uninstall %1?
 The system or other applications may not work properly</source>
-        <translation>Are you sure you want to uninstall %1?
+        <translation type="vanished">Are you sure you want to uninstall %1?
 The system or other applications may not work properly</translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
-        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
-    <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
-        <source>Install in compatible mode</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>main</name>
     <message>
-        <location filename="../src/deb-installer/main.cpp" line="48"/>
-        <location filename="../src/deb-installer/main.cpp" line="49"/>
         <source>Package Installer</source>
-        <translation>Package Installer</translation>
+        <translation type="vanished">Package Installer</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/main.cpp" line="50"/>
         <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-        <translation>Package Installer helps users install and remove local packages, and supports bulk installation.</translation>
+        <translation type="vanished">Package Installer helps users install and remove local packages, and supports bulk installation.</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-deb-installer_am_ET.ts
+++ b/translations/deepin-deb-installer_am_ET.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation type="unfinished">የምር unserialize የተመстанов</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>መግጠሚያ</translation>
     </message>
@@ -414,8 +409,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>ማሳነሻ</translation>
@@ -480,113 +475,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>ማሳነሻ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>እንደገና መግጠሚያ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>በኔ ያስገቡ አይነት ምልክት: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>በፊት ያስገቡ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>በፊት ያስገቡ አይነት ምልክት: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>ማስወገድ አይነት ምልክቶች ም: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>የ%1 የመстанов መጥ vä</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>እትም: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>መግጠሚያ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>ማስወገጃ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>እሺ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>ወደ ኋላ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>ተው already</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -603,7 +603,7 @@
         <translation type="vanished">የ%2 የ%1 የሞድ ምረጥ የተመстанов የተሳካ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>ተሳክቶ ተገጥሟል</translation>
     </message>
@@ -612,62 +612,62 @@
         <translation type="vanished">የ%2 የ%1 የሞድ ምረጥ የተመመ የተሳካ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>ተሳክቶ ጠፍቷል</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>ማጥፋት አልተቻለም</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>የ%1 የመстанов ምም ይሰር: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>የመነሳ ምም የተመዘገበ የምር unserialize</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>የመነሳ ምም የሌለ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">መሰረዣ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>አዘዝ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>የዲጅታል ምም የሌለ ባለስ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>ስም: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>ተመሳሳይ እትም ተገጥሟል</translation>
     </message>
@@ -675,16 +675,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>ዝርዝር ይምረጥ</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>ዝርዝር የመነሳ ምም ይምረጥ</translation>
     </message>
@@ -692,8 +692,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>ዝርዝር ይምረጥ</translation>
     </message>
@@ -753,9 +753,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>ተመሳሳይ ሁነታ ማስገባት</translation>
+        <translation type="vanished">ተመሳሳይ ሁነታ ማስገባት</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_ar.ts
+++ b/translations/deepin-deb-installer_ar.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>مثبّت الحزم</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>جاري تثبيت حزم أخرى ... الرجاء فتح البرنامج في وقت لاحق</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>فشل التحليل: تم العثور على بنية ملف غير قانونية في ملف البيان!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>فشل التحليل: تم العثور على رقم إصدار غير قانوني في ملف البيان!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>لم يتم العثور على حزم من نوع deb، الرجاء التحقق من المجلد.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>حزمة %1 قد تكون مشكلة</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>يمكنك تثبيت حزم %1 المحلية فقط</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>لا تستطيع الوصول إلى هذا الملف夹</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>تم إضافته مسبقاً</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>٪1 غير موجود، يرجى إعادة الإختيار</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>تثبيت جماعي</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>طي</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>طي</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>إعادة التثبيت</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>تم تثبيت الإصدار الأحدث: 1%</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>الرجوع إلى إصدار أقدم</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>تم تثبيت الإصدار السابق: 1%</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>جاري تثبيت الحزم المتطلبة (الاعتماديات):  1%</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>فشل تثبيت 1%</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>الإصدار :</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>تثبيت</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>إزالة</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>موافق</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>السابق</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>تم</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 تم تثبيته بنجاح في وضع التوافق %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>تم التثبيت بنجاح</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 تم إلغاء تثبيته بنجاح من وضع التوافق %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>تم إلغاء التثبيت بنجاح</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>فشل إزالة التثبيت</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>سيقوم تثبيت %1 بإزالة: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>الحزم المتطلبة (الاعتماديات) التي في المستودع</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>الحزم المتطلبة (الاعتماديات) مفقودة</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>تحديث</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>توقيع رقمي غير صالح</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>الاسم:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>الإصدار نفسه مثبت</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>إظهار التفاصيل</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>اظهار الحزم المتطلبة (الاعتماديات)</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>إظهار التفاصيل</translation>
     </message>
@@ -764,9 +764,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>تثبيت في الوضع المتوافق</translation>
+        <translation type="vanished">تثبيت في الوضع المتوافق</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_az.ts
+++ b/translations/deepin-deb-installer_az.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Paket quraşdırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Digər paketlər quraşdırılır... Bunu sonra açın.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Təhlil etmək mümkün olmadı: MANİFEST faylında səhv quruluşa malik fayl tapıldı!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Təhlil etmək mümkün olmadı: MANİFEST faylında səhv versiya nömrəsi tapıldı!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>DEB paket tapılmadı. Qovluğu yoxlayın.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation> %1 paketi xəta olub olabilir</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Sadece yerli %1 paketlerini yükləyə bilərsiz</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Bu foldera ezaflı qalmadınız</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Artıq əlavə olunub</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 mövcud deyil, lütfən, yenidən seçin</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Toplu quraşdırmaq</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Yığmaq</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Yığmaq</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Yenidən quraşdırmaq</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Sonrakı versiya quraşdırıldı: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Bir versiya geriyə</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Əvvəlki versiya quraşdırıldı: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Asılılıqlar quraşdırılır: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>%1 quraşdırılması baş tutmadı</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Versiya: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Quraşdırmaq</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Silmək</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Geriyə</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>İcra olundu</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">&apos;%2 müvəffaqiyyətlə %1 uyğunluq modunda yükləndi</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Uğurla quraşdırıldı</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">&apos;%2 müvəffaqiyyətlə %1 uyğunluq modundan qalxalandı</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Uğurla silindi</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Silinə bilmədi</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>%1 yüklənəcək və siləcək: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Bu repozitoriyadakı asılılıqlar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Çatışmayan asılılıqlar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Yeniləmək</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Rəqəmsal imza səhvdir</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Adı:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Eyni versiya quraşdırıldı</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Təfərrüatları göstərmək</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Asılılıqları göstərmək</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Təfərrüatları göstərmək</translation>
     </message>
@@ -765,9 +765,8 @@ Sistem və başqa tətbiqlər düzgün işləməyə bilər</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Uyğun rejimdə quraşdır</translation>
+        <translation type="vanished">Uyğun rejimdə quraşdır</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_bg.ts
+++ b/translations/deepin-deb-installer_bg.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Мениджър на пакети</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Инсталиране на други пакети... Моля, отворете го по-късно.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Парсингът се провали: във файловия манифест е открит неправилен файлов структура!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Парсингът се провали: във файловия манифест е открит неправилен номер на версия!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Не са открити deb пакети. Моля, проверете папката.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Пакетът %1 може да е повреден</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Можете да инсталирате само локални %1 пакети</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Няма разрешение за достъп до тази папка</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Вече добавен</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 не съществува, моля, изберете отново</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Групова инсталация</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Сриване</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Сриване</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Преинсталиране</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>По-нова версия е инсталирана: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Намаляване</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Предишна версия е инсталирана: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Инсталиране на зависимости: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Неуспешно инсталиране на %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Версия:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Инсталиране</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Премахване</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Завършено</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">&apos;%2 е успешно инсталиран в режим на съвместимост с %1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Инсталирането е успешно</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">&apos;%2 е успешно премахнат от режим на съвместимост с %1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Деинсталирането е успешно</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Деинсталирането е неуспешно</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Инсталирането на %1 ще премахне: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Зависимости в репозитория</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Липсващи зависимости</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Отказ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Обнови</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Невалидна цифрова подпис</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Име:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Същата версия е инсталирана</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Покажи подробности</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Покажи зависимости</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Покажи подробности</translation>
     </message>
@@ -765,9 +765,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Инсталиране в съвместим режим</translation>
+        <translation type="vanished">Инсталиране в съвместим режим</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_bn.ts
+++ b/translations/deepin-deb-installer_bn.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>প্যাকেজ ইনস্টল্যাটর</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>সেটিংস</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>অন্যান্য প্যাকেজগুলি ইনস্টল হচ্ছে... আপনাকে আরেকবার খুলতে হবে।</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>প্রসেস ব্যর্থ হয়েছে: ম্যানিফেস্ট ফাইলে অনুরূপ ফাইল স্ট্রাকচার পাওয়া গেছে!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>প্রসেস ব্যর্থ হয়েছে: ম্যানিফেস্ট ফাইলে অনুরূপ সংস্করণ নাম্বার পাওয়া গেছে!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>deb প্যাকেজ নেই। মুদ্রার পাথ পরীক্ষা করুন।</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>%1 প্যাকেজটি অকোম্প্লিট হতে পারে</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>আপনি কেবলমাত্র লোক্ল %1 প্যাকেজ ইনস্টল করতে পারেন</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>এই ফোল্ডারে এক্সেস করার অনুমতি নেই</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>যেতে পারে</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 সেট নেই, আবার নির্বাচন করুন</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>মূল্যবোধ ইনস্টল</translation>
     </message>
@@ -427,8 +422,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>ক্লেপ্লে</translation>
@@ -493,113 +488,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>ক্লেপ্লে</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>রিইনস্টল</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>বাদের সংস্করণ ইনস্টলড হয়েছে: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>ডাউনগ্রেড</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>পুরোনো সংস্করণ ইনস্টলড হয়েছে: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>অবশ্যক প্রদান ইনস্টল হচ্ছে: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>%1 ইনস্টল করতে ব্যর্থ হয়েছে</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>সংস্করণ: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>ইনস্টল করুন</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>বাতিল করুন</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>স্বাগতম</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>পিছনে</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>কর্মসূচী সম্পন্ন</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -616,7 +616,7 @@
         <translation type="vanished">%2 সফলভাবে %1 সহযোগিতা মডেল এ ইনস্টল হয়েছে</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>সফলভাবে ইনস্টল হয়েছে</translation>
     </message>
@@ -625,62 +625,62 @@
         <translation type="vanished">%2 সফলভাবে %1 সহযোগিতা মডেল থেকে বাতিল হয়েছে</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>সফলভাবে বাতিল হয়েছে</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>বাতিল ব্যর্থ হয়েছে</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>%1 ইনস্টল করতে নিম্নলিখিত থাকার কথা: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>রিপোজিটরীতে নির্ভরশীল উপাদান</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>কমিশ্ন নির্ভরশীল উপাদান</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>সংশোধন</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>মূল্যায়ন অকৃত্রিম চিহ্ন অবিশ্বাসযোগ্য</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>নাম: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>ইনস্টল করা হয়েছে তাঁরা একই সংস্করণ</translation>
     </message>
@@ -688,16 +688,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>রেঞ্জ দেখুন</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>নির্ভরশীল উপাদান দেখুন</translation>
     </message>
@@ -705,8 +705,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>রেঞ্জ দেখুন</translation>
     </message>
@@ -766,9 +766,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>সামঞ্জস্যপূর্ণ মোডে ইনস্টল করুন</translation>
+        <translation type="vanished">সামঞ্জস্যপূর্ণ মোডে ইনস্টল করুন</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_bo.ts
+++ b/translations/deepin-deb-installer_bo.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>མཉེན་ཆས་ཁུག་སྒྲིག་སྦྱོར་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>སྒྲིག་བཀོད།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>སྒྲིག་སྦྱོར་བྱ་རིམ་ལག་བསྟར་བྱེད་བཞིན་པས། ཁ་ཕྱེ་ཐབས་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>མཉེན་ཆས་ཁུག་མ་དབྱེ་ཞིབ་མི་ཐུབ་པས། མཉེན་ཆས་ཁུག་ནང་སྒྲིག་བརྒལ་ཡིག་ཆ་འདུས་ཡོད།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>མཉེན་ཆས་ཁུག་མ་དབྱེ་ཞིབ་མི་ཐུབ་པས། མཉེན་ཆས་ཁུག་ནང་སྒྲིག་བརྒལ་གྱི་པར་ཨང་འདུས་ཡོད།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>སྒྲིག་སྦྱོར་ཁུག་མ་ཪྙེད་མ་བྱུང་བས། སྒྲིག་སྦྱོར་དཀར་ཆག་ལ་བརྟག་བཤེར་གནང་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>སྣོན་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1ཡིག་ཆ་མི་འདུག་པས། ཡང་བསྐྱར་འདེམས་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>མང་པོ་མཉམ་དུ་སྒྲིག་སྦྱོར་བྱེད་པ།</translation>
     </message>
@@ -418,8 +413,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>བསྡུ་བ།</translation>
@@ -484,178 +479,183 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>བསྡུ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>ཡང་བསྐྱར་སྒྲིག་སྦྱོར།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>ཅུང་གསར་པའི་པར་གཞི་%1སྒྲིག་སྦྱོར་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>པར་གཞི་རྙིང་པ་སྒྲིག་འཇུག་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>ཅུང་སྔ་བའི་པར་གཞི་%1སྒྲིག་སྦྱོར་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>བརྟེན་པའི་འབྲེལ་བ་བཙུགས་བཞིན་པ། %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>%1སྒྲིག་སྦྱོར་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>སྒྲིག་སྦྱོར།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>བཤིག་འདོན།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>ཕྱིར་ལོག</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>ལེགས་གྲུབ།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>སྒྲིག་སྦྱོར་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>བཤིག་འདོན་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>བཤིག་འདོན་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>མཛོད་ནང་ཡོད་པའི་རྟེན་ཁུག</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>མཛོད་ནང་མེད་པའི་རྟེན་ཁུག</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>གསར་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>གྲངས་ཀའི་མིང་རྟགས་ཕན་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>པར་གཞི་འདྲ་མཚུངས་སྒྲིག་སྦྱོར་བྱས་ཟིན།</translation>
     </message>
@@ -663,16 +663,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>ཞིབ་ཕྲའི་ཆ་འཕྲིན་འཆར་བ།</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>རྟེན་ཁུག་དབར་གྱི་འབྲེལ་བ་མངོན་པ།</translation>
     </message>
@@ -680,8 +680,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>བཤིག་འདོན་བྱེད་རིམ་འཆར་བ།</translation>
     </message>
@@ -741,9 +741,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>མཐུན་ཆོས་ཡི་གནས་ཚུལ་ཁྱེར་ནས་གཞི་སྒྲིག་བྱ་པ།</translation>
+        <translation type="vanished">མཐུན་ཆོས་ཡི་གནས་ཚུལ་ཁྱེར་ནས་གཞི་སྒྲིག་བྱ་པ།</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_br.ts
+++ b/translations/deepin-deb-installer_br.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Stalier pakadoù</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>جارٍ تثبيت حزم أخرى... الرجاء فتحها لاحقاً.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>فشل التحليل: تم العثور على هيكل ملف غير قانوني في ملف الوضعية!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>فشل التحليل: تم العثور على رقم إصدار غير قانوني في ملف الوضعية!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>لم يتم العثور على أي حزم deb. الرجاء التحقق من المجلد.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>قد يكون حزمة %1 تالفة</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>يمكنك تثبيت حزم %1 المحلية فقط</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>لا يوجد إذن لدخول هذا المجلد</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Ouzhpennet endeo</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>لا يوجد %1، الرجاء إعادة الاختيار</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Lies-staliañ</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Bihanaat</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Bihanaat</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Adstaliañ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Stumm war-lerc&apos;h staliet: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>التحديث العكسي</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Stumm kent staliet: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>O staliañ an dalc&apos;hioù: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>فشل في تنصيب %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Stumm:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Staliañ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Dilemel</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Mat eo</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Kent</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Echuet</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">تم تنصيب %2 بنجاح في وضع التوافق %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Staliet gant berzh</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">تم إزالة %2 بنجاح من وضع التوافق %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Distaliet gant berzh</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Distaliañ c&apos;hwitet</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>تنصيب %1 سيؤدي إلى إزالة:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>الاعتماديات في المستودع</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>الاعتماديات المفقودة</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Nullañ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>التحديث</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>توقيع رقمي غير صحيح</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Anv:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Hevelep stumm staliet</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Diskouez ar munudoù</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>عرض الاعتماديات</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Diskouez ar munudoù</translation>
     </message>
@@ -765,9 +765,8 @@ Ar sistem pe aplikasionoù all a vo diaes dezho mont en-dro mat</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Staliañ er mod kevveraat</translation>
+        <translation type="vanished">Staliañ er mod kevveraat</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_ca.ts
+++ b/translations/deepin-deb-installer_ca.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Instal·lador de paquets</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Paràmetres</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>S&apos;instal·len altres paquets... Si us plau, obriu-ho més tard.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>S&apos;ha produït un error a l&apos;anàlisi: s&apos;ha trobat una estructura de fitxer il·legal al fitxer de manifest!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>S&apos;ha produït un error a l&apos;anàlisi: s&apos;ha trobat un número de versió il·legal al fitxer de manifest!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>No s&apos;han trobat paquets deb. Si us plau, comproveu-ne la carpeta.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>El paquet %1 potser està trencat.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Només podeu instal·lar paquets locals %1.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>No teniu permís per accedir a aquesta carpeta.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Ja s&apos;ha afegit</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 no existeix. Si us plau, refeu la selecció.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Instal·lació massiva</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Replega</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Replega</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Reinstal·la</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Darrera versió instal·lada: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Degrada</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Versió instal·lada abans: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>S&apos;instal·len dependències: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Ha fallat instal·lar %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Versió:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Instal·la</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Enrere</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Fet</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">S&apos;ha instal·lat %2 correctament en mode de compatibilitat %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Instal·lació correcta</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 s&apos;ha desinstal·lat correctament del mode de compatibilitat %1.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Desinstal·lació correcta</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Ha fallat la instal·lació.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Instal·lar %1 eliminarà el següent:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Dependències al repositori</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Dependències que manquen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Actualitza</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Signatura digital no vàlida</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Nom:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>N&apos;hi ha instal·lada la mateixa versió.</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Mostra&apos;n els detalls</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Mostra&apos;n les dependències</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Mostra&apos;n els detalls</translation>
     </message>
@@ -765,9 +765,8 @@ Pot ser que el sistema o altres aplicacions no funcionin correctament.</translat
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Instal·la en mode compatible</translation>
+        <translation type="vanished">Instal·la en mode compatible</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_cs.ts
+++ b/translations/deepin-deb-installer_cs.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Instalátor balíčků</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Probíhá instalace jiných balíčků… Prosím počkejte s otevřením na později.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Zpracování se nezdařilo: V souboru manifestu byla nalezena neplatná struktura souboru!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Zpracování se nezdařilo: V souboru manifestu bylo nalezeno nesprávné číslo verze!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Nenalezeny žádné .deb balíčky – zkontrolujte složku.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Balíček %1 může být poškozen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Můžete nainstalovat pouze místní balíčky %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Nemáte oprávnění k přístupu do tohoto adresáře</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Už přidáno</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 neexistuje, vyberte</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Hromadná instalace</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Sbalit</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Sbalit</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Přeinstalovat</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Později nainstalovaná verze: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Vrátit se zpět ke starší verzi</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Dříve nainstalovaná verze: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Instalují se součásti, na kterých závisí: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Nepodařilo se nainstalovat %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Verze:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Nainstalovat</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Odebrat</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Zpět</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 bylo úspěšně nainstalováno do režimu kompatibility %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Úspěšně nainstalováno</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 bylo úspěšně odinstalováno z režimu kompatibility %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Úspěšně odinstalováno</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Odinstalace se nezdařila</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Instalace %1 odebere: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Závislosti v repozitáři</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Chybějící závislosti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Aktualizovat</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Neplatný digitální podpis</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Název: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Stejná verze už je nainstalovaná</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Zobrazit podrobnosti</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Zobrazit závislosti</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Zobrazit podrobnosti</translation>
     </message>
@@ -765,9 +765,8 @@ Systém nebo ostatní aplikace by tím nemusely fungovat tak, jak mají</transla
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Instalovat v kompatibilním režimu</translation>
+        <translation type="vanished">Instalovat v kompatibilním režimu</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_da.ts
+++ b/translations/deepin-deb-installer_da.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Pakkeinstallationsprogram</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Indstillinger</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Installerer andre pakker... Åbn den senere.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Fejl i parsering: En ugyldig filstruktur blev fundet i manifestfilen!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Fejl i parsering: En ugyldig versionnummer blev fundet i manifestfilen!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Ingen deb-pakker fundet. Tjek mappen.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Den %1-pakke kan være beskadiget</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Du kan kun installere lokale %1-pakker</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Ingen tilladelse til at tilgå denne mappe</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Allerede tilføjet</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 findes ikke, venligst vælg omendeligt</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Masseinstallation</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Sammenfold</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Sammenfold</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Geninstaller</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Nyere version installeret: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Nedgradering</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Tidligere version installeret: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Installerer afhængigheder: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Fejl i installation af %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Version:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Installer</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Fjern</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Tilbage</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Færdig</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 blev succesfuldt installeret i %1 kompatibilitetsmode</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Installeret</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 er succesfuldt fjernet fra %1 kompatibilitetsmode</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Afinstalleret</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Afinstallation mislykkedes</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Installering af %1 vil fjerne: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Afhængigheder i repositoryet</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Mangler afhængigheder</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuller</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Opdater</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Ugyldig digital signatur</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Navn:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Samme version installeret</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Vis detaljer</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Vis afhængigheder</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Vis detaljer</translation>
     </message>
@@ -765,9 +765,8 @@ Systemet og andre programmer virker måske ikke korrekt</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Installer i kompatibel tilstand</translation>
+        <translation type="vanished">Installer i kompatibel tilstand</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_de.ts
+++ b/translations/deepin-deb-installer_de.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Paket-Installationsprogramm</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Andere Pakete werden installiert... Bitte öffnen Sie es später.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Parsing fehlgeschlagen: In der Manifest-Datei wurde eine ungültige Dateistruktur gefunden!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Parsing fehlgeschlagen: In der Manifest-Datei wurde eine ungültige Versionsnummer gefunden!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Keine deb Packete gefunden. Bitte schau in den Ordner.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Das %1 Packet könnte beschädigt sein</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Du kannst nur lokale %1 Pakete installieren</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Keine Berechtigung um den Ordner zu öffnen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Bereits hinzugefügt</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 existiert nicht, bitte wählen Sie erneut</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Masseninstallation</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Einklappen</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Einklappen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Neu installieren</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Neuere Version installiert: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Herabstufen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Ältere Version installiert: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Abhängigkeiten werden installiert: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Konnte %1 nicht installieren</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Version:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Installieren</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Entfernen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Zurück</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -611,7 +611,7 @@
         <translation type="vanished">Deinstalliere %2 aus dem %1-Kompatibilitätsmodus</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Erfolgreich installiert</translation>
     </message>
@@ -620,62 +620,62 @@
         <translation type="vanished">%2 wurde erfolgreich aus dem %1-Kompatilitätsmodus entfernt</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Erfolgreich deinstalliert</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Deinstallation fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>%1 zu installieren wird folgendes entfernen:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Abhängigkeiten im Repositorium</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Fehlende Abhängigkeiten</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Ungültige digitale Signatur</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Name: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Gleiche Version installiert</translation>
     </message>
@@ -683,16 +683,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Details anzeigen</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Abhängigkeiten anzeigen</translation>
     </message>
@@ -700,8 +700,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Details anzeigen</translation>
     </message>
@@ -761,9 +761,8 @@ Das System oder andere Anwendungen funktionieren dann möglicherweise nicht rich
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Im Kompatibilitätsmodus installieren</translation>
+        <translation type="vanished">Im Kompatibilitätsmodus installieren</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_en_US.ts
+++ b/translations/deepin-deb-installer_en_US.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Package Installer</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Installing other packages... Please open it later.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Parsing failed: An illegal file structure was found in the manifest file!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Parsing failed: An illegal version number was found in the manifest file!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>No deb packages found. Please check the folder.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>The %1 package may be broken</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>You can only install local %1 packages</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>No permission to access this folder</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Already Added</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 does not exist, please reselect</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Bulk Install</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Collapse</translation>
@@ -492,69 +487,69 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Name: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Version: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Reinstall</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Install</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Remove</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -563,8 +558,8 @@
         <translation type="vanished">Trying to install %2 in %1 compatibility mode</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -577,12 +572,12 @@
         <translation type="vanished">%2 was successfully installed to %1 compatibility mode</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Installed successfully</translation>
     </message>
@@ -591,95 +586,100 @@
         <translation type="vanished">%2 has been successfully uninstalled from %1 compatibility mode</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Uninstalled successfully</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Uninstall Failed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Collapse</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Install %1 will remove: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Dependencies in the repository</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Missing dependencies</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Same version installed</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Later version installed: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Downgrade</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Earlier version installed: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Update</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Installing dependencies: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Failed to install %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Invalid digital signature</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Show details</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Show dependencies</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Show details</translation>
     </message>
@@ -763,9 +763,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Install in compatible mode</translation>
+        <translation type="vanished">Install in compatible mode</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_es.ts
+++ b/translations/deepin-deb-installer_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>AptConfigMessage</name>
     <message>
@@ -47,70 +49,69 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Instalador de paquetes</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Instalando otros paquetes... Por favor, ábralo más tarde.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Error de análisis: Se ha encontrado una estructura de archivo ilegal en el archivo de manifiesto.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Error de análisis: Se ha encontrado un número de versión ilegal en el archivo de manifiesto.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>No se han encontrado paquetes deb. Por favor, compruebe la carpeta.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>El paquete %1 puede estar dañado</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Sólo puede instalar %1 paquetes locales</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>No tiene permiso para acceder a la carpeta</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Ya agregado</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 aún no existe, vuelva a seleccionar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
         <source>Compatible Mode Install</source>
-        <translation>Instalación en modo compatibilidad</translation>
+        <translation type="vanished">Instalación en modo compatibilidad</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Instalación en masa</translation>
     </message>
@@ -424,8 +425,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Contraer</translation>
@@ -490,178 +491,187 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Contraer</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Reinstalar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation>Instalando en modo compatible %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation>%1 se instaló correctamente en modo compatible</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Una versión más nueva está instalada: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Degradar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Una versión anterior está instalada: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished">Instalación en modo compatibilidad</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Instalando dependencias: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>La instalación de %1 falló</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Versión:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Instalar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Quitar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Atrás</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Finalizar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation>Si este software es una versión anterior (ya adaptada para una versión de sistema heredada), puede intentar instalarlo en modo de compatibilidad.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation>El modo de compatibilidad UOS V25 es una función que le permite seguir utilizando aplicaciones de la versión V20 en el sistema V25. Crea un entorno de compatibilidad que permite que el software que originalmente solo podía ejecutarse en el sistema V20 funcione correctamente también en el sistema V25.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation>Confirme la instalación en modo de compatibilidad.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Desinstalar %2 del modo de compatibilidad %1</translation>
+        <translation type="vanished">Desinstalar %2 del modo de compatibilidad %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Instalación exitosa</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Desinstalación exitosa</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>La desinstalación falló</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>La instalación %1 eliminará:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Dependencias en el repositorio</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Dependencias que faltan</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation>Instalación compatible</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Firma digital inválida</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>La misma versión está instalada</translation>
     </message>
@@ -669,16 +679,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Mostrar detalles</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Mostrar las dependencias</translation>
     </message>
@@ -686,8 +696,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Mostrar detalles</translation>
     </message>
@@ -747,9 +757,8 @@ El sistema u otras aplicaciones tal vez no funcionen correctamente</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Instalar en modo compatible</translation>
+        <translation type="vanished">Instalar en modo compatible</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_et.ts
+++ b/translations/deepin-deb-installer_et.ts
@@ -49,72 +49,67 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Pakihaldur</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Seaded</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Paigaldatakse muude pakete... Atributsege hiljem avamiseks.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Analüüsi ebaõnnestus: Manifesifailis leiti ebasobiv failistruktuur!
 </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Analüüsi ebaõnnestus: Manifesifailis leiti ebasobiv versiooninumber!
 </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Deb pakete ei leitud. Palun kontrolli kaustat.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Paigutatud %1 pakett võib olla vikiga</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Sa võid paigaldada ainult kohalikke %1 pakete</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Ei ole sissekandimise õigust selle kausta</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Juba lisatud</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 ei eksisteeri, palun vali uuesti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Hulgi paigaldamine</translation>
     </message>
@@ -428,8 +423,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Sulge</translation>
@@ -494,113 +489,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Sulge</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Paigalda uuesti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Parem versioon on installitud: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Väljastada</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Aegsem versioon on installitud: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Installitakse sõltuvusi: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Ei saa %1 installida</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Versioon:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Paigalda</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Eemalda</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Tagasi</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Valmis</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -617,7 +617,7 @@
         <translation type="vanished">%2 on edukalt %1 kompatüübilahenduses installitud</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Paigaldatud</translation>
     </message>
@@ -626,62 +626,62 @@
         <translation type="vanished">%2 on edukalt %1 kompatüübilahendustest eemaldatud</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Eemaldatud</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Eemaldamine ebaõnnestus</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Installida %1 eemaldatakse: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Salvestusala sõltuvused</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Puuduvad sõltuvused</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Uuenda</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Vigane digitaalallikas</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Nimi:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Sama versioon on juba paigaldatud</translation>
     </message>
@@ -689,16 +689,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Näita detajeid</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Näita sõltuvusi</translation>
     </message>
@@ -706,8 +706,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Näita yksikäsitteisi</translation>
     </message>
@@ -767,9 +767,8 @@ Põhjuslikult või teiste rakenduste tuleksid ei toimuda õigesti</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Paigalda ühilduvas režiimis</translation>
+        <translation type="vanished">Paigalda ühilduvas režiimis</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_fi.ts
+++ b/translations/deepin-deb-installer_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>AptConfigMessage</name>
     <message>
@@ -47,70 +49,69 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Ohjelma-asentaja</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Asennetaan muita paketteja... Avaa se myöhemmin.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Jäsentäminen epäonnistui: Kokoonpanotiedostosta löytyi laiton tiedostorakenne!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Jäsentäminen epäonnistui: Kokoonpanotiedostosta löytyi laiton versionumero!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Deb-paketteja ei löytynyt. Tarkista kansio.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Paketti %1 voi olla rikki</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Voit asentaa vain %1-paketteja</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Ei ole käyttöoikeuksia tähän kansioon</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Jo lisätty</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 ei ole, valitse uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
         <source>Compatible Mode Install</source>
-        <translation>Asenna yhteensopivuustilassa</translation>
+        <translation type="vanished">Asenna yhteensopivuustilassa</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Suora-asennus</translation>
     </message>
@@ -424,8 +425,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Pudotus</translation>
@@ -490,178 +491,187 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Pudotus</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation>Asennetaan %1 yhteensopivuustilassa</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation>%1 asennettiin yhteensopivuustilassa</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Uudempi versio asennettu: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Aiempi vesio</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Aiempi versio asennettu: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished">Asenna yhteensopivuustilassa</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Riippuvuuksien asentaminen: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Kohteen %1 asentaminen epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Versio:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Asenna</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Takaisin</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Valmis</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation>Jos ohjelma on vanhempi versio (vanha järjestelmäversio), voit yrittää asentaa sen yhteensopivuustilassa.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation>UOS V25 -yhteensopivuustilassa, voit jatkaa V20-version sovellusten käyttöä. Se luo sinulle ympäristön, jonka ansiosta ohjelmat, jotka alun perin toimivat vain V20-versioissa, toimivat oikein myös V25-versiossa.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation>Vahvista asennus yhteensopivuustilassa</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
         <source>Uninstalling %2 from %1 compatibility mode</source>
-        <translation>Poistetaan asennusta %2 %1 yhteensopivuustilasta</translation>
+        <translation type="vanished">Poistetaan asennusta %2 %1 yhteensopivuustilasta</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Asennettu onnistuneesti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Asennuksen poisto onnistui</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Poisto epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>%1 asentaminen poistaa:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Pakettivaraston riippuvuudet</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Puuttuvat riippuvuudet</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation>Yhteensopiva asennus</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peru</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Päivitys</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Virheellinen digitaalinen allekirjoitus</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Nimi:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Sama versio on asennettu</translation>
     </message>
@@ -669,16 +679,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Näytä tiedot</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Näytä riippuvuudet</translation>
     </message>
@@ -686,8 +696,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Näytä tiedot</translation>
     </message>
@@ -747,9 +757,8 @@ Järjestelmä tai muut sovellukset eivät välttämättä toimi oikein</translat
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Asenna yhteensopivuustilassa</translation>
+        <translation type="vanished">Asenna yhteensopivuustilassa</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_fr.ts
+++ b/translations/deepin-deb-installer_fr.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Installateur de paquets</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Installation d&apos;autres paquets... Veuillez l&apos;ouvrir plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Échec de la lecture: Une structure de fichier illégale a été trouvée dans le manifeste.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Échec de la lecture: Une numéro de version illégal a été trouvé dans le manifeste.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Pas de paquet DEB trouvé. Vérifiez le dossier.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Le paquet %1 est peut-être cassé</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Vous ne pouvez installer que %1 paquets locaux</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Vous n&apos;avez pas la permission d&apos;accéder à ce dossier</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Déjà ajouté</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 n&apos;existe pas, veuillez resélectionner </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Installation Multiple</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Réduire</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Réduire</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Réinstaller</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Version ultérieure installée : %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Rétrograder</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Version antérieure installée : %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Installation des dépendances : %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Échec de l&apos;installation de %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Version :</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Installer</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Précédent</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Terminé</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 تم تثبيته بنجاح في وضع التوافق مع %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Installé avec succès</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 a été désinstallé avec succès dans %1 en mode compatibilité</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Désinstallé avec succès</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Échec de la désinstallation</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Installer %1 va supprimer :</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Dépendances dans le dépôt</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Dépendances manquantes</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuler</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Mettre à jour</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Signature numérique non valide</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Nom :</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Version identique installée</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Afficher les détails</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Afficher les dépendances</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Afficher les détails</translation>
     </message>
@@ -765,9 +765,8 @@ Le système ou d&apos;autres applications peuvent ne pas fonctionner correctemen
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Installer en mode compatible</translation>
+        <translation type="vanished">Installer en mode compatible</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_gl_ES.ts
+++ b/translations/deepin-deb-installer_gl_ES.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Instalador do paquete</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Configuración</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Instalando outros paquetes... Abra esto posteriormente.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Falló a análise: atopouse unha estrutura de ficheiro ilegal no ficheiro manifest!!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Falló a análise: atopouse un número de versión ilegal no ficheiro manifest!!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Non se atoparon paquetes deb. Comprueba a carpeta.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>O paquete %1 pode estar roto</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Pode instalar só paquetes %1 locais</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Non teña permiso para acceder a esta carpeta</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Xa se engadiu</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 non existe, seleccione de novo</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Instalar en bloque</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Colapsou</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Colapsou</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Reinstalar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Versión máis recente instalada: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Desactualizar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Versión máis recente instalada: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Instalando dependencias; %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Erro ao instalar %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Versión:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Instalar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Volver</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Feito</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 foi instalado con éxito en modalidade de compatibilidade %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Instalado con éxito</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 foi desinstalado con éxito de modalidade de compatibilidade %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Desinstalado con éxito</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Fallo ao desinstalar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>A instalación de %1 eliminará: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Dependencias no repositorio</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Dependencias ausentes</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Firma digital inválida</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Mesma versión instalada</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Amosar detalles</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Mostrar dependencias</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Amosar detalles</translation>
     </message>
@@ -765,9 +765,8 @@ O sistema ou outros aplicativos poden non funcionar correctamente</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Instalar en modo compatible</translation>
+        <translation type="vanished">Instalar en modo compatible</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_he.ts
+++ b/translations/deepin-deb-installer_he.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>מונח הלוחות</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>מתקין חבילות נוספות... יש לפתוח את זה מאוחר יותר.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>הפעלה נכשלה: נמצא מבנה קובץ לא חוקי בקובץ המаниפסט!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>הפעלה נכשלה: נמצא מספר גרסה לא חוקי בקובץ המניפסט!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>לא נמצאו חבילות deb. יש לבדוק את הכתובת.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>החבילה %1 עלולה להיות מתקלקלה</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>אתה יכול להתקין רק חבילות %1 מקומיות</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>אין הרשאה לגשת לכתובת זו</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>הוספה כבר</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 לא קיים, יש לבחור מחדש</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>התקנה קבוצתית</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>צמצום</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>צמצום</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>התקנה מחדש</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>התקנת גרסה מאוחרת: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>התקנת גרסה נמוכה יותר</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>הותקנה גרסה מוקדמת יותר: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>התקנת תחנות תומכות: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>נכשל להתקין %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>גרסה:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>התקנה</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>הסרה</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>אישור</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>חזרה</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>סימן</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 התקנת בהצלחה למצב התואמה %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>הותקן בהצלחה</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 נמחקה בהצלחה מהמצב התואמה %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>הוסר בהצלחה</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>ההסרה נכשלה</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>התקנת %1 תמחק: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>תתותומכות במאגר</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>תתותומכות חסרות</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>עדכן</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>חתת דיגיטלית לא תקינה</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>שם:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>אותה הגרסה מותקנת</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>הצג פרטים</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>הצג תחנות תומכות</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>הצג פרטים</translation>
     </message>
@@ -765,9 +765,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>התקנה במצב תאימות</translation>
+        <translation type="vanished">התקנה במצב תאימות</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_hi_IN.ts
+++ b/translations/deepin-deb-installer_hi_IN.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>पैकेज इंस्टॉलर</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>अन्य पैकेज इंस्टॉल कर रहे हैं... बाद में खोलें</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>पार्सिंग विफल: मैनिफेस्ट फ़ाइल में अवैध फ़ाइल संरचना पाई गई!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>पार्सिंग विफल: मैनिफेस्ट फ़ाइल में अवैध संस्करण संख्या पाई गई!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>कोई deb पैकेज नहीं मिला। कृपया फ़ोल्डर चेक करें।</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>पैकेज %1 टूट गया हो सकता है</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>आप केवल स्थानीय %1 पैकेज इंस्टॉल कर सकते हैं</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>इस फ़ोल्डर के एक्सेस के लिए अनुमति नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>पहले से ही शामिल</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 मौजूद नहीं है, कृपया पुनः चुनें</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>सामूहिक इंस्टॉल</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>संक्षिप्त करें</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>संक्षिप्त करें</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>पुनः इंस्टॉल करें</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>नवीन संस्करण इंस्टॉल है : %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>डाउनग्रेड</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>पूर्व संस्करण इंस्टॉल है : %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>आश्रित पैकेज इंस्टॉल हो रहे हैं : %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>%1 इंस्टॉल विफल</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>संस्करण :</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>इंस्टॉल करें</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ठीक है</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>वापस</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>पूर्ण हुआ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 %1 संगतता मोड में सफलतापूर्वक इंस्टॉल कर दिया गया है</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>इंस्टॉल सफल रहा</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 %1 संगतता मोड से सफलतापूर्वक अनइंस्टॉल कर दिया गया है</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>इंस्टॉल हटाना सफल रहा</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>इंस्टॉल हटाना विफल रहा</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>%1 के इंस्टॉल करने से हटाया जाएगा: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>पैकेज-संग्रह में मौजूद आश्रित पैकेज</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>अनुपलब्ध आश्रित पैकेज</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>अपडेट</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>अमान्य डिजिटल हस्ताक्षर</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>नाम :</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>समान संस्करण पहले से इंस्टॉल है</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>विवरण दिखाएँ</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>आश्रित पैकेज दिखाएँ</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>विवरण दिखाएँ</translation>
     </message>
@@ -765,9 +765,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>संगत मोड में इंस्टॉल करें</translation>
+        <translation type="vanished">संगत मोड में इंस्टॉल करें</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_hr.ts
+++ b/translations/deepin-deb-installer_hr.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Instaler paketa</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Postavke</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Instalacija drugih paketa... Molimo otvorite ga kasnije.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Parsing je pao: pronađena je nevaljana struktura datoteke u manifestu!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Parsing je pao: pronađen je nevaljani broj verzije u manifestu!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Nisu pronađeni deb paketi. Molimo provjerite mapu.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Paket %1 može biti oštećen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Možete instalirati samo lokalne %1 pakete</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Nema dozvole za pristup ovoj mapi</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Već je dodan</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 ne postoji, molimo ponovno odaberite</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Skupno instaliranje</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Provjerite digitalne potpise ako je omogućen režim razvijalaca</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Povratak na staru verziju</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Ponovno instaliraj</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Instalirana je kasnija inačica: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Povlačenje</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Instalirana je ranija inačica: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Instaliram međuzavisnosti: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Nespjela instalacija %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Inačica:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Instaliraj</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Ukloni</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>U redu</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Natrag</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Učinjeno</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">&apos;%2 je uspješno instaliran u režim kompatibilnosti %1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Uspješno instalirano</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">&apos;%2 je uspješno deinstaliran iz režima kompatibilnosti %1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Uspješno deinstalirano</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Neuspjela deinstalacija</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Instalacija %1 će ukloniti: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Međuzavisnosti u repozitoriju</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Međuzavisnosti koje nedostaju</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Otkaži</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Ažuriraj</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Neispravni digitalni potpis</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Ime:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Instalirana je ista inačica</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Pokaži pojedinosti</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Pokaži međuzavisnosti</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Pokaži pojedinosti</translation>
     </message>
@@ -765,9 +765,8 @@ Sustav ili ostale aplikacije možda neće ispravno raditi</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Instaliraj u kompatibilnom načinu</translation>
+        <translation type="vanished">Instaliraj u kompatibilnom načinu</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_hu.ts
+++ b/translations/deepin-deb-installer_hu.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Csomagtelepítő</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Más csomagok telepítése folyamatban... Kérjük nyissa meg később.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Az elemzés sikertelen. Nem megengedett fájlstruktúra található a jegyzékfájlban!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Az elemzés sikertelen. Nem megengedett verziószám található a jegyzékfájlban!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Nem található .deb csomag. Kérjük ellenőrizze a mappát.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>A %1 csomag lehet hogy sérült</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Csak helyi %1 csomagok telepíthetőek</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Nincs engedély a mappa elérésére</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Már hozzáadva</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>A %1 nem létezik, kérjük válassza ki újra</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Csoportos telepítés</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Összecsukás</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Összecsukás</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Újratelepítés</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Újabb verzió telepítve: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Visszaminősítés</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Korábbi verzió telepítve: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Telepítési függőségek: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>A %1 telepítése sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Verzió:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Telepítés</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Eltávolítás</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Vissza</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Kész</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 sikeresen telepítve lett a %1 kompatibilitási módra</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Sikeresen telepítve</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">A %2 sikeresen eltávolítva a %1 kompatibilitási módból</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Sikeresen eltávolítva</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Az eltávolítás sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>A telepített %1 eltávolítása:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Függőségek a tárolóban</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Hiányzó függőségek</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Frissítés</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Érvénytelen digitális aláírás</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Név:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Ez a verzió már telepítve van</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Részletek mutatása</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Függőségek megjelenítése</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Részletek mutatása</translation>
     </message>
@@ -765,9 +765,8 @@ A rendszer, illetve más alkalmazások esetleg nem megfelelően fognak működni
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Telepítés kompatibilis módban</translation>
+        <translation type="vanished">Telepítés kompatibilis módban</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_id.ts
+++ b/translations/deepin-deb-installer_id.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Pemasang Paket</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Setelan</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Menginstal paket lain... Silakan buka nanti.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Parsing gagal: Struktur file yang tidak sah ditemukan dalam file manifest!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Parsing gagal: Nomor versi yang tidak sah ditemukan dalam file manifest!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Tidak ada paket deb yang ditemukan. Silakan periksa folder.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Paket %1 mungkin rusak</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Anda hanya dapat menginstal paket %1 lokal</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Tidak ada izin untuk mengakses folder ini</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Telah ditambahkan</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 tidak ada, silakan pilih ulang</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Pasang massal</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Jatuhkan</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Jatuhkan</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Pasang ulang</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Versi yang lebih baru terpasang: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Turunkan versi</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Versi sebelumnya terpasang: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Memasang dependensi: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Gagal memasang %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Versi:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Pasang</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Hapus</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Kembali</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Selesai</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 berhasil diinstal ke mode kompatibilitas %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Pemasangan berhasil</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 berhasil diuninstal dari mode kompatibilitas %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Pelepasan berhasil</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Pelepasan gagal</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Instal %1 akan menghapus: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Dependensi di repositori</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Dependensi hilang</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Batal</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Perbarui</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Tanda tangan digital tidak valid</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Nama:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Versi sama terpasang</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Tampilkan detail</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Tampilkan dependensi</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Tampilkan detail</translation>
     </message>
@@ -765,9 +765,8 @@ Sistem atau aplikasi lain mungkin tidak berfungsi dengan baik</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Instal dalam mode kompatibel</translation>
+        <translation type="vanished">Instal dalam mode kompatibel</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_it.ts
+++ b/translations/deepin-deb-installer_it.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Gestore pacchetti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Installazione altri pacchetti... Per cortesia aprilo dopo.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Analisi fallita: un file con struttura errata è stato trovato nel file Manifesto!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Analisi fallita: un numero versione errata è stato rilevato nel file Manifesto!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Nessun file Deb rilevato. Per cortesia controlla la cartella.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Già aggiunto</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 non esiste, per cortesia riprova</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Installazione di massa</translation>
     </message>
@@ -418,8 +413,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Collassa</translation>
@@ -484,178 +479,183 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Collassa</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Versione successiva già installata: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Ripristina alla versione precedente</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Versione precedente installata: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Installazione dipendenze: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Installazione fallita per %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Versione:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Installa</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Rimuovi</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Indietro</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Fatto</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Installazione riuscita</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Disinstallazione riuscita</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Disinstallazione fallita</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Dipendenze nel repository</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Dipendenze mancanti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Firma digitale non valida</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Medesima versione installata</translation>
     </message>
@@ -663,16 +663,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Mostra dettagli</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Mostra le dipendenze</translation>
     </message>
@@ -680,8 +680,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Mostra dettagli</translation>
     </message>
@@ -741,9 +741,8 @@ Il sistema o eventuali App potrebbero non funzionare correttamente</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Installa in modalità compatibile</translation>
+        <translation type="vanished">Installa in modalità compatibile</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_ja.ts
+++ b/translations/deepin-deb-installer_ja.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>パッケージ インストーラー</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>他のパッケージをインストールしています...後でもう一度お試しください。</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>debパッケージが見つかりません。フォルダをご確認ください。</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>このフォルダへのアクセス権限がありません</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>既に追加されています</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1は存在しません。もう一度お試しください</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>一括インストール</translation>
     </message>
@@ -418,8 +413,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>折りたたむ</translation>
@@ -484,178 +479,183 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>折りたたむ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>再インストール</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>新しいバージョンがインストールされています: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>ダウングレード</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>古いバージョンがインストールされています: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>依存関係をインストール中: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>%1のインストールに失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>バージョン:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>インストール</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>消去</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>戻る</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完了</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>インストールが完了しました</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>アンインストールが完了しました</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>アンインストール失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>デジタル署名が不正です</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>名前:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>同じバージョンがインストールされています</translation>
     </message>
@@ -663,16 +663,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>詳細を表示</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation type="unfinished"></translation>
     </message>
@@ -680,8 +680,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>詳細を表示</translation>
     </message>
@@ -741,9 +741,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>互換モードでインストール</translation>
+        <translation type="vanished">互換モードでインストール</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_ko.ts
+++ b/translations/deepin-deb-installer_ko.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>패키지 관리자</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>기타 패키지 설치 중... 나중에 열어주세요.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>파싱 실패: 메타데이터 파일에서 잘못된 파일 구조가 발견되었습니다!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>파싱 실패: 메타데이터 파일에서 잘못된 버전 번호가 발견되었습니다!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>deb 패키지가 없습니다. 폴더를 확인해주세요.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>%1 패키지가 손상되었을 수 있습니다</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>로컬 %1 패키지만 설치할 수 있습니다</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>이 폴더에 접근할 권한이 없습니다</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>이미 추가됨</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1이 존재하지 않습니다. 다시 선택해주세요</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>일괄 설치</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>축소</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>축소</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>재설치</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>이후 버전 설치: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>다운그레이드</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>이전 버전 설치: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>종속성 설치 중: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>%1 설치 실패</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>버전:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>설치</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>제거</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>확인</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>완료</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2이 %1 호환성 모드로 성공적으로 설치되었습니다</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>설치 성공</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2이 %1 호환성 모드에서 성공적으로 제거되었습니다</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>제거 성공</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>제거 실패</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>%1 설치 시 제거할 항목: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>저장소에 있는 종속성</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>결여된 종속성</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>업데이트</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>유효하지 않은 디지털 서명</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>이름:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>동일한 버전 설치됨</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>상세 정보 표시</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>종속성 표시</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>상세 정보 표시</translation>
     </message>
@@ -765,9 +765,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>호환 모드로 설치</translation>
+        <translation type="vanished">호환 모드로 설치</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_lo.ts
+++ b/translations/deepin-deb-installer_lo.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>ຕິດຕັ້ງແພັກເກດ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>ການຕັ້ງຄ່າ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>กำลังติดตั้งแพ็คเกจอื่น...กรุณาเปิดในภายหลัง</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>วิเคราะห์ล้มเหลว: พบโครงสร้างไฟล์ผิดปกติในไฟล์ manifest!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>วิเคราะห์ล้มเหลว: พบตัวเลขเวอร์ชันผิดปกติในไฟล์ manifest!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>ไม่พบ deb packages. กรุณาตรวจสอบโฟลเดอร์</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>แพ็คเกจ %1 อาจเสียหาย</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>คุณสามารถติดตั้ง deb packages ท้องถิ่นได้เท่านั้น</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>ไม่มีสิทธิ์เข้าถึงโฟลเดอร์นี้</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>ស្លាប់បានបញ្ចុច</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 មិនមានទេ, សូមជ្រើនភ្នំត្រូវស្វែងរកវិញ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>លំដាប់លំដះដាក់</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>រលាក់ចុង</translation>
@@ -492,69 +487,69 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>ຊື່: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>ສະເໜີ: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>ຕິດຕື່ງໃຫ້ຄັນອັກ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>ຕິດຕື່ງ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>ລື່ມ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ຕົວຢ່າງ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>ກັບຄົງ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>ສົ່ງສະໜອງແບບສົ່ງເປັນເຄື່ອງ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -563,8 +558,8 @@
         <translation type="vanished">ພະລັງການຕິດຕື່ງ %2ໃນແບບຄັນອັກ %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -577,12 +572,12 @@
         <translation type="vanished">ອົງປະຕິບັດທັງ່ %2 ເຊົ້າແລ້ວໄດ້ຖືກຕິດຕັ້ງຢຸດທາງ %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>ຕິດຕັ້ງສົ່ງເຖິງຄວາມສົ່ງເຖິງ</translation>
     </message>
@@ -591,95 +586,100 @@
         <translation type="vanished">ອົງປະຕິບັດທັງ່ %2 ເຊົ້າແລ້ວໄດ້ຖືກແບ່ງບອກອອກຈາກຢຸດທາງ %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>ແບ່ງບອກອອກສົ່ງເຖິງຄວາມສົ່ງເຖິງ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>ບໍ່ສົ່ງເຖິງຄວາມບໍ່ສົ່ງເຖິງ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>ກົນtract</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>%1 ລະບົດຈະຖືກລກງລົງ: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>ຖານທີ້ານົມໃນຖານທີ້ານົມ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>ຖານທີ້ານົມທີ້າງພາກ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>ລະບົດຕົວຈິງດຽວກັບທີ້າງພາກ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>ລະບົດເບິ່ງຄົງຫຼາຍກວ່າ: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>ຕົວຈິງຫຼຸດລຸດ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>ລະບົດເບິ່ງຄົງແໆ: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>ປັບປຸງ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>ກົນtractຖານທີ້ານົມ: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>ນំឡូតລ้ม hỏng %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>ວាយសេរុទ្ធសូចមិនถูกต้อง</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>ສម្រេចລើង</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>ສម្រេចគាំ</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>ສម្រេចລើង</translation>
     </message>
@@ -765,9 +765,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>ຕິດຕັ້ງໃນໂໝດທີ່ກົງກັນ</translation>
+        <translation type="vanished">ຕິດຕັ້ງໃນໂໝດທີ່ກົງກັນ</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_lt.ts
+++ b/translations/deepin-deb-installer_lt.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Paketų diegimo programa</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Nustatymai</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Yra kitų pакетų įdiegimas... Atidarykite vėliau.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Analizė nepavyko: rinkinio failo struktūra yra nesilaikanti kūrėjo vadovėlių!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Analizė nepavyko: rinkinio failo rinkinio numeris yra nesilaikantis kūrėjo vadovėlių!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Nerasta deb pакетų. Patikrinkite folderį.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Gali būti, kad %1 paketas yra sugadintas</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Galite įdiegti tik vietinius %1 pакетus</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Nėra leidimų priežiūrėti šio folderio</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Jau pridėta</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 neegzistuoja, pasirinkite iš naujo</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Masinis įdiegimas</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Suskleisti</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Suskleisti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Įdiegti iš naujo</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Paskirta versija įdiegta: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Atsijungti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Ankstesnė versija įdiegta: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Yra įdiegiami prireikiniai: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Nepavyko įdiegti %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Versija: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Įdiegti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Šalinti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Gerai</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Atgal</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Atlikta</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 sėkmingai įdiegta %1 kompatybumo režime</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Sėkmingai įdiegta</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 sėkmingai pašalinta iš %1 kompatybumo režimo</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Sėkmingai pašalinta</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Šalinimas nepavyko</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Install %1 pašalins: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Bazėje yra prireikiniai</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Trūksta priklausomybių</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Atnaujinti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Neteisingas skaitmeninis parašas</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Pavadinimas: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Įdiegta ta pati versija</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Rodyti išsamiau</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Rodyti priklausomybes</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Rodyti išsamiau</translation>
     </message>
@@ -765,9 +765,8 @@ Sistema arba kitos programos gali tinkamai neveikti</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Įdiegti suderinamumo režimu</translation>
+        <translation type="vanished">Įdiegti suderinamumo režimu</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_mn.ts
+++ b/translations/deepin-deb-installer_mn.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Багц Зохицуулагч</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Харагдах</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Бусад багажуудыг загварлах... Дараа нь нээж үзнэ үү.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Харагдах: Харагдах файлын загвар нь буруу байна!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Харагдах: Харагдах файлын версийн дугаар нь буруу байна!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Деb багажууд олдсонгүй. Дүрэмийг шалгана уу.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>%1 багаж нь бүтэцтэй болохыг хүсэж байна</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Хаанаас чавдартай %1 багажуудыг загварлах боломжтой</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Энэ дүрэмийг оролдох эрх байхгүй</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Дахин нэмэгдсэн</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 байхгүй, дараа нь сонгоно уу</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Багц суулгац</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Дэлгэх</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Дэлгэх</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Дахин суулгах</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Үүнээс өмнө хувилбар бүртгэгдсэн: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Хөнгөнөөсөх</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Эрнээ хувилбар бүртгэгдсэн: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Хамааралыг бүртгэж байна: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>%1-ийг бүртгэхэд амжилтгүй</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Хувилбар:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Суулгах</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Устгах</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Буцах</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Дууссан</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">&apos;%2-г %1 хүчинчлэлтийн үед амжилттай нэмэгдүүлэв&apos;</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Амжилттай суулгагдлаа</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">&apos;%2-г %1 хүчинчлэлтийн үед амжилттай устгаж байна&apos;</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Амжилттай устгагдлаа</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Устгах ажиллагаа амжилтгүй болсон</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>%1-г нэмэх нь дараахыг устгах болно: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Хадгалагчийн хамаарал</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Хамаарал багажгүй</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Цуцлах</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Шинчлэл</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Хүчтэй дигитал шинжилгээ багажгүй</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Нэр:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Адил хувилбар суулгагдсан</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Үнэндээ харуулах</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Хамаарал харуулах</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Үнэндээ харуулах</translation>
     </message>
@@ -765,9 +765,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Нийцтэй горимд суулгах</translation>
+        <translation type="vanished">Нийцтэй горимд суулгах</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_ms.ts
+++ b/translations/deepin-deb-installer_ms.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Pemasang Pakej</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Tetapan</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Memasang pakej lain... Sila buka ia kemudian.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Gagal dihurai: Satu struktur fail tidak sah telah ditemui dalam fail manifes!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Gagal dihurai: Satu nombor versi tidak sah telah ditemui dalam fail manife!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Tiada pakej deb ditemui. Sila periksa folder.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Pakej %1 mungkin rosak</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Anda hanya boleh memasang pakej %1 yang lokasl</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Tiada kebenaran untuk mengakses folder ini</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Sudah Ditambah</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 tidak wujud, sila pilih semula</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Pasang Pukal</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Kuncup</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Kuncup</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Pasang Semula</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Versi terkemudian dipasang: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Nyahtatar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Versi lebih awal dipasang: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Memasang dependensi: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Gagal memasang %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Versi:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Pasang</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Buang</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Undur</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Selesai</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 telah dipasang dengan jayanya ke dalam mod kompatibiliti %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Berjaya dipasang</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 telah diuninstall dengan jayanya dari mod kompatibiliti %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Berjaya dinyahpasang</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Nyahpasang Gagal</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Pemasangan %1 akan menghapuskan: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Dependensi dalam repositori</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Dependensi hilang</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Batal</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Kemas kini</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Tandatangan digital tidak sah</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Nama:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Versi serupa telah dipasang</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Tunjuk perincian</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Tunjuk dependensi</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Tunjuk perincian</translation>
     </message>
@@ -765,9 +765,8 @@ Sistem atau lain-lain aplikasi mungkin tidak berfungsi dengan baik</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Pasang dalam mod serasi</translation>
+        <translation type="vanished">Pasang dalam mod serasi</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_ne.ts
+++ b/translations/deepin-deb-installer_ne.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>प्याकेज स्थापनाकर्ता</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>सेटिङ्स</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>अन्य पैकेजहरू इन्स्टल गर्दैछन्... कृपया बादमा खोल्नुहोस्।</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>पार्सिंग असफल: मैनिफेस्ट फाइलमा अवैध फाइल संरचना फेला परेको छ!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>पार्सिंग असफल: मैनिफेस्ट फाइलमा अवैध संस्करण संख्या फेला परेको छ!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>कुनै deb पैकेज नपाइएको छ। कृपया फोल्डर जाँच गर्नुहोस्।</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>पैकेज %1 चाहिँ भेदभाव गर्न सकिन्छ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>तपाईंको लोकल %1 पैकेजहरू मात्र इन्स्टल गर्न सकिन्छ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>कुनै अनुमति यस फोल्डरमा प्रवेश गर्न नभएको छ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>पहिले नै थपिएको</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 अदभाव छ, कृपया पुनः चयेनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>बल्क स्थापना</translation>
     </message>
@@ -428,8 +423,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>संक्षिप्त गर्नुहोस्</translation>
@@ -494,113 +489,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>संक्षिप्त गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>पुन: स्थापना गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>अन्य वर्जन स्थापित गरिएको: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>अवतरण</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>पहिलो वर्जन स्थापित गरिएको: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>आवश्यकता स्थापित गर्दै: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>%1 स्थापना गर्न असफल</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>स्थापना</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>हटाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ठिक छ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>पछाडि</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>भयो</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -617,7 +617,7 @@
         <translation type="vanished">%2 %1 संगति मोडमा सफलतापूर्वक स्थापित गरिएको</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>सफलतापूर्वक स्थापित भयो</translation>
     </message>
@@ -626,62 +626,62 @@
         <translation type="vanished">%2 %1 संगति मोडबाट सफलतापूर्वक हटाइएको</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>सफलतापूर्वक स्थापना रद्द गरियो</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>स्थापना रद्द गरियो</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>%1 स्थापना गर्नु होला: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>रेपोसिटरीमा आवश्यकता</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>कम आवश्यकता</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">रद्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>अपडेट</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>अमान्य डिजिटल साइनेचर</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>नाम</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>एउटै संस्करण स्थापित</translation>
     </message>
@@ -689,16 +689,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>विवरण देखाऊ</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>दर्शाउँदछ</translation>
     </message>
@@ -706,8 +706,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>विवरण देखाऊ</translation>
     </message>
@@ -766,9 +766,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>अनुकूल मोडमा स्थापना गर्नुहोस्</translation>
+        <translation type="vanished">अनुकूल मोडमा स्थापना गर्नुहोस्</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_nl.ts
+++ b/translations/deepin-deb-installer_nl.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Pakketinstallatie</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Bezig met installeren van andere pakketten… Keer later terug.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Verwerking mislukt: onjuiste bestandsstructuur aangetroffen in manifestbestand!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Verwerking mislukt: ongeldig versienummer aangetroffen in manifestbestand!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Er zijn geen deb-pakketten aangetroffen - controleer de map.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Het %1-pakket is mogelijk beschadigd</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Je kunt alleen lokale %1-pakketten installeren</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Geen toegang tot deze map</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Reeds toegevoegd</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 bestaat niet - kies een ander bestand</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Alles installeren</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Inklappen</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Inklappen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Opnieuw installeren</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Nieuwere versie geïnstalleerd: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Afwaarderen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Oudere versie geïnstalleerd: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Bezig met installeren van afhankelijkheden: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>%1 kan niet worden geïnstalleerd</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Versie:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Installeren</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Terug</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Klaar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 is succesvol geïnstalleerd in %1 compatibiliteitsmodus</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Installatie voltooid</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 is verwijderd uit de %1-compatibiliteitsmodus</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Verwijderd</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Opnieuw installeren mislukt</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Door %1 wordt het volgende verwijderd:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Afhankelijkheden in de pakketbron</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Ontbrekende afhankelijkheden</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Bijwerken</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Ongeldige digitale handtekening</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Dezelfde versie is geïnstalleerd</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Informatie tonen</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Afhankelijkheden tonen</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Informatie tonen</translation>
     </message>
@@ -765,9 +765,8 @@ Het systeem of andere programma&apos;s werken dan mogelijk niet goed meer.</tran
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Installeren in compatibele modus</translation>
+        <translation type="vanished">Installeren in compatibele modus</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_pa.ts
+++ b/translations/deepin-deb-installer_pa.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>پکیج انSTALLر</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>سیٹنگس</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>دوسرے پکیجز انSTALL کر رہے ہیں ... کیا کریں اسے بعد میں چھوڑ دیں۔</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>پارس کرنا ہے: مانیفیسٹ فائل میں غیرقانونی فائل ساخت پائی گئی!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>پارس کرنا ہے: مانیفیسٹ فائل میں غیرقانونی ورژن نمبر پائی گئی!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>کوئی دیب پکیج نہیں پایا گیا۔ فولڈر کا جائزہ لیں۔</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>پکیج %1 ٹوٹ چکا ہو سکتا ہے</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>آپ صرف لوکل %1 پکیجز انSTALL کر سکتے ہیں</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>اس فولڈر کا اکسیس کرنے کی اجازت نہیں</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>پہلے ہی شامل کر دیا گیا</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 موجود نہیں ہے، کیا کریں اسے دوبارہ انتخاب کریں۔</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>بک انSTALL</translation>
     </message>
@@ -427,8 +422,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>کولپس کریں</translation>
@@ -493,113 +488,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>الانكماش</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>ਮੁੜ-ਇੰਸਟਾਲ ਕਰੋ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>النسخة الأحدث تم تثبيتها: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>الحد من النسخة</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>النسخة الأقدم تم تثبيتها: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>تثبيت الاعتماديات: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>فشل في تثبيت %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>ਵਰਜ਼ਨ:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation type="unfinished">ਇੰਸਟਾਲ ਕਰੋ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation type="unfinished">ਹਟਾਓ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">ਠੀਕ ਹੈ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation type="unfinished">ਪਿੱਛੇ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation type="unfinished">ਮੁਕੰਮਲ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -616,7 +616,7 @@
         <translation type="vanished">%2 تم تثبيتها بنجاح في وضع التوافق %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>ਕਾਮਯਾਬੀ ਨਾਲ ਇੰਸਟਾਲ ਕੀਤਾ</translation>
     </message>
@@ -625,62 +625,62 @@
         <translation type="vanished">%2 تم إلغاء تثبيتها بنجاح من وضع التوافق %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>ਅਣ-ਇੰਸਟਾਲ ਕਰਨਾ ਕਾਮਯਾਬ ਰਿਹਾ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>ਅਣ-ਇੰਸਟਾਲ ਕਰਨਾ ਅਸਫ਼ਲ ਹੈ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>تثبيت %1 سيقوم بإزالة:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>الاعتماديات في المستودع</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>الاعتماديات المفقودة</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>التحديث</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>التوقيع الرقمي غير صحيح</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>الاسم:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>ਉਹੀ ਵਰਜ਼ਨ ਇੰਸਟਾਲ ਹੈ</translation>
     </message>
@@ -688,16 +688,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>عرض التفاصيل</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>عرض الاعتماديات</translation>
     </message>
@@ -705,8 +705,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>عرض التفاصيل</translation>
     </message>
@@ -766,9 +766,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>ਅਨੁਕੂਲ ਮੋਡ ਵਿੱਚ ਇੰਸਟੌਲ ਕਰੋ</translation>
+        <translation type="vanished">ਅਨੁਕੂਲ ਮੋਡ ਵਿੱਚ ਇੰਸਟੌਲ ਕਰੋ</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_pl.ts
+++ b/translations/deepin-deb-installer_pl.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Instalator pakietów</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Trwa instalacja innych pakietów... Otwórz później.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Wystąpił błąd parsowania: W pliku manifest znaleziono nieprawidłową strukturę!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Wystąpił błąd parsowania: W pliku manifest znaleziono nieprawidłowy numer wersji!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Nie znaleziono pakietów deb. Sprawdź folder, w którym się znajduje.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Pakiet %1 może być uszkodzony</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Możesz instalować tylko lokalne pakiety %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Brak uprawnień dostępu do tego folderu</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Już dodano</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 nie istnieje, zaznacz ponownie</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Instalacja zbiorcza</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Zwiń</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Zwiń</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Przeinstaluj</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Nowsza wersja zainstalowana: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Downgrade</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Wcześniejsza wersja zainstalowana: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Instalowanie zależności: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Nie udało się zainstalować %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Wersja:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Zainstaluj</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Wstecz</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Gotowe</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 został pomyślnie zainstalowany w trybie zgodności %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Zainstalowano pomyślnie</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">Odinstalowano pomyślnie %2 w trybie kompatybilności %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Odinstalowano pomyślnie</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Błąd odinstalowania</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Instalacja %1 usunie: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Zależności w repozytorium</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Brakujące zależności</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Aktualizuj</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Nieprawidłowa sygnatura certyfikatu</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Nazwa:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Zainstalowana ta sama wersja</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Pokaż szczegóły</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Pokaż zależności</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Pokaż szczegóły</translation>
     </message>
@@ -765,9 +765,8 @@ System lub inne aplikacje mogą nie działać poprawnie</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Zainstaluj w trybie zgodności</translation>
+        <translation type="vanished">Zainstaluj w trybie zgodności</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_pt.ts
+++ b/translations/deepin-deb-installer_pt.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Instalador de Pacotes</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Definições</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>A instalar outros pacotes... Abrir mais tarde.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Falha ao analisar: Foi encontrada uma estrutura de ficheiro ilegal no ficheiro de manifesto!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Falha ao analisar: Foi encontrado um número de versão ilegal no ficheiro de manifesto!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Não foram encontrados pacotes deb. Verificar a pasta.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>O pacote %1 pode estar danificado</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Você pode instalar apenas pacotes %1 locais</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Sem permissão para acessar esta pasta</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Já adicionado</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 não existe, selecione novamente</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Instalação em massa</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Ocultar</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Ocultar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Reinstalar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Versão posterior instalada: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Desatualizar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Versão anterior instalada: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>A instalar dependências: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Falha ao instalar %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Versão:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Instalar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Remover</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Concluído</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 foi instalado com sucesso no modo de compatibilidade %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Instalado com sucesso</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 foi desinstalado com sucesso do modo de compatibilidade %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Desinstalado com sucesso</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Falha na desinstalação</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Instalar %1 removerá: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Dependências no repositório</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Dependências em falta</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Assinatura digital inválida</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>A mesma versão já está instalada</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Mostrar detalhes</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Mostrar dependências</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Mostrar detalhes</translation>
     </message>
@@ -765,9 +765,8 @@ O sistema ou outras aplicações podem não funcionar corretamente</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Instalar em modo compatível</translation>
+        <translation type="vanished">Instalar em modo compatível</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_pt_BR.ts
+++ b/translations/deepin-deb-installer_pt_BR.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Instalador de Pacotes</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Instalando outros pacotes... Abra-o mais tarde.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>A análise falhou: Foi encontrada uma estrutura de arquivo ilegal no arquivo de manifesto!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>A análise falhou: Foi encontrado um número de versão ilegal no arquivo de manifesto!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Nenhum pacote .deb foi encontrado. Verifique a pasta.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>O pacote %1 pode estar corrompido</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Você só pode instalar %1 pacotes locais</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Nenhuma permissão para acessar esta pasta</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Já adicionado</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 não existe; selecione-o novamente</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Instalação em massa</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Ocultar</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Ocultar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Reinstalar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Última versão instalada: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Downgrade</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Versão anterior instalada: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Instalando dependências: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Falha na instalação %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Versão:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Instalar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Remover</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Voltar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Concluído</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 foi instalado em %1 com sucesso pelo modo de compatibilidade</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Instalado</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 foi desinstalado de %1 com sucesso pelo modo de compatibilidade</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Desinstalado</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>A desinstalação falhou</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>A instalação de %1 removerá:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Dependências no repositório</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Dependências ausentes</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Assinatura digital inválida</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Mesma versão instalada</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Exibir detalhes</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Exibir dependências</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Exibir detalhes</translation>
     </message>
@@ -765,9 +765,8 @@ O sistema e/ou outros aplicativos podem não funcionar corretamente</translation
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Instalar em modo compatível</translation>
+        <translation type="vanished">Instalar em modo compatível</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_ru.ts
+++ b/translations/deepin-deb-installer_ru.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Установщик пакетов</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Установка других пакетов... Пожалуйста, откройте позже.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Ошибка анализа: в файле манифеста обнаружена недопустимая структура файла!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Ошибка анализа: в файле манифеста обнаружен недопустимый номер версии!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>DEB-пакеты не найдены. Проверьте папку.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Пакет %1 может быть повреждён</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Вы можете устанавливать только локальные пакеты %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Нет прав доступа к этой папке</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Уже добавлено</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 не существует, пожалуйста, выберите снова</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Массовая установка</translation>
     </message>
@@ -434,8 +429,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Свернуть</translation>
@@ -500,64 +495,69 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Свернуть</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Переустановить</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Установлена более новая версия: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Понизить версию</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Установлена более старая версия: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Установка зависимостей: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Не удалось установить %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Версия:</translation>
     </message>
@@ -566,51 +566,51 @@
         <translation type="vanished">Выберите режим совместимости:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Установить</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -627,7 +627,7 @@
         <translation type="vanished">%2 успешно установлен в режим совместимости %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Установка выполнена успешно</translation>
     </message>
@@ -636,62 +636,62 @@
         <translation type="vanished">%2 успешно удалён из режима совместимости %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Удаление выполнено успешно</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Ошибка удаления</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Установка %1 приведёт к удалению:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Зависимости из репозитория</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Отсутствующие зависимости</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Отмена</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Недействительная цифровая подпись</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Название:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Такая же версия уже установлена</translation>
     </message>
@@ -699,16 +699,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Показать подробности</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Показать зависимости</translation>
     </message>
@@ -716,8 +716,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Показать подробности</translation>
     </message>
@@ -783,9 +783,8 @@ from %1 compatibility mode?</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Установить в режиме совместимости</translation>
+        <translation type="vanished">Установить в режиме совместимости</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_sk.ts
+++ b/translations/deepin-deb-installer_sk.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Správca balíčkov</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Inštalácia iných balíčkov... Prosím, otvorte to neskôr.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Parsovanie zlyhalo: v manifestovom súbore sa našlo neplatné štruktúr</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Parsovanie zlyhalo: v manifestovom súbore sa našlo neplatné číslo verzie!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Nie sú nájdené žiadne deb balíčky. Prosím, skontrolujte priečinok.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Balíčok %1 môže byť poškodený</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Môžete inštalovať len lokálne %1 balíčky</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Žiadna oprávnenie na prístup do tohto priečinku</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Už pridaný</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 neexistuje, prosím, zvoľte znovu</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Hromadná inštalácia</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Zbaliť</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Zbaliť</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Reinštalovať</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Neskoršia verzia je nainštalovaná: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Znížiť verziu</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Nainštalovaná skoršia verzia: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Inštalácia závislostí: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Nepodarilo sa nainštalovať %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Verzia:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Inštalovať</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Odstrániť</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Späť</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 bol úspešne nainštalovaný do režimu kompatibility %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Úspešne nainštalované</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 bol úspešne odinštalovaný v režime kompatibility s %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Úspešne odinštalované</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Odinštalovanie zlyhalo</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Inštalácia %1 odstráni: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Závislosti v repozitári</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Chýbajúce závislosti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Aktualizovať</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Neplatný digitálne podpis</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Názov:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Rovnaká verzia je nainštalovaná</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Zobraziť podrobnosti</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Zobraziť závislosti</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Zobraziť podrobnosti</translation>
     </message>
@@ -765,9 +765,8 @@ Systém alebo iné aplikácie môžu nefungovať správne</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Inštalovať v kompatibilnom režime</translation>
+        <translation type="vanished">Inštalovať v kompatibilnom režime</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_sl.ts
+++ b/translations/deepin-deb-installer_sl.ts
@@ -49,72 +49,67 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Instalator paketov</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Nastavitve</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Nastavljanje drugih paketov... Prosim, odprite ga kasneje.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Analiziranje je spodletelo: Nalazena je nepravilna struktura datoteke v manifestu!
 </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Analiziranje je spodletelo: Nalazeno je nepravilno številko različice v manifestu!
 </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Ni najdenih deb paketov. Prosim, preverite mapo.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Paket %1 je možno narejeno zgrešeno</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Možno je naložiti samo lokalnih paketov %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Ni dovoljenja za dostop do tej mape</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Večkrat dodano</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 ne obstaja, prosimo, ponovno izberite</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Bulk namestitev</translation>
     </message>
@@ -429,8 +424,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Skrij</translation>
@@ -495,113 +490,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Skrij</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Ponovno namesti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Nameščena je kasnejša različica: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Opusti različico</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Nameščena je ranjša različica: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Nameščanje ovisnosti: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Namestitev %1 je zavržena</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Različica:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Namesti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Odstrani</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>V redu</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Nazaj</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Opravljeno</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -618,7 +618,7 @@
         <translation type="vanished">%2 je uspešno nameščen v kompatibilnostnem načinu %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Uspešno nameščeno</translation>
     </message>
@@ -627,62 +627,62 @@
         <translation type="vanished">%2 je uspešno odstranjen iz kompatibilnostnega načina %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Uspešno odstranjeno</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Odstranjevanje neuspešno</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Namestitev %1 bo odstranila:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Ovisnosti v zbirki</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Manjkejo ovisnosti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Prekliči</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Posodobi</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Neveljaven digitalni potrdil</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Ime:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Ista različica že nameščena</translation>
     </message>
@@ -690,16 +690,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Pokaži podrobnosti</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Pokaž odvisnosti</translation>
     </message>
@@ -707,8 +707,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Pokaž podrobnosti</translation>
     </message>
@@ -768,9 +768,8 @@ Sistem ali druge aplikacije ne bodo močno delovale</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Namesti v združljivem načinu</translation>
+        <translation type="vanished">Namesti v združljivem načinu</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_sq.ts
+++ b/translations/deepin-deb-installer_sq.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Instalues Paketash</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Rregullime</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Po instalohen paketa të tjera… Ju lutemi, hapeni më vonë.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Analizimi dështoi: Te kartela manifest u gjet një strukturë jo e ligjshme kartelash!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Analizimi dështoi: Te kartela manifest u gjet një numër jo i ligjshëm versioni!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>S’u gjetën paketa deb. Ju lutemi, kontrolloni dosjen.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Paketa %1 mund të jetë e dëmtuar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Mund të instaloni vetëm paketa %1 vendore</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>S’ka leje për hyrjen në këtë dosje</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>E shtuar Tashmë</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 s’ekziston, ju lutemi, ripërzgjidhni</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Instalim Në Masë</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Tkurre</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Tkurre</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Riinstaloje</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Version më i vonshëm i instaluar: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Kaloje në versionin e mëparshëm</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Version më i hershëm i instaluar: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Po instalohen varësi: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>S’u arrit të instalohej %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Version: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Instaloje</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Hiqe</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Mbrapsht</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>U bë</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 ujë duke jetë suksessore instaluar në modën e kufizimeve të %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>U instalua me sukses</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 u çinstalua me sukses te mënyrë përputhje %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>U çinstalua me sukses</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Çinstalimi Dështoi</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Instalimi i %1 do të heqë: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Varësi te depoja</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Mungojnë varësi</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Përditësoje</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Nënshkrim dixhital i pavlefshëm</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Emër: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Version i njëjtë i instaluar</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Shfaq hollësi</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Shfaqi varësitë</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Shfaq hollësi</translation>
     </message>
@@ -765,9 +765,8 @@ Sistemi ose aplikacione të tjera mund të mos punojnë si duhet</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Instalo në mënyrë përputhëse</translation>
+        <translation type="vanished">Instalo në mënyrë përputhëse</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_sr.ts
+++ b/translations/deepin-deb-installer_sr.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Инсталатер Пакета</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Подешавања</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Инсталирање других пакета... Молимо вас, отворите га касније.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Парсиранje неuspelo: У манифесту је пронађена невалидна структура датотеке!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Парсиранje неuspelo: У манифесту је пронађен невалидан број верзије!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Нису пронађени deb пакети. Молимо вас проверите фолдер.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Пакет %1 можда је оштећен</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Можете да инсталирате само локалне %1 пакете</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Нема дозволе за приступ овом фолдеру</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Већ додато</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 не постоји, поново изаберите</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Групно инсталирање</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Скупи</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Скупи</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Инсталирај</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Новија верзија је инсталирана: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Снизи верзију</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Старија верзија је инсталирана: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Инсталирање зависности: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Неуспешна инсталација %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Верзија:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Инсталирај</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Уклони</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>У реду</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 је успешно инсталиран у режиму компатибилности %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Успешно инсталирано</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 је успешно деинсталиран из режима компатибилности %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Успешно уклоњено</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Неуспешно уклањање</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Инсталирање %1 ће уклонити: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Зависности у ризници</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Недостајуће зависности</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Откажи</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Ажурирај</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Неважећи дигитални потпис</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Име:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Иста верзија је инсталирана</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Детаљи</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Прикажи зависности</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Детаљи</translation>
     </message>
@@ -765,9 +765,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Инсталирај у компатибилном режиму</translation>
+        <translation type="vanished">Инсталирај у компатибилном режиму</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_tr.ts
+++ b/translations/deepin-deb-installer_tr.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Paket Kurucu</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Diğer paketler yükleniyor... Lütfen daha sonra tekrar açınız</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Ayrıştırma başarısız oldu: Manifest dosyasında geçersiz bir dosya yapısı bulundu!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Ayrıştırma başarısız oldu: Manifest dosyasında geçersiz bir sürüm numarası bulundu!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Hiçbir deb paketi bulunamadı. Lütfen klasörü kontrol edin.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>%1 paketi bozulmuş olabilir</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Yalnızca yerel %1 paketlerini yükleyebilirsiniz</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Bu klasöre erişim izni yok</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Zaten Eklenmiş</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 mevcut değil, lütfen yeniden seçin</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Toplu Kurulum</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Daralt</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Daralt</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Yeniden kur</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Daha sonraki sürüm kurulu: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Düşür</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Önceki sürüm kurulu: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Bağımlılıklar kuruluyor: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>%1 Kurulamadı</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Sürüm: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Kur</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Kaldır</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Tamam</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Geri</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Bitti</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2, %1&apos;in uyumluluk moduna başarıyla yüklendi</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Kuruldu</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2, %1&apos;in uyumluluk modundan başarıyla kaldırıldı</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Kaldırıldı</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Kaldırılamadı</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>%1 kurulumu şunları kaldıracak:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Depodaki bağımlılıklar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Eksik bağımlılıklar</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">İptal</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Yükselt</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Geçersiz dijital imza</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Ad: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Aynı sürüm kurulu</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Ayrıntıları göster</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Bağımlılıkları göster</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Ayrıntıları göster</translation>
     </message>
@@ -765,9 +765,8 @@ Sistem veya diğer uygulamalar düzgün çalışmayabilir</translation>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Uyumlu modda yükle</translation>
+        <translation type="vanished">Uyumlu modda yükle</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_ug.ts
+++ b/translations/deepin-deb-installer_ug.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>بوغچا قاچىلىغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>تەڭشەك</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>قاچىلاش باسقۇچى ئىجرا بولۇۋاتىدۇ، سەل تۇرۇپ ئېچىڭ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>يۇمشاق دېتال بولىقىنى يېشەلمىدى، يۇمشاق دېتال بولىقى تىزىملىكىدە قانۇنسىز ھۆججەت قۇرۇلمىسى مەۋجۇت!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>يۇمشاق دېتال بولىقىنى يېشەلمىدى، يۇمشاق دېتال بولىقى تىزىملىكىدە قانۇنسىز نەشر نومۇرى مەۋجۇت!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>قاچىلاش بولىقىنى تاپالمىدى، قاچىلاش مۇندەرىجىسىنى تەكشۈرۈڭ!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>دۇنيا %1 پاكىج بىلەن كېلگەن</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>سەن ئەپتەك %1 پاكىجلىرىنى ئۇچرىنىڭ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>بۇ كىتابخانەنى كىرەنگە ئەھۋالنى بېرىمەيدۇ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>بۇرۇنلا قوشۇلغان</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 ھۆججەت مەۋجۇت ئەمەس، باشقىسىنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>توپ قاچىلاش</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>يىمىرىش</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>يىمىرىش</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>قايتا قاچىلاش</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>ئەڭ يېڭى نەشىرى قاچىلاندى %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>كونا نەشرىنى قاچىلاش</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>بۇرۇنقى نەشىرى قاچىلاندى %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>بېقىنما %1 نى قاچىلاۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>نى قاچىلىيالمىدى %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>نەشىرى:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>قاچىلاش</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>ئۆچۈرۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>تامام</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>قايتىش</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>تامام</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -615,7 +615,7 @@
         <translation type="vanished">%2 %1 تېسىم ئەھۋالىنى ئۇچرىنىڭ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>قاچىلاش تاماملاندى</translation>
     </message>
@@ -624,62 +624,62 @@
         <translation type="vanished">%2 %1 تېسىم ئەھۋالىنى ئۇچرىنىڭ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>ئۆچۈرۋېتىش تاماملاندى</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>ئۆچۈرۈش مەغلۇپ بولدى</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>%1 ئۇچرىنىڭ بىلەن ئۇچرىنىڭ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>ئىسكىلاتتا بار ياتانچ بولاق</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>ئىسكىلاتتا يوق تايانچ بولاق</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>رەقەملىك ئىمزا ئىناۋەتسىز</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>ئىسمى:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>ئوخشاش نەشىرى قاچىلاندى</translation>
     </message>
@@ -687,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>تەپسىلىي ئۇچۇرىنى كۆرسىتىش</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>كۆرۈنگەن تايانچ بولاق</translation>
     </message>
@@ -704,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>تەپسىلىي ئۇچۇرىنى كۆرسىتىش</translation>
     </message>
@@ -765,9 +765,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>ماس كېلىدىغان ھالەتتە ئورنىتىش</translation>
+        <translation type="vanished">ماس كېلىدىغان ھالەتتە ئورنىتىش</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_uk.ts
+++ b/translations/deepin-deb-installer_uk.ts
@@ -49,70 +49,65 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Встановлювач пакунків</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Встановлюємо інші пакунки… Будь ласка, відкрийте пізніше.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Не вдалося обробити: у файлі маніфесту виявлено некоректну структуру файлів!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Не вдалося обробити: у файлі маніфесту виявлено некоректний номер версії!</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Не знайдено пакунків deb. Будь ласка, перевірте теку.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Ймовірно, пакунок %1 пошкоджено</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Ви можете встановлювати лише локальні пакунки %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Немає прав доступу до цієї теки</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Вже додано</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 не існує. Будь ласка, виберіть щось інше</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Масова інсталяція</translation>
     </message>
@@ -426,8 +421,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Згорнути</translation>
@@ -492,113 +487,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Згорнути</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Перевстановити</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Встановлено пізнішу версію: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Знизити версію</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Встановлено старішу версію: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Встановлення залежностей: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Не вдалося встановити %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Версія: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Встановити</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Завершити</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -611,7 +611,7 @@
         <translation type="vanished">Вилучаємо %2 з режиму сумісності %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Встановлено успішно</translation>
     </message>
@@ -620,62 +620,62 @@
         <translation type="vanished">%2 було успішно вилучено з режиму сумісності %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Видалено успішно</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Не вдалося видалити&#xa0;</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Встановлення %1 призведе до вилучення такого: </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Залежності у сховищі</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Залежності, яких не вистачає</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Некоректний цифровий підпис</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Ім&apos;я:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Одна і та сама версія встановлена</translation>
     </message>
@@ -683,16 +683,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Показати подробиці</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Показати залежності</translation>
     </message>
@@ -700,8 +700,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Показати подробиці</translation>
     </message>
@@ -761,9 +761,8 @@ The system or other applications may not work properly</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Встановити в режимі сумісності</translation>
+        <translation type="vanished">Встановити в режимі сумісності</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_vi.ts
+++ b/translations/deepin-deb-installer_vi.ts
@@ -49,72 +49,67 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>Trình cài đặt gói</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>Cài đặt</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>Đang cài đặt các gói khác... Mở ứng dụng sau.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>Phân tích thất bại: Có cấu trúc tệp bất hợp pháp được tìm thấy trong tệp manifest!
 </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>Phân tích thất bại: Số phiên bản bất hợp pháp được tìm thấy trong tệp manifest!
 </translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>Không tìm thấy các gói deb. Vui lòng kiểm tra thư mục.</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>Gói %1 có thể bị hỏng</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>Bạn chỉ có thể cài đặt các gói %1 cục bộ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>Không có quyền truy cập vào thư mục này</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>Đã thêm</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1 không tồn tại, vui lòng chọn lại</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
-        <source>Compatible Mode Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>Cài đặt hàng loạt</translation>
     </message>
@@ -429,8 +424,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>Đóng lại</translation>
@@ -495,113 +490,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>Đóng lại</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>Cài lại</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>Phiên bản mới nhất đã cài: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>Giảm phiên bản</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>Phiên bản đã cài đặt trước đó: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>Đang cài đặt các thư viện liên quan: %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>Cài đặt thất bại %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>Phiên bản:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>Cài dặt</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>Xóa</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>Trở lại</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>Hoàn thành</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -618,7 +618,7 @@
         <translation type="vanished">%2 đã được cài đặt thành công trong chế độ tương thích %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>Đã cài đặt thành công</translation>
     </message>
@@ -627,62 +627,62 @@
         <translation type="vanished">%2 đã được gỡ cài đặt thành công từ chế độ tương thích %1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>Gỡ cài đặt thành công</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>Gỡ cài đặt thất bại</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>Cài đặt %1 sẽ gỡ cài đặt:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>Tùy thuộc trong kho</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>Tùy thuộc thiếu</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Cập nhật</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>Chữ ký số không hợp lệ</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>Tên:</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>Có một phiên bản tương tự đã được cài đặt</translation>
     </message>
@@ -690,16 +690,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>Hiện chi tiết</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>Hiển thị phụ thuộc</translation>
     </message>
@@ -707,8 +707,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>Hiện chi tiết</translation>
     </message>
@@ -768,9 +768,8 @@ Hệ thống hoặc phần mềm khác có thể không hoạt động</translat
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>Cài đặt ở chế độ tương thích</translation>
+        <translation type="vanished">Cài đặt ở chế độ tương thích</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_zh_CN.ts
+++ b/translations/deepin-deb-installer_zh_CN.ts
@@ -49,70 +49,69 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>软件包安装器</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>正在执行安装流程，无法打开</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>软件包解析失败，软件包清单包含非法的文件结构！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>软件包解析失败，软件包清单包含非法版本号！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>未检测到安装包，请检查安装目录！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>请检查%1包是否损坏</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>只能安装本地的%1包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>没有权限访问文件夹</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>已添加</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1文件不存在，请重新选择文件</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
         <source>Compatible Mode Install</source>
-        <translation>兼容模式安装</translation>
+        <translation type="vanished">兼容模式安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>批量安装</translation>
     </message>
@@ -426,8 +425,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>收 起</translation>
@@ -492,113 +491,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>重新安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation>正在从兼容模式卸载%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation>%1已成功安装到兼容模式</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>已安装较新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>安装旧版本</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>已安装较早的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation>兼容模式安装</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安装依赖：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>%1安装失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>卸 载</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation>如该软件为旧版（已适配历史系统版本）应用，可尝试以兼容模式安装。</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation>统信 UOS V25 兼容模式是一项让您能够在 V25 系统上继续使用 V20 版本应用程序的功能。为您创建了一个” 兼容环境”，让原本只能在 V20 系统上运行的软件，也能在 V25系统上正常工作。</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation>确认使用兼容模式安装软件包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation>正在使用兼容模式安装%1</translation>
     </message>
@@ -611,7 +615,7 @@
         <translation type="vanished">%2已成功安装到%1兼容模式</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>安装成功</translation>
     </message>
@@ -620,62 +624,62 @@
         <translation type="vanished">%2已从%1兼容模式成功卸载</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>卸载成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>卸载失败</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>安装%1将会卸载：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>仓库中存在的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>仓库中缺失的依赖包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation>兼容模式安装</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>数字签名无效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>名称：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>已安装相同版本</translation>
     </message>
@@ -683,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>显示详细信息</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>显示依赖包关系</translation>
     </message>
@@ -700,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>显示卸载进程</translation>
     </message>
@@ -767,9 +771,8 @@ All dependencies will also be removed</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>兼容模式安装</translation>
+        <translation type="vanished">兼容模式安装</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_zh_HK.ts
+++ b/translations/deepin-deb-installer_zh_HK.ts
@@ -49,70 +49,69 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>軟件包安裝器</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>正在執行安裝流程，無法打開</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>軟件包解析失敗，軟件包清單包含非法的文件結構！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>軟件包解析失敗，軟件包清單包含非法版本號！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>未檢測到安裝包，請檢查安裝目錄！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>請檢查%1包是否損壞</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>只能安裝本地的%1包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>沒有權限訪問文件夾</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>已添加</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1文件不存在，請重新選擇文件</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
         <source>Compatible Mode Install</source>
-        <translation>相容模式安裝</translation>
+        <translation type="vanished">相容模式安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>批量安裝</translation>
     </message>
@@ -426,8 +425,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>收 起</translation>
@@ -492,113 +491,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>重新安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation>正在從兼容模式卸載%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation>%1已成功安裝到兼容模式</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>已安裝較新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>安裝舊版本</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>已安裝較早的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation>相容模式安裝</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>卸 載</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation>如該軟件為舊版（已適配歷史系統版本）應用，可嘗試以相容模式安裝。</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation>統信 UOS V25 相容模式是一項讓您能夠在 V25 系統上繼續使用 V20 版本應用程式的功能。為您建立了一個相容環境，讓原本只能在 V20 系統上運作的軟件，也能在 V25 系統上正常運作。</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation>確認使用相容模式安裝軟件包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation>正在使用兼容模式安裝%1</translation>
     </message>
@@ -611,7 +615,7 @@
         <translation type="vanished">%2已從%1兼容模式成功卸載</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>安裝成功</translation>
     </message>
@@ -620,62 +624,62 @@
         <translation type="vanished">%2已從%1兼容模式成功卸載</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>卸載成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>卸載失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>安裝%1將會卸載：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation>相容模式安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>數字簽名無效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>名稱：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>已安裝相同版本</translation>
     </message>
@@ -683,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>顯示詳細訊息</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>顯示依賴包關係</translation>
     </message>
@@ -700,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>顯示卸載進程</translation>
     </message>
@@ -767,9 +771,8 @@ All dependencies will also be removed</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>相容模式安裝</translation>
+        <translation type="vanished">相容模式安裝</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_zh_TW.ts
+++ b/translations/deepin-deb-installer_zh_TW.ts
@@ -49,70 +49,69 @@
 <context>
     <name>DebInstaller</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="120"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
         <source>Package Installer</source>
         <translation>軟體包安裝器</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="133"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="733"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="890"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
         <source>Installing other packages... Please open it later.</source>
         <translation>正在執行安裝流程，無法打開</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="738"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
         <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
         <translation>套裝軟體解析失敗，套裝軟體清單包含非法的文件結構！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="740"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
         <source>Parsing failed: An illegal version number was found in the manifest file!</source>
         <translation>套裝軟體解析失敗，套裝軟體清單包含非法版本號！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="742"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
         <source>No deb packages found. Please check the folder.</source>
         <translation>未檢測到安裝包，請檢查安裝目錄！</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="913"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
         <source>The %1 package may be broken</source>
         <translation>請檢查%1包是否損壞</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="922"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
         <source>You can only install local %1 packages</source>
         <translation>只能安裝本機的%1包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="931"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
         <source>No permission to access this folder</source>
         <translation>沒有權限訪問資料夾</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="948"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
         <source>Already Added</source>
         <translation>已添加</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="957"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
         <source>%1 does not exist, please reselect</source>
         <translation>%1文件不存在，請重新選擇文件</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1162"/>
         <source>Compatible Mode Install</source>
-        <translation>相容模式安裝</translation>
+        <translation type="vanished">相容模式安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="450"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="965"/>
-        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1121"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
         <source>Bulk Install</source>
         <translation>批次安裝</translation>
     </message>
@@ -426,8 +425,8 @@
     <name>QApplication</name>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="61"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
         <source>Collapse</source>
         <comment>button</comment>
         <translation>隱 藏</translation>
@@ -492,113 +491,118 @@
 <context>
     <name>SingleInstallPage</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="996"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
         <source>Collapse</source>
         <translation>隱藏</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="394"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1144"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1196"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1428"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
         <source>Reinstall</source>
         <translation>重 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="787"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
         <source>Uninstalling %1 from compatibility mode</source>
         <translation>正在從相容模式卸載%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="923"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
         <source>%1 was successfully installed to compatibility mode</source>
         <translation>%1已成功安裝到相容模式</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1201"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1433"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
         <source>Later version installed: %1</source>
         <translation>已安裝較新的版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1202"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1434"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
         <source>Downgrade</source>
         <translation>安裝舊版本</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1207"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1439"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
         <source>Earlier version installed: %1</source>
         <translation>已安裝舊版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1326"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation>相容模式安裝</translation>
+    </message>
+    <message>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
         <source>Installing dependencies: %1</source>
         <translation>正在安裝依賴：%1</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1508"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
         <source>Failed to install %1</source>
         <translation>%1安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="222"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="386"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1233"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
         <source>Install</source>
         <comment>button</comment>
         <translation>安 裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="390"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
         <source>Remove</source>
         <comment>button</comment>
         <translation>移 除</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="398"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="978"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="402"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
         <source>Back</source>
         <comment>button</comment>
         <translation>返 回</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="406"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="914"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
         <source>Done</source>
         <comment>button</comment>
         <translation>完 成</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="517"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
         <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
         <translation>如該軟體為舊版（已適配歷史系統版本）應用，可嘗試以相容模式安裝。</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="518"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="541"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
         <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
         <translation>統信 UOS V25 相容模式是一項讓您能夠在 V25 系統上繼續使用 V20 版本應用程式的功能。為您建立了一個相容環境，讓原本只能在 V20 系統上運作的軟體，也能在 V25 系統上正常運作。</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="530"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
         <source>Confirm to install in compatibility mode</source>
         <translation>確認使用相容模式安裝軟體包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="704"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="744"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
         <source>Installing in compatibility mode %1</source>
         <translation>正在使用相容模式安裝%1</translation>
     </message>
@@ -611,7 +615,7 @@
         <translation type="vanished">%2已成功安裝到%1相容模式</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="926"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
         <source>Installed successfully</source>
         <translation>安裝成功</translation>
     </message>
@@ -620,62 +624,62 @@
         <translation type="vanished">%2已從%1相容模式成功移除</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
         <source>Uninstalled successfully</source>
         <translation>解除安裝成功</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="964"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
         <source>Uninstall Failed</source>
         <translation>解除安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1031"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
         <source>Install %1 will remove: </source>
         <translation>安裝%1將會移除：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1052"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
         <source>Dependencies in the repository</source>
         <translation>倉庫中存在的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1059"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
         <source>Missing dependencies</source>
         <translation>倉庫中缺失的依賴包</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1136"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
         <source>Compatible Install</source>
         <translation>相容模式安裝</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1138"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1208"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1440"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1514"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
         <source>Invalid digital signature</source>
         <translation>數位簽章無效</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="210"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
         <source>Name: </source>
         <translation>名稱：</translation>
     </message>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1195"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1427"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
         <source>Same version installed</source>
         <translation>已安裝相同版本</translation>
     </message>
@@ -683,16 +687,16 @@
 <context>
     <name>SingleInstallPage_Install</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="59"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="690"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="730"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="918"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
         <source>Show details</source>
         <translation>顯示詳細訊息</translation>
     </message>
     <message>
         <location filename="../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="60"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
         <source>Show dependencies</source>
         <translation>顯示依賴包關係</translation>
     </message>
@@ -700,8 +704,8 @@
 <context>
     <name>SingleInstallPage_Uninstall</name>
     <message>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="773"/>
-        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="932"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
         <source>Show details</source>
         <translation>顯示卸載進程</translation>
     </message>
@@ -767,9 +771,8 @@ All dependencies will also be removed</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
-        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation>相容模式安裝</translation>
+        <translation type="vanished">相容模式安裝</translation>
     </message>
 </context>
 <context>

--- a/translations/desktop/desktop_ar.ts
+++ b/translations/desktop/desktop_ar.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ar" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>مثبّت الحزم دبيان</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>مثبّت الحزم</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>مثبت الحزم: يساعد المستخدمين على تثبيت وإزالة الحزم المحلية، ويدعم أيضاً الثبيت الجماعي للحزم.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">مثبّت الحزم</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">مثبّت الحزم دبيان</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">مثبّت الحزم</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">مثبت الحزم: يساعد المستخدمين على تثبيت وإزالة الحزم المحلية، ويدعم أيضاً الثبيت الجماعي للحزم.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">مثبّت الحزم</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">مثبت الحزم: يساعد المستخدمين على تثبيت وإزالة الحزم المحلية، ويدعم أيضاً الثبيت الجماعي للحزم.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_az.ts
+++ b/translations/desktop/desktop_az.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="az" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin Paket Quraşdırıcı</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Paket quraşdırıcısı</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Paket quraşdırıcısı, istifadəçilərə paketləri quraşdırmağa və silməyə imkan verir, həmçinin toplu quraşdırmanı dəstəkləyir.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Paket quraşdırıcısı</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin Paket Quraşdırıcı</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Paket quraşdırıcısı</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Paket quraşdırıcısı, istifadəçilərə paketləri quraşdırmağa və silməyə imkan verir, həmçinin toplu quraşdırmanı dəstəkləyir.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Paket quraşdırıcısı</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Paket quraşdırıcısı, istifadəçilərə paketləri quraşdırmağa və silməyə imkan verir, həmçinin toplu quraşdırmanı dəstəkləyir.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_bg.ts
+++ b/translations/desktop/desktop_bg.ts
@@ -1,20 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bg">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bg">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Мениджър на пакети</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 <context>
     <name>desktop</name>
     <message>
-        <location filename="Desktop Entry]Name" line="0"/>
         <source>Deepin Package Installer</source>
-        <translation>Инсталатор на пакети Deepin</translation>
+        <translation type="vanished">Инсталатор на пакети Deepin</translation>
     </message>
     <message>
-        <location filename="Desktop Entry]GenericName" line="0"/>
         <source>Package Installer</source>
-        <translation>Мениджър на пакети</translation>
+        <translation type="vanished">Мениджър на пакети</translation>
     </message>
     <message>
-        <location filename="Desktop Entry]Comment" line="0"/>
         <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-        <translation>Deepin Мениджър на пакети се използва, за да помогне на потребителите да инсталират и премахват локален пакет, поддръжка на групово инсталиране.</translation>
+        <translation type="vanished">Deepin Мениджър на пакети се използва, за да помогне на потребителите да инсталират и премахват локален пакет, поддръжка на групово инсталиране.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Мениджър на пакети</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Deepin Мениджър на пакети се използва, за да помогне на потребителите да инсталират и премахват локален пакет, поддръжка на групово инсталиране.</translation>
     </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_bn.ts
+++ b/translations/desktop/desktop_bn.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="bn" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>ডিপিন প্যাকেজ ইনস্টল্যার</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>প্যাকেজ ইনস্টল্যার</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>প্যাকেজ ইনস্টল্যার মালিকানাধীন প্যাকেজ ইনস্টল এবং উন্মোচন করার সাহায্য করে এবং বার্ষিক ইনস্টলেশন সমর্থন করে।</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bn">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">প্যাকেজ ইনস্টল্যার</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">ডিপিন প্যাকেজ ইনস্টল্যার</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">প্যাকেজ ইনস্টল্যার</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">প্যাকেজ ইনস্টল্যার মালিকানাধীন প্যাকেজ ইনস্টল এবং উন্মোচন করার সাহায্য করে এবং বার্ষিক ইনস্টলেশন সমর্থন করে।</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">প্যাকেজ ইনস্টল্যার</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">প্যাকেজ ইনস্টল্যার মালিকানাধীন প্যাকেজ ইনস্টল এবং উন্মোচন করার সাহায্য করে এবং বার্ষিক ইনস্টলেশন সমর্থন করে।</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_bo.ts
+++ b/translations/desktop/desktop_bo.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="bo" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>གཏིང་ཟབ་མཉེན་ཆས་ཁུག་སྒྲིག་སྦྱོར་ཆས།</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>མཉེན་ཆས་ཁུག་སྒྲིག་སྦྱོར་ཆས།</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>མཉེན་ཆས་ཁུག་སྒྲིག་སྦྱོར་ཆས་ནི་སྤྱོད་མཁན་ལ་རང་སའི་མཉེན་ཆས་སྒྲིག་སྦྱོར་དང་བཤིག་འདོན་བྱེད་རོགས་བྱེད་པའི་ཡོ་བྱད་ཅིག་རེད་ལ། ཉེར་སྤྱོད་མང་པོ་མཉམ་དུ་སྒྲིག་སྦྱོར་བྱ་ཐུབ།</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bo">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">མཉེན་ཆས་ཁུག་སྒྲིག་སྦྱོར་ཆས།</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">གཏིང་ཟབ་མཉེན་ཆས་ཁུག་སྒྲིག་སྦྱོར་ཆས།</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">མཉེན་ཆས་ཁུག་སྒྲིག་སྦྱོར་ཆས།</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">མཉེན་ཆས་ཁུག་སྒྲིག་སྦྱོར་ཆས་ནི་སྤྱོད་མཁན་ལ་རང་སའི་མཉེན་ཆས་སྒྲིག་སྦྱོར་དང་བཤིག་འདོན་བྱེད་རོགས་བྱེད་པའི་ཡོ་བྱད་ཅིག་རེད་ལ། ཉེར་སྤྱོད་མང་པོ་མཉམ་དུ་སྒྲིག་སྦྱོར་བྱ་ཐུབ།</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">མཉེན་ཆས་ཁུག་སྒྲིག་སྦྱོར་ཆས།</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">མཉེན་ཆས་ཁུག་སྒྲིག་སྦྱོར་ཆས་ནི་སྤྱོད་མཁན་ལ་རང་སའི་མཉེན་ཆས་སྒྲིག་སྦྱོར་དང་བཤིག་འདོན་བྱེད་རོགས་བྱེད་པའི་ཡོ་བྱད་ཅིག་རེད་ལ། ཉེར་སྤྱོད་མང་པོ་མཉམ་དུ་སྒྲིག་སྦྱོར་བྱ་ཐུབ།</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_br.ts
+++ b/translations/desktop/desktop_br.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="br" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Stalier pakadoù Deepin</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Stalier pakadoù</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Ar stalier pakadoù a sikour an implijaderien da staliañ ha da zilemel ar pakadoù lec&apos;hel, hag e kemer e kont ar staliadur a-vloc&apos;had.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="br">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Stalier pakadoù</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Stalier pakadoù Deepin</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Stalier pakadoù</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Ar stalier pakadoù a sikour an implijaderien da staliañ ha da zilemel ar pakadoù lec&apos;hel, hag e kemer e kont ar staliadur a-vloc&apos;had.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Stalier pakadoù</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Ar stalier pakadoù a sikour an implijaderien da staliañ ha da zilemel ar pakadoù lec&apos;hel, hag e kemer e kont ar staliadur a-vloc&apos;had.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_ca.ts
+++ b/translations/desktop/desktop_ca.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ca" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Instal·lador de paquets del Deepin</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Instal·lador de paquets</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>L&apos;Instal·lador de paquets ajuda els usuaris a instal·lar i eliminar paquets locals i admet la instal·lació massiva.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instal·lador de paquets</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Instal·lador de paquets del Deepin</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Instal·lador de paquets</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">L&apos;Instal·lador de paquets ajuda els usuaris a instal·lar i eliminar paquets locals i admet la instal·lació massiva.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instal·lador de paquets</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">L&apos;Instal·lador de paquets ajuda els usuaris a instal·lar i eliminar paquets locals i admet la instal·lació massiva.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_cs.ts
+++ b/translations/desktop/desktop_cs.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="cs" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin instalátor balíčků</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Instalátor balíčků</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Instalátor balíčků slouží uživateli jako pomůcka pro instalaci a odebírání místních balíčků (tj. nepocházejících z repozitářů). Podporuje také hromadnou instalaci.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalátor balíčků</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin instalátor balíčků</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Instalátor balíčků</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Instalátor balíčků slouží uživateli jako pomůcka pro instalaci a odebírání místních balíčků (tj. nepocházejících z repozitářů). Podporuje také hromadnou instalaci.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalátor balíčků</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Instalátor balíčků slouží uživateli jako pomůcka pro instalaci a odebírání místních balíčků (tj. nepocházejících z repozitářů). Podporuje také hromadnou instalaci.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_da.ts
+++ b/translations/desktop/desktop_da.ts
@@ -1,20 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="da">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="da">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Pakkeinstallationsprogram</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 <context>
     <name>desktop</name>
     <message>
-        <location filename="Desktop Entry]Name" line="0"/>
         <source>Deepin Package Installer</source>
-        <translation>Deepin-pakkeinstaller</translation>
+        <translation type="vanished">Deepin-pakkeinstaller</translation>
     </message>
     <message>
-        <location filename="Desktop Entry]GenericName" line="0"/>
         <source>Package Installer</source>
-        <translation>Pakkeinstallationsprogram</translation>
+        <translation type="vanished">Pakkeinstallationsprogram</translation>
     </message>
     <message>
-        <location filename="Desktop Entry]Comment" line="0"/>
         <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-        <translation>Pakkeinstallationsprogram hjælpe brugere med at installere og fjerne lokale pakker, med understøttelse af masseinstallation.</translation>
+        <translation type="vanished">Pakkeinstallationsprogram hjælpe brugere med at installere og fjerne lokale pakker, med understøttelse af masseinstallation.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Pakkeinstallationsprogram</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Pakkeinstallationsprogram hjælpe brugere med at installere og fjerne lokale pakker, med understøttelse af masseinstallation.</translation>
     </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_de.ts
+++ b/translations/desktop/desktop_de.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="de" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin Paket-Installationsprogramm</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Paket-Installationsprogramm</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Das Paket-Installationsprogramm hilft Benutzern bei der Installation und Entfernung lokaler Pakete und unterstützt die Masseninstallation.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Paket-Installationsprogramm</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin Paket-Installationsprogramm</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Paket-Installationsprogramm</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Das Paket-Installationsprogramm hilft Benutzern bei der Installation und Entfernung lokaler Pakete und unterstützt die Masseninstallation.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Paket-Installationsprogramm</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Das Paket-Installationsprogramm hilft Benutzern bei der Installation und Entfernung lokaler Pakete und unterstützt die Masseninstallation.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_es.ts
+++ b/translations/desktop/desktop_es.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="es" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Instalador de paquetes</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Instalador de paquetes</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Instalador de paquetes de Deepin ayuda a instalar y eliminar paquetes locales, y admite instalación en masa.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalador de paquetes</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Instalador de paquetes</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Instalador de paquetes</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Instalador de paquetes de Deepin ayuda a instalar y eliminar paquetes locales, y admite instalación en masa.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalador de paquetes</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Instalador de paquetes de Deepin ayuda a instalar y eliminar paquetes locales, y admite instalación en masa.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_es_419.ts
+++ b/translations/desktop/desktop_es_419.ts
@@ -1,3 +1,760 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="es_419"><context><name>desktop</name><message><location filename="Desktop Entry]GenericName" line="0"/><location filename="Desktop Entry]Name" line="0"/><source>Package Installer</source><translation>Gestor de Paquetes</translation></message><message><location filename="Desktop Entry]Comment" line="0"/><source>Package Installer helps users install and remove local packages, and supports bulk installation.</source><translation>El Gestor de Paquetes Deepin se usa para ayudar a los usuarios a instalar y eliminar paquetes locales, admite la instalación masiva.</translation></message></context></TS>
+<TS version="2.1" language="es_419">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Gestor de Paquetes</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Gestor de Paquetes</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">El Gestor de Paquetes Deepin se usa para ayudar a los usuarios a instalar y eliminar paquetes locales, admite la instalación masiva.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Gestor de Paquetes</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">El Gestor de Paquetes Deepin se usa para ayudar a los usuarios a instalar y eliminar paquetes locales, admite la instalación masiva.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/desktop/desktop_et.ts
+++ b/translations/desktop/desktop_et.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="et" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin paketihaldur</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Pakihaldur</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Deepin pakihaldur on rakendus, millega kasutajad saavad arvutisse tarkvara paigaldada ja seda sealt eemaldada. Toetab ka hulgipaigaldamist.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="et">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Pakihaldur</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin paketihaldur</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Pakihaldur</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Deepin pakihaldur on rakendus, millega kasutajad saavad arvutisse tarkvara paigaldada ja seda sealt eemaldada. Toetab ka hulgipaigaldamist.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Pakihaldur</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Deepin pakihaldur on rakendus, millega kasutajad saavad arvutisse tarkvara paigaldada ja seda sealt eemaldada. Toetab ka hulgipaigaldamist.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_fi.ts
+++ b/translations/desktop/desktop_fi.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="fi" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin ohjelma-asentaja</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Ohjelma-asentaja</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Ohjelma-asentaja auttaa käyttäjiä asentamaan ja poistamaan ohjelmia.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Ohjelma-asentaja</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin ohjelma-asentaja</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Ohjelma-asentaja</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Ohjelma-asentaja auttaa käyttäjiä asentamaan ja poistamaan ohjelmia.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Ohjelma-asentaja</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Ohjelma-asentaja auttaa käyttäjiä asentamaan ja poistamaan ohjelmia.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_fil.ts
+++ b/translations/desktop/desktop_fil.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="fil" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin Package Installer</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Package Installer</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Ang Package Installer ay nakakatulog sa pag install at pag-tanggal ng mga local packages, at sinusuportahan ito nang pag-install ng mga packages na maramihan.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fil">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Package Installer</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin Package Installer</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Package Installer</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Ang Package Installer ay nakakatulog sa pag install at pag-tanggal ng mga local packages, at sinusuportahan ito nang pag-install ng mga packages na maramihan.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Package Installer</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Ang Package Installer ay nakakatulog sa pag install at pag-tanggal ng mga local packages, at sinusuportahan ito nang pag-install ng mga packages na maramihan.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_fr.ts
+++ b/translations/desktop/desktop_fr.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="fr" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Installateur de paquets Deepin</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Installateur de paquets</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Installateur de paquets aide les utilisateurs à installer et supprimer des paquets locaux et prend en charge l&apos;installation en bloc.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Installateur de paquets</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Installateur de paquets Deepin</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Installateur de paquets</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Installateur de paquets aide les utilisateurs à installer et supprimer des paquets locaux et prend en charge l&apos;installation en bloc.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Installateur de paquets</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Installateur de paquets aide les utilisateurs à installer et supprimer des paquets locaux et prend en charge l&apos;installation en bloc.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_gl_ES.ts
+++ b/translations/desktop/desktop_gl_ES.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="gl_ES" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Instalador do paquete de Deepin</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Instalador do paquete</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>O instalador do paquete axuda aos usuarios a instalar e eliminar paquetes locais e admite a instalación masiva.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="gl_ES">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalador do paquete</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Instalador do paquete de Deepin</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Instalador do paquete</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">O instalador do paquete axuda aos usuarios a instalar e eliminar paquetes locais e admite a instalación masiva.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalador do paquete</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">O instalador do paquete axuda aos usuarios a instalar e eliminar paquetes locais e admite a instalación masiva.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_he.ts
+++ b/translations/desktop/desktop_he.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="he" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>מונח הלוחות של דינין</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>מונח הלוחות</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>מונח הלוחות עוזר למשתמשים להתקין ולמחוק לוחות מקומיים, ועוזר להתקין בדבוש</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="he">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">מונח הלוחות</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">מונח הלוחות של דינין</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">מונח הלוחות</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">מונח הלוחות עוזר למשתמשים להתקין ולמחוק לוחות מקומיים, ועוזר להתקין בדבוש</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">מונח הלוחות</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">מונח הלוחות עוזר למשתמשים להתקין ולמחוק לוחות מקומיים, ועוזר להתקין בדבוש</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_hi_IN.ts
+++ b/translations/desktop/desktop_hi_IN.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="hi_IN" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>दीपिन पैकेज इंस्टॉलर</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>पैकेज इंस्टॉलर</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>पैकेज इंस्टॉलर द्वारा उपयोक्ता लोकल पैकेज इंस्टॉल व हटा सकते हैं, यह सामूहिक इंस्टॉल की सुविधा भी प्रदान करता है।</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hi_IN">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">पैकेज इंस्टॉलर</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">दीपिन पैकेज इंस्टॉलर</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">पैकेज इंस्टॉलर</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">पैकेज इंस्टॉलर द्वारा उपयोक्ता लोकल पैकेज इंस्टॉल व हटा सकते हैं, यह सामूहिक इंस्टॉल की सुविधा भी प्रदान करता है।</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">पैकेज इंस्टॉलर</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">पैकेज इंस्टॉलर द्वारा उपयोक्ता लोकल पैकेज इंस्टॉल व हटा सकते हैं, यह सामूहिक इंस्टॉल की सुविधा भी प्रदान करता है।</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_hr.ts
+++ b/translations/desktop/desktop_hr.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="hr" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin instaler paketa</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Instaler paketa</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Instaler paketa pomaže korisnicima instalaciju i uklanjanje lokalnih paketa kao i skupno instaliranje.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hr">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instaler paketa</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin instaler paketa</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Instaler paketa</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Instaler paketa pomaže korisnicima instalaciju i uklanjanje lokalnih paketa kao i skupno instaliranje.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instaler paketa</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Instaler paketa pomaže korisnicima instalaciju i uklanjanje lokalnih paketa kao i skupno instaliranje.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_hu.ts
+++ b/translations/desktop/desktop_hu.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="hu" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin® Csomagtelepítő</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Csomagtelepítő</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>A Csomagtelepítő segít a felhasználóknak különféle csomagok telepítésében és eltávolításában, valamint támogatja a kötegelt telepítést.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Csomagtelepítő</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin® Csomagtelepítő</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Csomagtelepítő</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">A Csomagtelepítő segít a felhasználóknak különféle csomagok telepítésében és eltávolításában, valamint támogatja a kötegelt telepítést.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Csomagtelepítő</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">A Csomagtelepítő segít a felhasználóknak különféle csomagok telepítésében és eltávolításában, valamint támogatja a kötegelt telepítést.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_id.ts
+++ b/translations/desktop/desktop_id.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="id" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Pemasang Paket Deepin</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Pemasang Paket</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Pemasang Paket membantu pengguna memasang dan menghapus paket lokal, dan mendukung instalasi massal.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="id">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Pemasang Paket</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Pemasang Paket Deepin</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Pemasang Paket</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Pemasang Paket membantu pengguna memasang dan menghapus paket lokal, dan mendukung instalasi massal.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Pemasang Paket</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Pemasang Paket membantu pengguna memasang dan menghapus paket lokal, dan mendukung instalasi massal.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_it.ts
+++ b/translations/desktop/desktop_it.ts
@@ -1,18 +1,766 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="it" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Gestore pacchetti di Deepin</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Gestore pacchetti</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Il Gestore pacchetti è utile per installare e rimuovere software in locale, supporta inoltre l&apos;installazione massiva.
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Gestore pacchetti</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Gestore pacchetti di Deepin</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Gestore pacchetti</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Il Gestore pacchetti è utile per installare e rimuovere software in locale, supporta inoltre l&apos;installazione massiva.
 Localizzazione italiana a cura di Massimo A. Carofano.</translation>
-</message>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Gestore pacchetti</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Il Gestore pacchetti è utile per installare e rimuovere software in locale, supporta inoltre l&apos;installazione massiva.
+Localizzazione italiana a cura di Massimo A. Carofano.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_ja.ts
+++ b/translations/desktop/desktop_ja.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ja" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin パッケージ インストーラー</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>パッケージ インストーラー</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>パッケージ インストーラーは、ユーザーがローカル パッケージをインストールしたり削除したりするのに役立ちます。一括インストールにも対応しています。</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">パッケージ インストーラー</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin パッケージ インストーラー</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">パッケージ インストーラー</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">パッケージ インストーラーは、ユーザーがローカル パッケージをインストールしたり削除したりするのに役立ちます。一括インストールにも対応しています。</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">パッケージ インストーラー</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">パッケージ インストーラーは、ユーザーがローカル パッケージをインストールしたり削除したりするのに役立ちます。一括インストールにも対応しています。</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_ko.ts
+++ b/translations/desktop/desktop_ko.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ko" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin 패키지 설치도구</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>패키지 관리자</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>패키지 설치 관리자는 사용자가 로컬 패키지를 설치하고, 제거할 수 있도록 지원하고 일괄 설치를 지원합니다.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ko">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">패키지 관리자</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin 패키지 설치도구</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">패키지 관리자</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">패키지 설치 관리자는 사용자가 로컬 패키지를 설치하고, 제거할 수 있도록 지원하고 일괄 설치를 지원합니다.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">패키지 관리자</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">패키지 설치 관리자는 사용자가 로컬 패키지를 설치하고, 제거할 수 있도록 지원하고 일괄 설치를 지원합니다.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_lo.ts
+++ b/translations/desktop/desktop_lo.ts
@@ -1,20 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">ກຳນຳ ອົງປະກອບ</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 <context>
     <name>desktop</name>
     <message>
-        <location filename="Desktop Entry]Name" line="0"/>
         <source>Deepin Package Installer</source>
-        <translation>ລូຫ្គិន ກියិតសຳຫຼື ກຳນຳ ອົງປະກອບ</translation>
+        <translation type="vanished">ລូຫ្គិន ກියិតសຳຫຼື ກຳນຳ ອົງປະກອບ</translation>
     </message>
     <message>
-        <location filename="Desktop Entry]GenericName" line="0"/>
         <source>Package Installer</source>
-        <translation>ກຳນຳ ອົງປະກອບ</translation>
+        <translation type="vanished">ກຳນຳ ອົງປະກອບ</translation>
     </message>
     <message>
-        <location filename="Desktop Entry]Comment" line="0"/>
         <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-        <translation>ກຳນຳ ອົງປະກອບ ກຳນຳຜູ້ໃຊ້ງານ ກຳນຳ ອົງປະກອບທ່ານຳໃນທະນາແມງແລະ ຂ້ອງກຳນຳກຳກຳກຳ ກຳນຳພາກຳພັນທະນາກຳນຳພາກຳໃຫ້ມີກວ່າໜີ້ໜີ້. ມີສະຫຼີດການນຳໃຊ້ກຳນຳພາກຳພັນທະນາ.</translation>
+        <translation type="vanished">ກຳນຳ ອົງປະກອບ ກຳນຳຜູ້ໃຊ້ງານ ກຳນຳ ອົງປະກອບທ່ານຳໃນທະນາແມງແລະ ຂ້ອງກຳນຳກຳກຳກຳ ກຳນຳພາກຳພັນທະນາກຳນຳພາກຳໃຫ້ມີກວ່າໜີ້ໜີ້. ມີສະຫຼີດການນຳໃຊ້ກຳນຳພາກຳພັນທະນາ.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">ກຳນຳ ອົງປະກອບ</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">ກຳນຳ ອົງປະກອບ ກຳນຳຜູ້ໃຊ້ງານ ກຳນຳ ອົງປະກອບທ່ານຳໃນທະນາແມງແລະ ຂ້ອງກຳນຳກຳກຳກຳ ກຳນຳພາກຳພັນທະນາກຳນຳພາກຳໃຫ້ມີກວ່າໜີ້ໜີ້. ມີສະຫຼີດການນຳໃຊ້ກຳນຳພາກຳພັນທະນາ.</translation>
     </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_lt.ts
+++ b/translations/desktop/desktop_lt.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="lt" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin Paketų Įdiegėjas</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Paketų diegimo programa</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Paketų diegimo programa padeda naudotojams įdiegti ir šalinti vietinius paketus bei palaiko masinį įdiegimą.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lt">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Paketų diegimo programa</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin Paketų Įdiegėjas</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Paketų diegimo programa</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Paketų diegimo programa padeda naudotojams įdiegti ir šalinti vietinius paketus bei palaiko masinį įdiegimą.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Paketų diegimo programa</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Paketų diegimo programa padeda naudotojams įdiegti ir šalinti vietinius paketus bei palaiko masinį įdiegimą.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_mn.ts
+++ b/translations/desktop/desktop_mn.ts
@@ -1,20 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="mn">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="mn">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Багц Зохицуулагч</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 <context>
     <name>desktop</name>
     <message>
-        <location filename="Desktop Entry]Name" line="0"/>
         <source>Deepin Package Installer</source>
-        <translation>Deepin-ийн пакажи хөгжүүлэгч</translation>
+        <translation type="vanished">Deepin-ийн пакажи хөгжүүлэгч</translation>
     </message>
     <message>
-        <location filename="Desktop Entry]GenericName" line="0"/>
         <source>Package Installer</source>
-        <translation>Багц Зохицуулагч</translation>
+        <translation type="vanished">Багц Зохицуулагч</translation>
     </message>
     <message>
-        <location filename="Desktop Entry]Comment" line="0"/>
         <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-        <translation>Деепин Багц Зохицуулагч нь хэрэглэгчдэд програм суулгах устгахад туслахаас гадна бүлэг суулгалтыг дэмждэг.</translation>
+        <translation type="vanished">Деепин Багц Зохицуулагч нь хэрэглэгчдэд програм суулгах устгахад туслахаас гадна бүлэг суулгалтыг дэмждэг.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Багц Зохицуулагч</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Деепин Багц Зохицуулагч нь хэрэглэгчдэд програм суулгах устгахад туслахаас гадна бүлэг суулгалтыг дэмждэг.</translation>
     </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_ms.ts
+++ b/translations/desktop/desktop_ms.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ms" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Pemasang Pakej Deepin</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Pemasang Pakej</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Pemasang pakej dapat membantu pengguna dan membuang pakej-pakej setempat, dan juga menyokong pemasangan pukal.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ms">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Pemasang Pakej</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Pemasang Pakej Deepin</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Pemasang Pakej</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Pemasang pakej dapat membantu pengguna dan membuang pakej-pakej setempat, dan juga menyokong pemasangan pukal.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Pemasang Pakej</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Pemasang pakej dapat membantu pengguna dan membuang pakej-pakej setempat, dan juga menyokong pemasangan pukal.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_ne.ts
+++ b/translations/desktop/desktop_ne.ts
@@ -1,20 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ne">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ne">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">प्याकेज स्थापनाकर्ता</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 <context>
     <name>desktop</name>
     <message>
-        <location filename="Desktop Entry]Name" line="0"/>
         <source>Deepin Package Installer</source>
-        <translation>डीपिन पैकेज इंस्टॉलर</translation>
+        <translation type="vanished">डीपिन पैकेज इंस्टॉलर</translation>
     </message>
     <message>
-        <location filename="Desktop Entry]GenericName" line="0"/>
         <source>Package Installer</source>
-        <translation>प्याकेज स्थापनाकर्ता</translation>
+        <translation type="vanished">प्याकेज स्थापनाकर्ता</translation>
     </message>
     <message>
-        <location filename="Desktop Entry]Comment" line="0"/>
         <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-        <translation>प्याकेज स्थापनाकर्ताले प्रयोगकर्ताहरूलाई स्थानीय प्याकेजहरू स्थापना र हटाउन मद्दत गर्दछ, र बल्क स्थापनालाई समर्थन गर्दछ।</translation>
+        <translation type="vanished">प्याकेज स्थापनाकर्ताले प्रयोगकर्ताहरूलाई स्थानीय प्याकेजहरू स्थापना र हटाउन मद्दत गर्दछ, र बल्क स्थापनालाई समर्थन गर्दछ।</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">प्याकेज स्थापनाकर्ता</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">प्याकेज स्थापनाकर्ताले प्रयोगकर्ताहरूलाई स्थानीय प्याकेजहरू स्थापना र हटाउन मद्दत गर्दछ, र बल्क स्थापनालाई समर्थन गर्दछ।</translation>
     </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_nl.ts
+++ b/translations/desktop/desktop_nl.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="nl" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin Pakketinstallatie</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Pakketinstallatie</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Pakketinstallatie is een programma dat gebruikers helpt bij het installeren van lokale software.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Pakketinstallatie</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin Pakketinstallatie</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Pakketinstallatie</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Pakketinstallatie is een programma dat gebruikers helpt bij het installeren van lokale software.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Pakketinstallatie</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Pakketinstallatie is een programma dat gebruikers helpt bij het installeren van lokale software.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_pa.ts
+++ b/translations/desktop/desktop_pa.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="pa" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>ਡੀਪਿਨ ਪੈਕੇਜ ਇੰਸਟਾਲਰ</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>ਪੈਕੇਜ ਮੈਨੇਜਰ</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>ਪੈਕੇਜ ਇੰਸਟਾਲਰ ਲੋਕਲ ਪੈਕੇਜਾਂ ਨੂੰ ਇੰਸਟਾਲ ਅਤੇ ਹਟਾਉਣ ਲਈ ਮਦਦ ਕਰਦਾ ਹੈ, ਇਹ ਵੱਡੀ ਗਿਣਤੀ ਵਿੱਚ ਇੰਸਟਾਲੇਸ਼ਨ ਲਈ ਵੀ ਸਹਾਇਕ ਹੈ।</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pa">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">ਪੈਕੇਜ ਮੈਨੇਜਰ</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">ਡੀਪਿਨ ਪੈਕੇਜ ਇੰਸਟਾਲਰ</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">ਪੈਕੇਜ ਮੈਨੇਜਰ</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">ਪੈਕੇਜ ਇੰਸਟਾਲਰ ਲੋਕਲ ਪੈਕੇਜਾਂ ਨੂੰ ਇੰਸਟਾਲ ਅਤੇ ਹਟਾਉਣ ਲਈ ਮਦਦ ਕਰਦਾ ਹੈ, ਇਹ ਵੱਡੀ ਗਿਣਤੀ ਵਿੱਚ ਇੰਸਟਾਲੇਸ਼ਨ ਲਈ ਵੀ ਸਹਾਇਕ ਹੈ।</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">ਪੈਕੇਜ ਮੈਨੇਜਰ</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">ਪੈਕੇਜ ਇੰਸਟਾਲਰ ਲੋਕਲ ਪੈਕੇਜਾਂ ਨੂੰ ਇੰਸਟਾਲ ਅਤੇ ਹਟਾਉਣ ਲਈ ਮਦਦ ਕਰਦਾ ਹੈ, ਇਹ ਵੱਡੀ ਗਿਣਤੀ ਵਿੱਚ ਇੰਸਟਾਲੇਸ਼ਨ ਲਈ ਵੀ ਸਹਾਇਕ ਹੈ।</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_pl.ts
+++ b/translations/desktop/desktop_pl.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="pl" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Instalator pakietów Deepin</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Instalator pakietów</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Instalator pakietów pomaga użytkownikom instalować i usuwać pakiety lokalne oraz obsługuje instalację zbiorczą.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalator pakietów</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Instalator pakietów Deepin</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Instalator pakietów</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Instalator pakietów pomaga użytkownikom instalować i usuwać pakiety lokalne oraz obsługuje instalację zbiorczą.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalator pakietów</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Instalator pakietów pomaga użytkownikom instalować i usuwać pakiety lokalne oraz obsługuje instalację zbiorczą.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_pt.ts
+++ b/translations/desktop/desktop_pt.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="pt" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Instalador de Pacotes Deepin</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Instalador de Pacotes</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>O Instalador de Pacotes ajuda os utilizadores a instalar e remover pacotes locais e suporta a instalação em massa.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalador de Pacotes</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Instalador de Pacotes Deepin</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Instalador de Pacotes</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">O Instalador de Pacotes ajuda os utilizadores a instalar e remover pacotes locais e suporta a instalação em massa.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalador de Pacotes</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">O Instalador de Pacotes ajuda os utilizadores a instalar e remover pacotes locais e suporta a instalação em massa.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_pt_BR.ts
+++ b/translations/desktop/desktop_pt_BR.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="pt_BR" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Instalador de Pacotes</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Instalador de Pacotes</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>O Instalador de Pacotes ajuda os usuários a instalar e remover os pacotes; além de, permitir a instalação em massa.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalador de Pacotes</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Instalador de Pacotes</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Instalador de Pacotes</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">O Instalador de Pacotes ajuda os usuários a instalar e remover os pacotes; além de, permitir a instalação em massa.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalador de Pacotes</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">O Instalador de Pacotes ajuda os usuários a instalar e remover os pacotes; além de, permitir a instalação em massa.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_ru.ts
+++ b/translations/desktop/desktop_ru.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ru" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Установщик пакетов Deepin</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Установщик пакетов</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Установщик пакетов помогает пользователям устанавливать и удалять локальные пакеты, а также поддерживает массовую установку.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Установщик пакетов</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Установщик пакетов Deepin</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Установщик пакетов</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Установщик пакетов помогает пользователям устанавливать и удалять локальные пакеты, а также поддерживает массовую установку.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Установщик пакетов</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Установщик пакетов помогает пользователям устанавливать и удалять локальные пакеты, а также поддерживает массовую установку.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_sk.ts
+++ b/translations/desktop/desktop_sk.ts
@@ -1,20 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sk">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Správca balíčkov</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 <context>
     <name>desktop</name>
     <message>
-        <location filename="Desktop Entry]Name" line="0"/>
         <source>Deepin Package Installer</source>
-        <translation>Instalátor balíčkov Deepin</translation>
+        <translation type="vanished">Instalátor balíčkov Deepin</translation>
     </message>
     <message>
-        <location filename="Desktop Entry]GenericName" line="0"/>
         <source>Package Installer</source>
-        <translation>Správca balíčkov</translation>
+        <translation type="vanished">Správca balíčkov</translation>
     </message>
     <message>
-        <location filename="Desktop Entry]Comment" line="0"/>
         <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-        <translation>Aplikácia Deepin Správca balíčkov slúži na pomoc používateľom pri inštalácii a odstraňovaní lokálnych balíčkov, podporuje hromadnú inštaláciu.</translation>
+        <translation type="vanished">Aplikácia Deepin Správca balíčkov slúži na pomoc používateľom pri inštalácii a odstraňovaní lokálnych balíčkov, podporuje hromadnú inštaláciu.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Správca balíčkov</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Aplikácia Deepin Správca balíčkov slúži na pomoc používateľom pri inštalácii a odstraňovaní lokálnych balíčkov, podporuje hromadnú inštaláciu.</translation>
     </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_sl.ts
+++ b/translations/desktop/desktop_sl.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="sl" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Instalator pakitet Deepin</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Instalator pakitet</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Instalator pakitet pomaga uporabnikom namestiti in odinstalirati lokalna paketa in podpira nameščanje več paketov.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sl">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalator pakitet</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Instalator pakitet Deepin</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Instalator pakitet</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Instalator pakitet pomaga uporabnikom namestiti in odinstalirati lokalna paketa in podpira nameščanje več paketov.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalator pakitet</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Instalator pakitet pomaga uporabnikom namestiti in odinstalirati lokalna paketa in podpira nameščanje več paketov.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_sq.ts
+++ b/translations/desktop/desktop_sq.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="sq" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Instalues Paketash Deepin</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Instalues Paketash</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Instaluesi i Paketave i ndihmon përdoruesit të instalojnë dhe heqin paketa vendore dhe mbulon instalime në masë.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalues Paketash</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Instalues Paketash Deepin</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Instalues Paketash</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Instaluesi i Paketave i ndihmon përdoruesit të instalojnë dhe heqin paketa vendore dhe mbulon instalime në masë.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Instalues Paketash</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Instaluesi i Paketave i ndihmon përdoruesit të instalojnë dhe heqin paketa vendore dhe mbulon instalime në masë.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_sr.ts
+++ b/translations/desktop/desktop_sr.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="sr" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Дипин Инсталатер Пакета</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Инсталатер Пакета</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Инсалатер пакета помаже корисницима да инсталирају и уклањају локалне пакете. Подржава групну инсталацију.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sr">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Инсталатер Пакета</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Дипин Инсталатер Пакета</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Инсталатер Пакета</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Инсалатер пакета помаже корисницима да инсталирају и уклањају локалне пакете. Подржава групну инсталацију.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Инсталатер Пакета</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Инсалатер пакета помаже корисницима да инсталирају и уклањају локалне пакете. Подржава групну инсталацију.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_tr.ts
+++ b/translations/desktop/desktop_tr.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="tr" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin Paket Kurucu</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Paket Kurucu</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Paket Kurucu, kullanıcıların yerel paketleri kurmasına ve kaldırmasına yardımcı olur ve toplu kurulumu destekler.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Paket Kurucu</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin Paket Kurucu</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Paket Kurucu</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Paket Kurucu, kullanıcıların yerel paketleri kurmasına ve kaldırmasına yardımcı olur ve toplu kurulumu destekler.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Paket Kurucu</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Paket Kurucu, kullanıcıların yerel paketleri kurmasına ve kaldırmasına yardımcı olur ve toplu kurulumu destekler.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_ug.ts
+++ b/translations/desktop/desktop_ug.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ug" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin بوغچا قاچىلىغۇچ</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>بوغچا قاچىلىغۇچ</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>ئورالما ئورناتقۇچ ئىشلەتكۈچىلەرنىڭ يەرلىك ئورالمىلارنى ئورنىتىشى ۋە ئۆچۈرۈشىگە ياردەم بېرىدۇ ھەمدە توپ قاچىلاشنى قوللايدۇ.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ug">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">بوغچا قاچىلىغۇچ</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin بوغچا قاچىلىغۇچ</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">بوغچا قاچىلىغۇچ</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">ئورالما ئورناتقۇچ ئىشلەتكۈچىلەرنىڭ يەرلىك ئورالمىلارنى ئورنىتىشى ۋە ئۆچۈرۈشىگە ياردەم بېرىدۇ ھەمدە توپ قاچىلاشنى قوللايدۇ.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">بوغچا قاچىلىغۇچ</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">ئورالما ئورناتقۇچ ئىشلەتكۈچىلەرنىڭ يەرلىك ئورالمىلارنى ئورنىتىشى ۋە ئۆچۈرۈشىگە ياردەم بېرىدۇ ھەمدە توپ قاچىلاشنى قوللايدۇ.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_uk.ts
+++ b/translations/desktop/desktop_uk.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="uk" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Засіб встановлення пакунків Deepin</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Встановлювач пакунків</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>За допомогою засобу встановлення пакунків користувачі можуть встановлювати і вилучати локальні пакунки. Передбачено пакетне встановлення.</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Встановлювач пакунків</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Засіб встановлення пакунків Deepin</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Встановлювач пакунків</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">За допомогою засобу встановлення пакунків користувачі можуть встановлювати і вилучати локальні пакунки. Передбачено пакетне встановлення.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Встановлювач пакунків</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">За допомогою засобу встановлення пакунків користувачі можуть встановлювати і вилучати локальні пакунки. Передбачено пакетне встановлення.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_vi.ts
+++ b/translations/desktop/desktop_vi.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="vi" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Trình cài đặt gói</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>Trình cài đặt gói</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>Trình cài đặt gói hỗ trợ người dùng cài đặt và xóa hàng loạt các gói phần mềm</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="vi">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Trình cài đặt gói</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Trình cài đặt gói</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">Trình cài đặt gói</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">Trình cài đặt gói hỗ trợ người dùng cài đặt và xóa hàng loạt các gói phần mềm</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">Trình cài đặt gói</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">Trình cài đặt gói hỗ trợ người dùng cài đặt và xóa hàng loạt các gói phần mềm</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_zh_CN.ts
+++ b/translations/desktop/desktop_zh_CN.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="zh_CN" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>深度软件包安装器</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>软件包安装器</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>软件包安装器用于帮助用户安装和卸载本地软件，支持批量安装。</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">软件包安装器</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">深度软件包安装器</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">软件包安装器</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">软件包安装器用于帮助用户安装和卸载本地软件，支持批量安装。</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">软件包安装器</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">软件包安装器用于帮助用户安装和卸载本地软件，支持批量安装。</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_zh_HK.ts
+++ b/translations/desktop/desktop_zh_HK.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="zh_HK" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin 軟件包安裝器</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>軟件包安裝器</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>軟件包安裝器用於幫助用戶安裝和卸載本地軟件，支持批量安裝。</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">軟件包安裝器</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin 軟件包安裝器</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">軟件包安裝器</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">軟件包安裝器用於幫助用戶安裝和卸載本地軟件，支持批量安裝。</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">軟件包安裝器</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">軟件包安裝器用於幫助用戶安裝和卸載本地軟件，支持批量安裝。</translation>
+    </message>
 </context>
 </TS>

--- a/translations/desktop/desktop_zh_TW.ts
+++ b/translations/desktop/desktop_zh_TW.ts
@@ -1,17 +1,764 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="zh_TW" version="2.1"><context>
-<name>desktop</name>
-<message>
-    <location filename="Desktop Entry]Name" line="0"/>
-    <source>Deepin Package Installer</source><translation>Deepin 軟體包安裝器</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]GenericName" line="0"/>
-    <source>Package Installer</source><translation>軟體包安裝器</translation>
-</message>
-<message>
-    <location filename="Desktop Entry]Comment" line="0"/>
-    <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
-    <translation>軟體包安裝器用來幫助使用者安裝和移除本機軟體包。支援批次安裝。</translation>
-</message>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">軟體包安裝器</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>desktop</name>
+    <message>
+        <source>Deepin Package Installer</source>
+        <translation type="vanished">Deepin 軟體包安裝器</translation>
+    </message>
+    <message>
+        <source>Package Installer</source>
+        <translation type="vanished">軟體包安裝器</translation>
+    </message>
+    <message>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="vanished">軟體包安裝器用來幫助使用者安裝和移除本機軟體包。支援批次安裝。</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished">軟體包安裝器</translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished">軟體包安裝器用來幫助使用者安裝和移除本機軟體包。支援批次安裝。</translation>
+    </message>
 </context>
 </TS>

--- a/translations/policy/policy_ar.ts
+++ b/translations/policy/policy_ar.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ar" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>التوثيق مطلوب لمتابعة التكوين</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>التوثيق</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">التوثيق مطلوب لمتابعة التكوين</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">التوثيق</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_az.ts
+++ b/translations/policy/policy_az.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="az" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Konfiqurasiyanı davam etdirmək üçün kimlik doğrulaması tələb olunur</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>kimlik doğrulaması</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Konfiqurasiyanı davam etdirmək üçün kimlik doğrulaması tələb olunur</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">kimlik doğrulaması</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_bn.ts
+++ b/translations/policy/policy_bn.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="bn" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>অবসরণ করতে আутুথেন্টিকেশন প্রয়োজন</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>আউটোথেন্টিকেশন</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bn">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">অবসরণ করতে আутুথেন্টিকেশন প্রয়োজন</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">আউটোথেন্টিকেশন</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_bo.ts
+++ b/translations/policy/policy_bo.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="bo" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>མུ་མཐུད་བགོ་སྒྲིག་བྱ་དགོས་དབང་བརྩལ་བྱ་དགོས།</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>དཔང་དཔྱད།</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bo">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">མུ་མཐུད་བགོ་སྒྲིག་བྱ་དགོས་དབང་བརྩལ་བྱ་དགོས།</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">དཔང་དཔྱད།</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_ca.ts
+++ b/translations/policy/policy_ca.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ca" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Cal autenticació per continuar la configuració</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>autenticació</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Cal autenticació per continuar la configuració</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">autenticació</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_cs.ts
+++ b/translations/policy/policy_cs.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="cs" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Aby bylo možné pokračovat v nastavování, je třeba se ověřit</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>ověření se</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Aby bylo možné pokračovat v nastavování, je třeba se ověřit</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">ověření se</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_de.ts
+++ b/translations/policy/policy_de.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="de" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Zum Fortsetzen der Konfiguration ist eine Authentifizierung erforderlich</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>Authentifizierung</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Zum Fortsetzen der Konfiguration ist eine Authentifizierung erforderlich</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">Authentifizierung</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_es.ts
+++ b/translations/policy/policy_es.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="es" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Se requiere autenticación para continuar con la configuración</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>autenticación </translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Se requiere autenticación para continuar con la configuración</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">autenticación </translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_et.ts
+++ b/translations/policy/policy_et.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="et" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Autentikatsioon on vajalik jätka konfigureerimist</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>autentikatsioon</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="et">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Autentikatsioon on vajalik jätka konfigureerimist</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">autentikatsioon</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_fi.ts
+++ b/translations/policy/policy_fi.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="fi" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Määritysten jatkaminen edellyttää todennusta</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>todennus</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Määritysten jatkaminen edellyttää todennusta</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">todennus</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_fil.ts
+++ b/translations/policy/policy_fil.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="fil" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Authentication ay kailangan upang magpatuloy sa pag-ayos</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>authentication</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fil">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Authentication ay kailangan upang magpatuloy sa pag-ayos</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">authentication</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_fr.ts
+++ b/translations/policy/policy_fr.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="fr" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>L&apos;authentification est requise pour continuer la configuration</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>authentification</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">L&apos;authentification est requise pour continuer la configuration</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">authentification</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_gl_ES.ts
+++ b/translations/policy/policy_gl_ES.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="gl_ES" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>É necesario autenticarse para continuar a configuración</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>autenticación</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="gl_ES">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">É necesario autenticarse para continuar a configuración</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">autenticación</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_he.ts
+++ b/translations/policy/policy_he.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="he" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>ה(*)(תנתקתEMS היא חובה המשך ההגדרה</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>ה(*)(תנתקתEMS</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="he">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">ה(*)(תנתקתEMS היא חובה המשך ההגדרה</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">ה(*)(תנתקתEMS</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_hi_IN.ts
+++ b/translations/policy/policy_hi_IN.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="hi_IN" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>विन्यास जारी रखने हेतु प्रमाणीकरण आवश्यक है</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>प्रमाणीकरण</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hi_IN">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">विन्यास जारी रखने हेतु प्रमाणीकरण आवश्यक है</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">प्रमाणीकरण</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_hr.ts
+++ b/translations/policy/policy_hr.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="hr" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Potrebna je ovjera da bi nastavili s konfiguracijom</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>ovjera</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hr">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Potrebna je ovjera da bi nastavili s konfiguracijom</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">ovjera</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_hu.ts
+++ b/translations/policy/policy_hu.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="hu" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Hitelesítés szükséges a konfigurálás folytatásához</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>Hitelesítés</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Hitelesítés szükséges a konfigurálás folytatásához</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">Hitelesítés</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_id.ts
+++ b/translations/policy/policy_id.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="id" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Autentikasi diperlukan untuk melanjutkan konfigurasi</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>autentikasi</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="id">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Autentikasi diperlukan untuk melanjutkan konfigurasi</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">autentikasi</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_it.ts
+++ b/translations/policy/policy_it.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="it" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Autenticazione richiesta per continuare la configurazione</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>autenticazione</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Autenticazione richiesta per continuare la configurazione</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">autenticazione</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_ja.ts
+++ b/translations/policy/policy_ja.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ja" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>構成を続行するには認証が必要です</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>認証</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">構成を続行するには認証が必要です</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">認証</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_lo.ts
+++ b/translations/policy/policy_lo.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
 <context>
-	<name>policy</name>
-	<message>
-		<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-		<source>Authentication is required to continue the configuration</source>
-		<translation>ត្រូវការអាជីវកម្មដើម្បីបន្តការកំណត់ឡើងវិញ</translation>
-	</message>
-	<message>
-		<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-		<source>authentication</source>
-		<translation>អាជីវកម្ម</translation>
-	</message>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">ត្រូវការអាជីវកម្មដើម្បីបន្តការកំណត់ឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">អាជីវកម្ម</translation>
+    </message>
 </context>
 </TS>

--- a/translations/policy/policy_lt.ts
+++ b/translations/policy/policy_lt.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="lt" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Tęstymuojimo reikia tęsti konfigūraciją</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>jęstymuojimo</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lt">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Tęstymuojimo reikia tęsti konfigūraciją</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">jęstymuojimo</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_ms.ts
+++ b/translations/policy/policy_ms.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ms" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Pengesahihan diperlukan untuk meneruskan konfigurasi</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>pengesahihan</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ms">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Pengesahihan diperlukan untuk meneruskan konfigurasi</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">pengesahihan</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_nl.ts
+++ b/translations/policy/policy_nl.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="nl" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Voer je wachtwoord in om het instellen te voltooien</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>goedkeuring</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Voer je wachtwoord in om het instellen te voltooien</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">goedkeuring</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_pl.ts
+++ b/translations/policy/policy_pl.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="pl" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Wymagane jest uwierzytelnienie, aby kontynuować konfigurację</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>uwierzytelnienie</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Wymagane jest uwierzytelnienie, aby kontynuować konfigurację</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">uwierzytelnienie</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_pt.ts
+++ b/translations/policy/policy_pt.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="pt" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>É necessária a autenticação para continuar a configuração</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>autenticação</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">É necessária a autenticação para continuar a configuração</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">autenticação</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_pt_BR.ts
+++ b/translations/policy/policy_pt_BR.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="pt_BR" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>A autenticação é necessária para continuar com a configuração</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>autenticação</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">A autenticação é necessária para continuar com a configuração</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">autenticação</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_ru.ts
+++ b/translations/policy/policy_ru.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ru" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Чтобы продолжить конфигурирование необходимо авторизоваться. </translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>аутентификация</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Чтобы продолжить конфигурирование необходимо авторизоваться. </translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">аутентификация</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_sl.ts
+++ b/translations/policy/policy_sl.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="sl" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Za nadaljevanje konfiguracije je zahtevana鉴权</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>鉴权</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sl">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Za nadaljevanje konfiguracije je zahtevana鉴权</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">鉴权</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_sq.ts
+++ b/translations/policy/policy_sq.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="sq" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Që të vazhdohet formësimi, lypset mirëfilltësim</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>mirëfilltësim</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Që të vazhdohet formësimi, lypset mirëfilltësim</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">mirëfilltësim</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_sr.ts
+++ b/translations/policy/policy_sr.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="sr" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Идентификација је неопходна за наставак прилагођавања</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>идентификација</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sr">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Идентификација је неопходна за наставак прилагођавања</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">идентификација</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_tr.ts
+++ b/translations/policy/policy_tr.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="tr" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Yapılandırmaya devam etmek için kimlik doğrulaması gerekiyor</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>kimlik doğrulama</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Yapılandırmaya devam etmek için kimlik doğrulaması gerekiyor</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">kimlik doğrulama</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_ug.ts
+++ b/translations/policy/policy_ug.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ug" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>داۋاملىق تەڭشەش ئۈچۈن ھوقۇق بېرىڭ</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>دەلىللەش</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ug">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">داۋاملىق تەڭشەش ئۈچۈن ھوقۇق بېرىڭ</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">دەلىللەش</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_uk.ts
+++ b/translations/policy/policy_uk.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="uk" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Для продовження налаштовування слід пройти розпізнавання</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>розпізнавання</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Для продовження налаштовування слід пройти розпізнавання</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">розпізнавання</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_vi.ts
+++ b/translations/policy/policy_vi.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="vi" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>Cần xác thực để tiếp tục cấu hình</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>xác thực</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="vi">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">Cần xác thực để tiếp tục cấu hình</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">xác thực</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_zh_CN.ts
+++ b/translations/policy/policy_zh_CN.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="zh_CN" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>继续配置，需要授权</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>认证</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">继续配置，需要授权</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">认证</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_zh_HK.ts
+++ b/translations/policy/policy_zh_HK.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="zh_HK" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>繼續配置，需要授權</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>認證</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">繼續配置，需要授權</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">認證</translation>
+    </message>
+</context>
 </TS>

--- a/translations/policy/policy_zh_TW.ts
+++ b/translations/policy/policy_zh_TW.ts
@@ -1,15 +1,762 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="zh_TW" version="2.1">
-	<context>
-		<name>policy</name>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
-			<source>Authentication is required to continue the configuration</source>
-			<translation>繼續配置，需要授權</translation>
-		</message>
-		<message>
-			<location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
-			<source>authentication</source>
-			<translation>認證</translation>
-		</message>
-	</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
+<context>
+    <name>AptConfigMessage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="85"/>
+        <source>Enter the number to configure: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/AptConfigMessage.cpp" line="90"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackendProcessPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="18"/>
+        <source>Loading packages...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="19"/>
+        <source>%1/%2 loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="22"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/backendprocesspage.cpp" line="39"/>
+        <source>Updating package cache...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdimErrorPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/ddimerrorpage.cpp" line="18"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebInstaller</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="121"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="134"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="478"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="958"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="1114"/>
+        <source>Bulk Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="759"/>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="883"/>
+        <source>Installing other packages... Please open it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="764"/>
+        <source>Parsing failed: An illegal file structure was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="766"/>
+        <source>Parsing failed: An illegal version number was found in the manifest file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="768"/>
+        <source>No deb packages found. Please check the folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="906"/>
+        <source>The %1 package may be broken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="915"/>
+        <source>You can only install local %1 packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="924"/>
+        <source>No permission to access this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="941"/>
+        <source>Already Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/debinstaller.cpp" line="950"/>
+        <source>%1 does not exist, please reselect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="113"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="136"/>
+        <source>Installation failed, please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="117"/>
+        <source>Installation failed, please check for updates in Control Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="120"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="126"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="142"/>
+        <source>Installation failed, insufficient disk space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="148"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="153"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="962"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="158"/>
+        <source>Authentication failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="161"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="947"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2006"/>
+        <source>The administrator has set policies to prevent installation of this package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="168"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="896"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="930"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="932"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="934"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="940"/>
+        <source>Broken dependencies, try installing the app in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="943"/>
+        <source>Compatibility mode installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="965"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="969"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="975"/>
+        <source>Broken dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1231"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1266"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1316"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1378"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2005"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1268"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1381"/>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="2008"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1272"/>
+        <source>Failed to install %1: no valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1321"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1322"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1379"/>
+        <source>This package does not have a valid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1422"/>
+        <source>This package does not have a valid digital signature. Continue with the installation?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1424"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1425"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileChooseWidget</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="51"/>
+        <source>Drag deb packages here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/filechoosewidget.cpp" line="93"/>
+        <source>Select File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="35"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="179"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="180"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="182"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="545"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="563"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="570"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="629"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectItem</name>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="87"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="91"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="96"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/packageselectitem.cpp" line="102"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackageSelectView</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="23"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/packageselectview.cpp" line="24"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListDelegate</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="62"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="66"/>
+        <source>Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="70"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="74"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="246"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="248"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="250"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PackagesListView</name>
+    <message>
+        <location filename="../../src/deb-installer/model/packagelistview.cpp" line="189"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="64"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/deb-installer/model/deblistmodel.cpp" line="1318"/>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="49"/>
+        <source>This package does not have a valid digital signature and has been blocked from installing/running. Go to Security Center &gt; Tools &gt; App Security to change the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/model/packageslistdelegate.cpp" line="282"/>
+        <source>Will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package.cpp" line="54"/>
+        <source>The system has not installed Linglong environment, please install it first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="9"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/setting_translation.cpp" line="10"/>
+        <source>Check digital signatures if the developer mode is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="88"/>
+        <source>To install unsigned apps, go to Security Center &gt; Tools &gt; App Security, and select the app types that can be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/settingdialog.cpp" line="90"/>
+        <source>Security Center &gt; Tools &gt; App Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="47"/>
+        <source>Unable to install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="52"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/widgets/error_notify_dialog_helper.cpp" line="53"/>
+        <source>Proceed</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="219"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="231"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="395"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1256"/>
+        <source>Install</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="399"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="403"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1164"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1219"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1456"/>
+        <source>Reinstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="407"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="998"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="411"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="415"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="934"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="526"/>
+        <source>If this software is an older version (already adapted for a legacy system version), you can try installing it in compatibility mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="527"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="550"/>
+        <source>UOS V25 Compatibility Mode is a feature that allows you to continue using V20 version applications on the V25 system. It creates a compatibility environment for you, enabling software that originally could only run on the V20 system to work properly on the V25 system as well.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="539"/>
+        <source>Confirm to install in compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="713"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="764"/>
+        <source>Installing in compatibility mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="807"/>
+        <source>Uninstalling %1 from compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="943"/>
+        <source>%1 was successfully installed to compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="946"/>
+        <source>Installed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="958"/>
+        <source>Uninstalled successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="984"/>
+        <source>Uninstall Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1004"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1542"/>
+        <source>Invalid digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1016"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1051"/>
+        <source>Install %1 will remove: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1072"/>
+        <source>Dependencies in the repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1079"/>
+        <source>Missing dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1156"/>
+        <source>Compatible Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1158"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1218"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1455"/>
+        <source>Same version installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1224"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1461"/>
+        <source>Later version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1225"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1462"/>
+        <source>Downgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1230"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1467"/>
+        <source>Earlier version installed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1231"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1468"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1265"/>
+        <source>Compatible Mode Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1354"/>
+        <source>Installing dependencies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="1536"/>
+        <source>Failed to install %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Install</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/multipleinstallpage.cpp" line="32"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="63"/>
+        <source>Show dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="62"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="699"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="750"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="938"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SingleInstallPage_Uninstall</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="793"/>
+        <location filename="../../src/deb-installer/view/pages/singleinstallpage.cpp" line="952"/>
+        <source>Show details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Uab::UabPackageListModel</name>
+    <message>
+        <location filename="../../src/deb-installer/uab/uab_package_list_model.cpp" line="557"/>
+        <source>Installation Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UninstallConfirmPage</name>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Show related packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="17"/>
+        <source>Collapse</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="39"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="41"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="131"/>
+        <source>Are you sure you want to uninstall %1?
+All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="133"/>
+        <source>Are you sure you want to uninstall %1?
+The system or other applications may not work properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/view/pages/uninstallconfirmpage.cpp" line="177"/>
+        <source>Are you sure you want to uninstall %1 from compatibility mode? All dependencies will also be removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="48"/>
+        <location filename="../../src/deb-installer/main.cpp" line="49"/>
+        <source>Package Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/deb-installer/main.cpp" line="50"/>
+        <source>Package Installer helps users install and remove local packages, and supports bulk installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>policy</name>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!message" line="0"/>
+        <source>Authentication is required to continue the configuration</source>
+        <translation type="vanished">繼續配置，需要授權</translation>
+    </message>
+    <message>
+        <location filename="com.deepin.pkexec.deepin-deb-installer-dependsInstall!description" line="0"/>
+        <source>authentication</source>
+        <translation type="vanished">認證</translation>
+    </message>
+</context>
 </TS>


### PR DESCRIPTION
1. 依赖不满足界面不显示兼容模式标题，只在checkbox二次确认界面才显示
2. 右键菜单"兼容模式安装"入口(--compatible)直接进入checkbox确认视图
3. 修复同一实例内"先兼容安装、后普通安装"时标志串味问题
4. 修复D-Bus单实例转发路径下s_forceCompatible为过期值的问题
5. 更新所有语言翻译文件

修复兼容模式安装时titlebar显示逻辑：
- 依赖不满足界面：titlebar为空
- checkbox二次确认界面：titlebar显示"兼容模式安装"

Log: 修复兼容模式titlebar显示逻辑