### PR TITLE
chore: update version to 6.5.48

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-deb-installer (6.5.48) unstable; urgency=medium
+
+  * feat(dconfig): force one apt update on first launch
+  * feat(i18n): update translations and add short compat-mode hint in batch list
+  * chore: update version to 6.5.47
+
+ -- xiepengfei <xiepengfei@uniontech.com>  Thu, 16 Jul 2026 19:15:18 +0800
+
 deepin-deb-installer (6.5.47) unstable; urgency=medium
 
   * feat(dconfig): add switch to skip apt cache refresh before install


### PR DESCRIPTION
- bump version to 6.5.48

Log : bump version to 6.5.48

## Summary by Sourcery

Build:
- Update Debian packaging changelog to reflect version 6.5.48.