### PR TITLE
fix(depends): fall back to real package when provider cannot satisfy …

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -1459,6 +1459,36 @@ void PackagesManager::packageCandidateChoose(QSet<QString> &choosed_set,
         if (!package)
             continue;
 
+        // packageWithArch 可能因"已安装提供者优先"返回虚包的提供者而非真实包。
+        // 依赖带版本约束时，需按 Debian policy 校验提供者的 Provides 版本：
+        // 1. 提供者的版本化 Provides 能满足约束且已安装，则依赖已满足，无需安装或升级；
+        // 2. 提供者不能满足约束时，回退选择仓库中的真实软件包（与 apt 行为一致），
+        //    避免把无新版本的提供者反复加入安装列表造成空安装循环。
+        if (package->name() != info.packageName() && !info.packageVersion().isEmpty()) {
+            const QString provideVersion = package->providesListEnhance().value(info.packageName());
+            const bool providerSatisfies =
+                    !provideVersion.isEmpty()
+                    && dependencyVersionMatch(Package::compareVersion(provideVersion, info.packageVersion()),
+                                              info.relationType());
+
+            if (providerSatisfies && !package->installedVersion().isEmpty()) {
+                qCInfo(appLog) << "Depend" << info.packageName() << info.packageVersion()
+                               << "satisfied by installed provider" << package->name()
+                               << "provides" << provideVersion << ", skip installing";
+                continue;
+            }
+
+            if (!providerSatisfies) {
+                Package *realPackage = packageWithArch(info.packageName(), debArch, info.multiArchAnnotation(), false);
+                if (realPackage && realPackage->name() == info.packageName()) {
+                    qCInfo(appLog) << "Provider" << package->name() << "cannot satisfy" << info.packageName()
+                                   << info.packageVersion() << "in candidate choose, using real package"
+                                   << realPackage->name() << realPackage->version();
+                    package = realPackage;
+                }
+            }
+        }
+
         const auto choosed_name = package->name() + resolvMultiArchAnnotation(QString(), package->architecture());
         if (choosed_set.contains(choosed_name))
             break;
@@ -2216,18 +2246,44 @@ const PackageDependsStatus PackagesManager::checkDependsPackageStatus(QSet<QStri
     QString pkgRealVer = package->version();
     bool isVirtualPackage = false;
 
+    const RelationType relation = dependencyInfo.relationType();
+
 #ifdef ENABLE_VIRTUAL_PACKAGE_ENHANCE
     if (package->name() != package_name) {
         auto pkgMap = package->providesListEnhance();
         auto iter = pkgMap.find(package_name);
         if (iter != pkgMap.end()) {
-            pkgRealVer = *iter;
-            isVirtualPackage = true;
+            // 依据 Debian policy 判定提供者能否满足依赖：
+            // 1. 依赖不带版本约束时，任意提供者均可满足；
+            // 2. 依赖带版本约束时，无版本号的 Provides 无法满足，
+            //    带版本号的 Provides 需版本符合关系要求。
+            const bool provideSatisfies = dependencyInfo.packageVersion().isEmpty()
+                    || (!iter->isEmpty()
+                        && dependencyVersionMatch(Package::compareVersion(*iter, dependencyInfo.packageVersion()), relation));
+
+            if (!provideSatisfies) {
+                // 提供者不满足版本约束（如兼容包的无版本号 Provides），
+                // 回退查找真实软件包（含仓库候选版本，跳过提供者匹配），交由后续流程判定其状态
+                Package *realPackage = packageWithArch(package_name, realArch, dependencyInfo.multiArchAnnotation(), false);
+                if (realPackage && realPackage->name() == package_name) {
+                    qCInfo(appLog) << "PackagesManager:"
+                            << "provider" << package->name() << "cannot satisfy" << package_name
+                            << dependencyInfo.packageVersion() << ", fall back to real package";
+                    package = realPackage;
+                    pkgRealVer = package->version();
+                } else {
+                    // 仓库中不存在真实软件包，只能依赖此提供者，按原逻辑处理
+                    pkgRealVer = *iter;
+                    isVirtualPackage = true;
+                }
+            } else {
+                pkgRealVer = *iter;
+                isVirtualPackage = true;
+            }
         }
     }
 #endif
 
-    const RelationType relation = dependencyInfo.relationType();
     QString installedVersion = package->installedVersion();
 
     if (!installedVersion.isEmpty()) {
@@ -2475,7 +2531,7 @@ bool PackagesManager::checkPackageArchValid(const QApt::Package *package, const 
     return archIsValidRet;
 }
 
-Package *PackagesManager::packageWithArch(const QString &packageName, const QString &sysArch, const QString &annotation)
+Package *PackagesManager::packageWithArch(const QString &packageName, const QString &sysArch, const QString &annotation, bool resolveProvider)
 {
     qCDebug(appLog) << "Getting package with arch for package:" << packageName;
     Backend *backend = PackageAnalyzer::instance().backendPtr();
@@ -2493,8 +2549,9 @@ Package *PackagesManager::packageWithArch(const QString &packageName, const QStr
 
     if (package) {
         // 检查反向提供者：如果当前包未安装，但某个提供者已安装，优先使用已安装的提供者
+        // resolveProvider 为 false 时跳过（用于回退查找真实软件包的场景）
         QString installedVersion = package->installedVersion();
-        if (installedVersion.isEmpty()) {
+        if (resolveProvider && installedVersion.isEmpty()) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
             QString providedPackageName = package->name();
             providedPackageName.remove(QRegExp(":[^:]*$"));
@@ -2547,9 +2604,11 @@ Package *PackagesManager::packageWithArch(const QString &packageName, const QStr
     }
 
     // check virtual package providers
-    for (auto *virtualPackage : backend->availablePackages()) {
-        if (virtualPackage->name() != packageName && virtualPackage->providesList().contains(packageName)) {
-            return packageWithArch(virtualPackage->name(), sysArch, annotation);
+    if (resolveProvider) {
+        for (auto *virtualPackage : backend->availablePackages()) {
+            if (virtualPackage->name() != packageName && virtualPackage->providesList().contains(packageName)) {
+                return packageWithArch(virtualPackage->name(), sysArch, annotation);
+            }
         }
     }
 

--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -366,7 +366,7 @@ private:
      * @param annotation    注解
      * @return  package指针
      */
-    QApt::Package *packageWithArch(const QString &packageName, const QString &sysArch, const QString &annotation = QString());
+    QApt::Package *packageWithArch(const QString &packageName, const QString &sysArch, const QString &annotation = QString(), bool resolveProvider = true);
 
     /**
      * @brief checkPackageArchValid 检测通过包名 \a packageName 获取的软件包 \a package 架构

--- a/src/deb-installer/model/backend/apt_install_backend.cpp
+++ b/src/deb-installer/model/backend/apt_install_backend.cpp
@@ -527,6 +527,8 @@ void AptInstallBackend::slotDependsInstallTransactionFinished()
         qCDebug(appLog) << "Bumping install index due to failed dependency install";
         m_model->bumpInstallIndex();
     } else {
+        qCDebug(appLog) << "Dependency installation successful, invalidating depends status cache";
+        m_model->m_packagesManager->resetPackageDependsStatus(m_model->m_operatingStatusIndex);
         qCDebug(appLog) << "Dependency installation successful, installing next deb";
         // Dependencies already verified, no need to re-verify
         m_model->installNextDeb();

--- a/tests/src/model/ut_apt_install_backend.cpp
+++ b/tests/src/model/ut_apt_install_backend.cpp
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "../deb-installer/model/deblistmodel.h"
+#include "../deb-installer/model/backend/apt_install_backend.h"
+#include "../deb-installer/manager/packagesmanager.h"
+#include "../deb-installer/manager/PackageDependsStatus.h"
+#include "../deb-installer/utils/hierarchicalverify.h"
+
+#include <stub.h>
+
+#include <QList>
+#include <unistd.h>
+
+#include <fstream>
+
+using namespace QApt;
+
+namespace {
+
+const QByteArray kMd5 { "md5-deps-loop" };
+
+bool aptBackend_backend_init()
+{
+    return true;
+}
+
+QStringList aptBackend_backend_architectures()
+{
+    return { "i386", "amd64" };
+}
+
+QApt::Transaction *aptBackend_backend_commitChanges()
+{
+    return nullptr;
+}
+
+Package *aptBackend_packageWithArch(QString, QString, QString)
+{
+    return nullptr;
+}
+
+Package *aptBackend_backend_package(const QString &)
+{
+    return nullptr;
+}
+
+bool aptBackend_isBackendReady()
+{
+    return true;
+}
+
+QString aptBackend_packageManager_package(const int)
+{
+    return "";
+}
+
+bool aptBackend_dealInvalidPackage(QString)
+{
+    return true;
+}
+
+bool aptBackend_stub_model_is_open()
+{
+    return true;
+}
+
+void aptBackend_stub_model_open(const std::string &, std::ios_base::openmode)
+{
+}
+
+bool aptBackend_Hierarchical_isValid()
+{
+    return false;
+}
+
+QApt::ExitStatus aptBackend_exitStatus_success()
+{
+    return QApt::ExitSuccess;
+}
+
+QApt::Transaction *g_senderTransaction = nullptr;
+
+QObject *aptBackend_sender()
+{
+    if (!g_senderTransaction)
+        g_senderTransaction = new QApt::Transaction("1");
+    return g_senderTransaction;
+}
+
+DebListModel *g_model = nullptr;
+bool g_installNextDebCalled = false;
+bool g_dependsCachePresentWhenInstallNextDeb = false;
+
+void aptBackend_installNextDeb_watchCache()
+{
+    g_installNextDebCalled = true;
+    g_dependsCachePresentWhenInstallNextDeb =
+        g_model->m_packagesManager->m_packageMd5DependsStatus.contains(kMd5);
+}
+
+} // namespace
+
+class ut_AptInstallBackend_test : public ::testing::Test
+{
+protected:
+    void SetUp() override;
+    void TearDown() override;
+
+    DebListModel *m_debListModel = nullptr;
+    Stub stub;
+};
+
+void ut_AptInstallBackend_test::SetUp()
+{
+    stub.set((void(std::fstream::*)(const std::string &, std::ios_base::openmode))ADDR(std::fstream, open),
+             aptBackend_stub_model_open);
+    stub.set((bool(std::fstream::*)())ADDR(std::fstream, is_open), aptBackend_stub_model_is_open);
+
+    stub.set(ADDR(Backend, init), aptBackend_backend_init);
+    stub.set(ADDR(Backend, architectures), aptBackend_backend_architectures);
+    stub.set(ADDR(Backend, commitChanges), aptBackend_backend_commitChanges);
+    stub.set(ADDR(Backend, reloadCache), aptBackend_backend_init);
+
+    stub.set((Package *(Backend::*)(const QString &) const)ADDR(Backend, package), aptBackend_backend_package);
+
+    stub.set(ADDR(PackagesManager, isBackendReady), aptBackend_isBackendReady);
+    stub.set(ADDR(PackagesManager, packageWithArch), aptBackend_packageWithArch);
+    stub.set(ADDR(PackagesManager, package), aptBackend_packageManager_package);
+    stub.set(ADDR(PackagesManager, dealInvalidPackage), aptBackend_dealInvalidPackage);
+
+    stub.set(ADDR(HierarchicalVerify, isValid), aptBackend_Hierarchical_isValid);
+
+    g_installNextDebCalled = false;
+    g_dependsCachePresentWhenInstallNextDeb = false;
+
+    m_debListModel = new DebListModel();
+    g_model = m_debListModel;
+    usleep(10 * 1000);
+}
+
+void ut_AptInstallBackend_test::TearDown()
+{
+    g_model = nullptr;
+    delete m_debListModel;
+    if (g_senderTransaction) {
+        delete g_senderTransaction;
+        g_senderTransaction = nullptr;
+    }
+}
+
+TEST_F(ut_AptInstallBackend_test, aptInstallBackend_UT_slotDependsInstallTransactionFinished_success_invalidatesDependsCache)
+{
+    stub.set(ADDR(Transaction, exitStatus), aptBackend_exitStatus_success);
+    stub.set(ADDR(DebListModel, installNextDeb), aptBackend_installNextDeb_watchCache);
+
+    PackagesManager *pm = m_debListModel->m_packagesManager;
+    pm->m_preparedPackages.append("/tmp/ut-deps-loop.deb");
+    pm->m_packageMd5.append(kMd5);
+    pm->m_packageMd5DependsStatus.insert(kMd5, PackageDependsStatus(Pkg::DependsAvailable, "ut-deps-loop"));
+
+    m_debListModel->m_operatingIndex = 0;
+    m_debListModel->m_operatingStatusIndex = 0;
+    m_debListModel->m_operatingPackageMd5 = kMd5;
+
+    AptInstallBackend backend(m_debListModel);
+
+    Stub stubSender;
+    stubSender.set(ADDR(QObject, sender), aptBackend_sender);
+
+    backend.slotDependsInstallTransactionFinished();
+
+    EXPECT_TRUE(g_installNextDebCalled);
+    EXPECT_FALSE(g_dependsCachePresentWhenInstallNextDeb);
+    EXPECT_FALSE(pm->m_packageMd5DependsStatus.contains(kMd5));
+}


### PR DESCRIPTION
…version

Per Debian Policy, a versionless Provides cannot satisfy a versioned dependency. Validate provider version and fall back to the real package in repo instead of reporting a false DependsBreak.

依据 Debian Policy，无版本号的 Provides 不能满足带版本号的依赖。
校验提供者版本约束，不满足时回退到仓库中的真实软件包进行判定，
避免误报"依赖关系不满足"。

Log: 修复无版本号Provides导致带版本依赖误报不满足的问题
PMS: BUG-374331
Influence: 修复安装器对含版本约束依赖的误判，与apt行为对齐；其余调用点行为不变。

## Summary by Sourcery

Fix versioned dependency resolution by validating provider versions and falling back to real packages when providers cannot satisfy the constraint.

Bug Fixes:
- Correct dependency resolution for versioned dependencies satisfied by package providers, rejecting unversioned Provides and falling back to the matching real package to avoid false dependency failures and install loops.
- Invalidate dependency status caches after successful dependency installation so subsequent package processing uses current results.

Enhancements:
- Align provider version handling and real-package fallback behavior with Debian Policy and apt.

Tests:
- Add coverage ensuring the dependency status cache is cleared before the next package installation proceeds.