### PR TITLE
chore: update version to 6.5.47

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-deb-installer (6.5.47) unstable; urgency=medium
+
+  * feat(dconfig): add switch to skip apt cache refresh before install
+  * chore: update version to 6.5.46
+
+ -- xiepengfei <xiepengfei@uniontech.com>  Thu, 02 Jul 2026 14:07:13 +0800
+
 deepin-deb-installer (6.5.46) unstable; urgency=medium
 
   * fix(compat): show compat title on same-name pkg judgment view


### PR DESCRIPTION
- bump version to 6.5.47

Log : bump version to 6.5.47

## Summary by Sourcery

Chores:
- Update Debian changelog metadata to reflect version 6.5.47.