### PR TITLE
feat(dconfig): force one apt update on first launch

### DIFF
--- a/assets/deepin-deb-installer.cache.json
+++ b/assets/deepin-deb-installer.cache.json
@@ -14,6 +14,19 @@
             "description[zh_CN]": "安装前是否刷新 apt 软件包缓存（apt update）。关闭后，安装器启动时不再刷新 apt 缓存。",
             "permissions": "readwrite",
             "visibility": "private"
+        },
+        "oneTimeUpdateOnFirstPackage": {
+            "value": true,
+            "serial": 0,
+            "flags": [
+                "global"
+            ],
+            "name": "One-time Update On First Launch",
+            "name[zh_CN]": "首次启动时一次性刷新软件源",
+            "description": "When true, force a single apt update on the first launch after install; auto-resets to false once that update completes (success or failure).",
+            "description[zh_CN]": "为 true 时，安装后首次启动将强制执行一次 apt update；该次 update 完成（无论成功或失败）后自动置为 false。",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
 }

--- a/src/deb-installer/model/packageanalyzer.cpp
+++ b/src/deb-installer/model/packageanalyzer.cpp
@@ -100,21 +100,58 @@ void PackageAnalyzer::initBackend()
     qCInfo(appLog) << "Backend initialization process finished.";
 }
 
-bool PackageAnalyzer::isAutoUpdateBeforeInstallEnabled() const
+bool PackageAnalyzer::readDConfigBool(const QString &key, bool defaultValue) const
 {
 #ifdef DTKCORE_CLASS_DConfigFile
     Dtk::Core::DConfig *cfg = Dtk::Core::DConfig::create("deepin-deb-installer", "deepin-deb-installer.cache");
     if (cfg && cfg->isValid()) {
-        bool enabled = cfg->value("autoUpdateBeforeInstall", true).toBool();
-        qCDebug(appLog) << "DConfig autoUpdateBeforeInstall:" << enabled;
+        bool value = cfg->value(key, defaultValue).toBool();
         cfg->deleteLater();
-        return enabled;
+        return value;
     }
     if (cfg)
         cfg->deleteLater();
 #endif
-    // DConfig 不可用（如旧版 dtkcore 或 schema 未安装）时默认开启，保持原行为
-    return true;
+    return defaultValue;
+}
+
+bool PackageAnalyzer::writeDConfigBool(const QString &key, bool value)
+{
+#ifdef DTKCORE_CLASS_DConfigFile
+    Dtk::Core::DConfig *cfg = Dtk::Core::DConfig::create("deepin-deb-installer", "deepin-deb-installer.cache");
+    if (cfg && cfg->isValid()) {
+        cfg->setValue(key, value);
+        cfg->deleteLater();
+        return true;
+    }
+    if (cfg)
+        cfg->deleteLater();
+#endif
+    return false;
+}
+
+bool PackageAnalyzer::isAutoUpdateBeforeInstallEnabled() const
+{
+    bool enabled = readDConfigBool("autoUpdateBeforeInstall", true);
+    qCDebug(appLog) << "DConfig autoUpdateBeforeInstall:" << enabled;
+    return enabled;
+}
+
+void PackageAnalyzer::markOneTimeUpdateDone()
+{
+    if (writeDConfigBool("oneTimeUpdateOnFirstPackage", false)) {
+        qCInfo(appLog) << "One-time update done, DConfig oneTimeUpdateOnFirstPackage set to false";
+    } else {
+        qCWarning(appLog) << "DConfig unavailable, cannot persist oneTimeUpdateOnFirstPackage=false";
+    }
+}
+
+bool PackageAnalyzer::isOneTimeUpdateEnabled() const
+{
+    // DConfig 不可用时返回 false：无法持久化"已完成"状态，返回 true 会导致每次启动都强制 apt update
+    bool enabled = readDConfigBool("oneTimeUpdateOnFirstPackage", false);
+    qCDebug(appLog) << "DConfig oneTimeUpdateOnFirstPackage:" << enabled;
+    return enabled;
 }
 
 void PackageAnalyzer::updatePackageCache()
@@ -126,8 +163,10 @@ void PackageAnalyzer::updatePackageCache()
         return;
     }
 
