### PR TITLE
chore: update version to 6.5.44

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deb-installer (6.5.44) unstable; urgency=medium
+
+  * fix(compat): titlebar只在checkbox确认界面显示兼容模式安装
+
+ -- xiepengfei <xiepengfei@uniontech.com>  Wed, 24 Jun 2026 14:40:34 +0800
+
 deepin-deb-installer (6.5.43) unstable; urgency=medium
 
   * refactor: restructure package cache update logic with signal-driven approach


### PR DESCRIPTION
- bump version to 6.5.44

Log : bump version to 6.5.44

## Summary by Sourcery

Build:
- Update Debian changelog to reflect version 6.5.44 release.