### PR TITLE
fix(compat): show compat title on same-name pkg judgment view

### DIFF
--- a/src/deb-installer/view/pages/singleinstallpage.cpp
+++ b/src/deb-installer/view/pages/singleinstallpage.cpp
@@ -116,9 +116,14 @@ void SingleInstallPage::initUI()
     // 使用 QTimer::singleShot 延迟到事件循环处理，确保 showCompatConfirmView() 发出的信号能被 DebInstaller 捕获
     if (SingleInstallerApplication::s_forceCompatible && m_inCompatibleMode) {
         const int dependsStat = index.data(DebListModel::PackageDependsStatusRole).toInt();
-        // 兼容环境已有同名包时不自动跳转确认视图，保留第一视图供用户选择卸载/重新安装
         if (Pkg::CompatibleIntalled != dependsStat) {
+            // 兼容环境无同名包：直接进入 checkbox 二次确认视图（showCompatConfirmView 内部会发出 titlebar 信号）
             QTimer::singleShot(0, this, [this]() { showCompatConfirmView(); });
+        } else {
+            // 兼容环境有同名包：保留第一视图供用户选择卸载/重新安装，
+            // 但 titlebar 仍需显示"兼容模式安装"（与主环境同名包判断界面区分）
+            // 注意：与 showCompatConfirmView() 同理，构造期信号尚未连接，必须延迟到事件循环发出
+            QTimer::singleShot(0, this, [this]() { Q_EMIT signalSetTitlebarText(tr("Compatible Mode Install")); });
         }
     }
     qCDebug(appLog) << "UI initialized";


### PR DESCRIPTION
When right-click compat install meets a same-name package in compat env, keep the first view but also set the titlebar to "Compatible Mode Install".

右键兼容安装且兼容环境已存在同名包时，保留第一视图的同时在
titlebar 显示"兼容模式安装"，与主环境同名包判断界面区分。

Log: 兼容环境同名包判断界面titlebar显示兼容模式安装
PMS: BUG-367445
Influence: 仅右键兼容安装且兼容环境有同名包时titlebar新增显示兼容模式安装文本；主环境同名包判断界面及其它路径不受影响。

## Summary by Sourcery

Bug Fixes:
- Ensure the compat environment same-name package judgment view shows the "Compatible Mode Install" titlebar while keeping the initial view for uninstall/reinstall choices.