### PR TITLE
fix: defer package depends check until apt cache ready

### DIFF
--- a/src/deb-installer/manager/packagesmanager.cpp
+++ b/src/deb-installer/manager/packagesmanager.cpp
@@ -443,6 +443,11 @@ PackagesManager::PackagesManager(QObject *parent)
     connect(m_pAddPackageThread, &AddPackageThread::signalAppendFinished, this, &PackagesManager::slotAppendPackageFinished);
 
     getBlackApplications();
+
+    // 缓存更新完成后清除陈旧的 break/CompatibleNotInstalled 依赖状态，确保重新计算
+    connect(&PackageAnalyzer::instance(), &PackageAnalyzer::cacheUpdateFinished, this, [this]() {
+        invalidateStaleBreakStatus();
+    });
 }
 
 bool PackagesManager::isBackendReady()
@@ -1731,6 +1736,26 @@ void PackagesManager::resetPackageDependsStatus(const int index)
     m_packageMd5DependsStatus.remove(currentPackageMd5);  // 删除当前包的依赖状态（之后会重新获取此包的依赖状态）
 
     // we don't need reset m_markedDepends on installing
+}
+
+void PackagesManager::invalidateStaleBreakStatus()
+{
+    qCDebug(appLog) << "Invalidating stale break/compatible-not-installed cache entries";
+    QList<QByteArray> staleKeys;
+    for (auto it = m_packageMd5DependsStatus.begin(); it != m_packageMd5DependsStatus.end(); ++it) {
+        if (it.value().status == Pkg::DependsStatus::DependsBreak ||
+            it.value().status == Pkg::DependsStatus::CompatibleNotInstalled) {
+            staleKeys.append(it.key());
+        }
+    }
+    for (const auto &key : staleKeys) {
+        m_packageMd5DependsStatus.remove(key);
+    }
+    if (!staleKeys.isEmpty()) {
+        if (auto backend = PackageAnalyzer::instance().backendPtr()) {
+            backend->reloadCache();
+        }
+    }
 }
 
 /**

--- a/src/deb-installer/manager/packagesmanager.h
+++ b/src/deb-installer/manager/packagesmanager.h
@@ -285,6 +285,12 @@ public:
      */
     void resetPackageDependsStatus(const int index);
 