-    // 判断是否需要更新
-    if (!shouldUpdateCache()) {
+    if (isOneTimeUpdateEnabled()) {
+        qCInfo(appLog) << "One-time forced apt update triggered (first launch), skip shouldUpdateCache";
+        m_oneTimeUpdateInProgress = true;  // 标记，在 setCacheUpdateFinished 中延迟置 key=false
+    } else if (!shouldUpdateCache()) {
         qCInfo(appLog) << "Sources not changed, cache is still valid, skip update";
         setCacheUpdateFinished(true);
         return;
@@ -148,6 +187,11 @@ void PackageAnalyzer::setCacheUpdateFinished(bool finished)
 {
     m_cacheUpdateFinished = finished;
     if (finished) {
+        // 一次性 update 真正完成后才持久化 key=false，避免崩溃导致标志位丢失
+        if (m_oneTimeUpdateInProgress) {
+            m_oneTimeUpdateInProgress = false;
+            markOneTimeUpdateDone();
+        }
         emit cacheUpdateFinished();
     }
 }

--- a/src/deb-installer/model/packageanalyzer.h
+++ b/src/deb-installer/model/packageanalyzer.h
@@ -106,8 +106,18 @@ signals:
     void cacheUpdateFinished();
 
 private:
+    // 读取 DConfig bool 值，DConfig 不可用时返回 defaultValue
+    bool readDConfigBool(const QString &key, bool defaultValue) const;
+    // 写入 DConfig bool 值，成功返回 true
+    bool writeDConfigBool(const QString &key, bool value);
+
     // 读取 DConfig 开关：是否允许安装前自动刷新 apt 缓存。默认 true（DConfig 不可用时也返回 true，保持原行为）
     bool isAutoUpdateBeforeInstallEnabled() const;
+
+    // 将一次性 update 开关置 false（在 update 真正完成后调用，避免崩溃导致标志位丢失）
+    void markOneTimeUpdateDone();
+    // 读取一次性 update 开关，DConfig 不可用时返回 false（无法持久化完成状态，避免每次启动重复触发）
+    bool isOneTimeUpdateEnabled() const;
 
     QApt::Package *packageWithArch(const QString &packageName, const QString &sysArch, const QString &annotation) const;
     QString resolvMultiArchAnnotation(const QString &annotation, const QString &debArch, int multiArchType) const;
@@ -130,6 +140,9 @@ private:
     int alreadyAnalyzed = 0;
     std::atomic_bool uiExited;
     std::atomic_bool m_cacheUpdateFinished{false};
+
+    // 标记当前 update 是否由一次性开关触发，用于在 setCacheUpdateFinished 中延迟置 key=false
+    bool m_oneTimeUpdateInProgress{false};
 };
 
 Q_DECLARE_METATYPE(QList<DebIr>);


### PR DESCRIPTION
Add oneTimeUpdateOnFirstPackage DConfig key (default on). When enabled, on the first launch after install, updatePackageCache() skips both autoUpdateBeforeInstall and shouldUpdateCache checks and fires cacheUpdateStarted directly, then persists the key to false. Subsequent launches follow the original flow. Independent from autoUpdateBeforeInstall.

新增一次性 DConfig 开关 oneTimeUpdateOnFirstPackage（默认开启）。安装后 首次启动时 updatePackageCache 跳过 autoUpdateBeforeInstall 和 shouldUpdateCache 判断，直接触发 apt update，完成后（无论成败）将 key 置 为 false，后续启动恢复原流程。与现有 autoUpdateBeforeInstall 开关完全 独立，复用现有 cacheUpdateStarted → QApt 事务 → cacheUpdateFinished 信号链。

Log: 新增首次启动时一次性强制刷新 apt 缓存的功能
Influence: 仅在安装后首次启动时多触发一次 apt update，之后恢复原流程；管理员可通过 DConfig 提前关闭

## Summary by Sourcery

Introduce a one-time DConfig-controlled apt cache update on first launch after installation, independent of the existing automatic update setting.

New Features:
- Add a DConfig key oneTimeUpdateOnFirstPackage to control a one-time forced apt cache update on first launch.
- Trigger cacheUpdateStarted and mark the one-time update as done when the first-launch update path is taken.

Enhancements:
- Log DConfig availability and oneTimeUpdateOnFirstPackage state to aid debugging of first-launch cache updates.