### PR TITLE
chore: update version to 6.5.45

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-deb-installer (6.5.45) unstable; urgency=medium
+
+  * fix(compat): check same-name pkg on right-click compat install
+  * chore: update version to 6.5.44
+
+ -- xiepengfei <xiepengfei@uniontech.com>  Thu, 25 Jun 2026 19:47:50 +0800
+
 deepin-deb-installer (6.5.44) unstable; urgency=medium
 
   * fix(compat): titlebar只在checkbox确认界面显示兼容模式安装


### PR DESCRIPTION
- bump version to 6.5.45

Log : bump version to 6.5.45

## Summary by Sourcery

Chores:
- Bump recorded package version to 6.5.45 in Debian changelog.