+    /**
+     * @brief invalidateStaleBreakStatus 清除缓存中状态为 break/CompatibleNotInstalled 的条目
+     * 在 apt 缓存更新完成后调用，确保陈旧的依赖判定被重新计算
+     */
+    void invalidateStaleBreakStatus();
+
     //// 依赖查找 获取等相关函数
 private:
     /**

--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -649,6 +649,28 @@ void DebInstaller::slotPackagesSelected(const QStringList &packagesPathList)
 {
     const QStringList &pkgRealPathList = pathTransform(packagesPathList);
     qCDebug(appLog) << "Packages selected:" << pkgRealPathList;
+    // 后端/缓存未就绪时暂存待处理包，避免依赖检查抢跑导致误判为 break 并永久缓存错误结果
+    if (!PackageAnalyzer::instance().isBackendReady() || !PackageAnalyzer::instance().isCacheUpdateFinished()) {
+        qCInfo(appLog) << "Backend/cache not ready, deferring package selection until cache update finished";
+        m_pendingPackages = pkgRealPathList;
+        if (!m_packageAppendDeferred) {
+            m_packageAppendDeferred = true;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+            connect(&PackageAnalyzer::instance(), &PackageAnalyzer::cacheUpdateFinished,
+                    this, &DebInstaller::slotProcessPendingPackages);
+#else
+            connect(&PackageAnalyzer::instance(), &PackageAnalyzer::cacheUpdateFinished, this, [this]() {
+                m_packageAppendDeferred = false;
+                if (!m_pendingPackages.isEmpty()) {
+                    QStringList pending = m_pendingPackages;
+                    m_pendingPackages.clear();
+                    slotPackagesSelected(pending);
+                }
+            }, Qt::SingleShotConnection);
+#endif
+        }
+        return;
+    }
     // 兼容模式下不允许追加新包
     const QModelIndex existIdx = m_fileListModel->index(0);
     if (existIdx.isValid()) {
@@ -675,6 +697,18 @@ void DebInstaller::slotPackagesSelected(const QStringList &packagesPathList)
 
         // 开始添加包，将要添加的包传递到后端，添加包由后端处理
         m_fileListModel->slotAppendPackage(pkgRealPathList);
+    }
+}
+
+void DebInstaller::slotProcessPendingPackages()
+{
+    disconnect(&PackageAnalyzer::instance(), &PackageAnalyzer::cacheUpdateFinished,
+               this, &DebInstaller::slotProcessPendingPackages);
+    m_packageAppendDeferred = false;
+    if (!m_pendingPackages.isEmpty()) {
+        QStringList pending = m_pendingPackages;
+        m_pendingPackages.clear();
+        slotPackagesSelected(pending);
     }
 }
 

--- a/src/deb-installer/view/pages/debinstaller.h
+++ b/src/deb-installer/view/pages/debinstaller.h
@@ -65,6 +65,12 @@ private slots:
     void slotPackagesSelected(const QStringList &packages);
 
     /**
+     * @brief slotProcessPendingPackages 处理暂存的待安装包
+     * 在后端/缓存就绪后重新执行包选择流程
+     */
+    void slotProcessPendingPackages();
+
+    /**
      * @brief slotDdimSelected
      * @param ddimFiles 清单文件
      * 根据清单文件进行解析操作
@@ -370,6 +376,9 @@ private:
 
     bool m_packageAppending = false;
     int m_wineAuthStatus = -1;  // 记录依赖配置授权状态
+
+    QStringList m_pendingPackages;        // 暂存后端未就绪时的待处理包路径
+    bool m_packageAppendDeferred = false; // 防止重复连接 cacheUpdateFinished 信号
 };
 
 #endif  // DEBINSTALLER_H


### PR DESCRIPTION
## Root Cause Analysis

When the deb installer launches, its constructor starts `initBackend()` + `updatePackageCache()` in a background `QtConcurrent::run` thread (takes seconds), but `slotPackagesSelected()` — invoked via `Qt::QueuedConnection` on the next event-loop tick (milliseconds) — reaches dependency checking before the backend/cache is ready. `packageWithArch()` returns nullptr → the result is cached as `DependsBreak` → converted to `CompatibleNotInstalled` in `m_packageMd5DependsStatus` and stored permanently. After the cache finishes updating, the stale `_break` result is never invalidated or recomputed, so the UI erroneously enters compatible mode and the install fails. The user confirmed via `apt-cache policy` that all four dependencies (`libreadline7`, `libffi6`, `libmpdec2`, `bridge-utils`) have candidate versions in the apt source, ruling out "dependency missing" and confirming this is a pure timing race.

Key evidences:
- `debinstaller.cpp:648-679` — `slotPackagesSelected()` guard only checks `WorkerStatus`/`wineAuthStatus`, with no `isBackendReady()`/`isCacheUpdateFinished()` gate.
- `packagesmanager.cpp:1246-1261` — `dependsStatus.isBreak()` → `CompatibleNotInstalled` written into `m_packageMd5DependsStatus`, cached permanently.
- `debinstaller.cpp:536-556` — `slotUpdateCacheFinished()` does `reloadCache()` + `setCacheUpdateFinished(true)` but never invalidates the already-cached `_break` results.

## Fix Solution

Two complementary directions are implemented. (1) Gate `slotPackagesSelected()` with `isBackendReady()` && `isCacheUpdateFinished()`: when not ready, store pending package paths in `m_pendingPackages` and defer processing until the `cacheUpdateFinished` signal fires, reusing the single-shot-connection pattern established by PMS 354283 (with a `#if QT_VERSION` guard for Qt5/Qt6). (2) After `cacheUpdateFinished`, call the new `invalidateStaleBreakStatus()` method to remove `DependsBreak`/`CompatibleNotInstalled` entries from `m_packageMd5DependsStatus` and `reloadCache()`, so stale results get recomputed against the refreshed cache. The actual implementation matches the analysis-report fix suggestion with no deviation.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Medium
- The `cacheUpdateFinished` signal and `isCacheUpdateFinished()` pattern were introduced by PMS 354283; direction 1 reuses that established waiting pattern and does not revert it. Direction 2 only adds a new selective cache-invalidation method (`invalidateStaleBreakStatus`) without modifying any existing function signature.
- Blame history shows `getPackageDependsStatus()` has ~80 references (broad impact surface), but direction 2 only adds a new method and direction 1 only adds an early-return deferral at the entry — both are backward-compatible. All related PMS fixes (354283, 364455, 321451, 358267, 311901) are preserved: the arch-mismatch check (PMS 364455) is re-run after cache invalidation, and only `DependsBreak`/`CompatibleNotInstalled` entries are cleared, leaving `DependsOk`/`DependsAvailable` untouched.
- Highest-risk callers: `slotPackagesSelected()` (main entry — behavior changes from "execute now" to "defer until ready", final result identical) and `slotUpdateCacheFinished()` (invocation point for `invalidateStaleBreakStatus()` — must verify package data already exists in `m_fileListModel` at that moment).

### Business Impact Scope

- **Package installation (single/multi package)**: the dependency-check flow triggered when a user double-clicks a deb file or adds packages via the file picker. Affected scenarios: installing immediately on first launch, installing after the backend is ready, and adding multiple packages in sequence.
- **Compatible-mode installation**: the fallback flow to compatible-rootfs install when dependencies are unmet. After this fix, packages whose dependencies are actually satisfied will no longer be misrouted into compatible mode.

### Verification Suggestion

- Test installing `com.uos.rainbow` immediately on first launch (original bug scenario) — should install normally without entering compatible mode.
- Test installing a normal deb package after the backend is ready, and verify compatible mode still triggers for packages with genuinely broken dependencies (regression check for direction 2).

---

## 根因分析

安装器构造时在后台 `QtConcurrent::run` 线程启动 `initBackend()` + `updatePackageCache()`（耗时数秒），但 `slotPackagesSelected()` 经 `Qt::QueuedConnection` 在下一事件循环 tick（毫秒级）即执行依赖检查——此时后端尚未就绪、apt 缓存尚未刷新。`packageWithArch()` 返回 nullptr → 结果被缓存为 `DependsBreak` → 转为 `CompatibleNotInstalled` 写入 `m_packageMd5DependsStatus` 并永久缓存。缓存更新完成后，陈旧的 `_break` 结果从不失效重算，UI 据此误入兼容模式，安装失败。用户已通过 `apt-cache policy` 确认 `libreadline7`、`libffi6`、`libmpdec2`、`bridge-utils` 四个依赖在 apt 源中均有候选版本，排除了"依赖缺失"，确认为纯时序竞态。

关键证据：
- `debinstaller.cpp:648-679` — `slotPackagesSelected()` 守卫仅检查 `WorkerStatus`/`wineAuthStatus`，无 `isBackendReady()`/`isCacheUpdateFinished()` 门禁。
- `packagesmanager.cpp:1246-1261` — `dependsStatus.isBreak()` → `CompatibleNotInstalled` 写入 `m_packageMd5DependsStatus`，永久缓存。
- `debinstaller.cpp:536-556` — `slotUpdateCacheFinished()` 执行 `reloadCache()` + `setCacheUpdateFinished(true)`，但不失效已缓存的 `_break` 结果。

## 修复方案

实施两个互补方向。（1）在 `slotPackagesSelected()` 中加入 `isBackendReady()` && `isCacheUpdateFinished()` 门禁：未就绪时将待处理包路径暂存至 `m_pendingPackages`，监听 `cacheUpdateFinished` 信号触发后再处理，复用 PMS 354283 引入的 SingleShotConnection 等待模式（用 `#if QT_VERSION` 兼容 Qt5/Qt6）。（2）`cacheUpdateFinished` 后调用新增的 `invalidateStaleBreakStatus()` 方法，清除 `m_packageMd5DependsStatus` 中 `DependsBreak`/`CompatibleNotInstalled` 条目并 `reloadCache()`，使陈旧结果基于刷新后的缓存重新计算。实际实现与分析报告修复建议一致，无偏离。

## 改动安全评估

### 代码安全评估

- **风险等级**: 中风险
- `cacheUpdateFinished` 信号与 `isCacheUpdateFinished()` 模式由 PMS 354283 引入，方向一复用该已建立的等待模式，不撤销其修复。方向二仅新增选择性缓存清除方法 `invalidateStaleBreakStatus()`，不修改任何已有函数签名。
- blame 历史显示 `getPackageDependsStatus()` 有约 80 处引用（影响面广），但方向二仅新增方法、方向一仅入口处新增早返回延迟逻辑，均为向后兼容改动。所有关联 PMS 修复（354283、364455、321451、358267、311901）均不受影响：架构不匹配检查（PMS 364455）在缓存失效重算时会重新经过，且仅清除 `DependsBreak`/`CompatibleNotInstalled` 条目，`DependsOk`/`DependsAvailable` 等正确状态不受影响。
- 风险最高的调用者：`slotPackagesSelected()`（主入口——行为由"立即执行"变为"延迟至就绪后执行"，最终结果一致）和 `slotUpdateCacheFinished()`（`invalidateStaleBreakStatus()` 调用点——需确认此时 `m_fileListModel` 中已有包数据）。

### 业务影响范围

- **软件包安装（单包/多包）**：用户双击 deb 文件或通过文件选择器添加包时的依赖检查流程。受影响场景：首次启动后立即安装、后端就绪后安装、多包连续添加。
- **兼容模式安装**：依赖不满足时回退到兼容 rootfs 安装的流程。修复后，依赖实际满足的包不再被误导入兼容模式。

### 验证建议

- 测试首次启动后立即安装 `com.uos.rainbow`（本 bug 原场景）——应正常安装，不再误入兼容模式。
- 测试后端就绪后安装普通 deb 包，并验证依赖确实不满足时仍正常进入兼容模式（方向二回归检查）。

## Summary by Sourcery

Prevent dependency checks from racing package-cache initialization and causing valid Debian packages to enter compatible installation mode.

Bug Fixes:
- Defer package selection and dependency checks until the backend and package cache are ready, preventing valid packages from being incorrectly classified as having broken dependencies.
- Clear stale broken-dependency and compatible-not-installed statuses after cache updates so dependency results are recalculated against the refreshed cache.

Enhancements:
- Add pending-package processing when cache initialization completes, with safeguards against duplicate deferred processing.