### PR TITLE
fix(i18n): restore compat-mode menu translations for zh_CN/HK/TW

### DIFF
--- a/translations/deepin-deb-installer_zh_CN.ts
+++ b/translations/deepin-deb-installer_zh_CN.ts
@@ -771,8 +771,9 @@ All dependencies will also be removed</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation type="vanished">兼容模式安装</translation>
+        <translation>兼容模式安装</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_zh_HK.ts
+++ b/translations/deepin-deb-installer_zh_HK.ts
@@ -771,8 +771,9 @@ All dependencies will also be removed</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation type="vanished">相容模式安裝</translation>
+        <translation>相容模式安裝</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-deb-installer_zh_TW.ts
+++ b/translations/deepin-deb-installer_zh_TW.ts
@@ -771,8 +771,9 @@ All dependencies will also be removed</source>
 <context>
     <name>dfmplugin_debinstaller::DebInstallerMenuScene</name>
     <message>
+        <location filename="../src/dfmplugin-debinstaller/menu/debinstallermenuscene.cpp" line="70"/>
         <source>Install in compatible mode</source>
-        <translation type="vanished">相容模式安裝</translation>
+        <translation>相容模式安裝</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
zh_CN/HK/TW "Install in compatible mode" entries were marked vanished, so lrelease dropped them and the menu showed English. Restore them.

zh_CN/HK/TW 的"兼容模式安装"菜单项被标记为 vanished，
导致 lrelease 丢弃译文、菜单回退为英文，现恢复并补全 location。

Log: 恢复兼容模式安装菜单的中文翻译
PMS: BUG-367443
Influence: 右键菜单"兼容模式安装"在简繁中文环境下恢复正常显示，不再回退为英文。