### PR TITLE
fix: reduce delay before auth dialog on install

### DIFF
--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -57,7 +57,7 @@ bool DebListModel::isDpkgRunning()
     proc.start("ps", QStringList() << "-e"
                << "-o"
                << "comm");
-    proc.waitForFinished();
+    proc.waitForFinished(3000);
 
     // 获取进程信息的数据
     const QString processOutput = proc.readAllStandardOutput();
@@ -820,9 +820,6 @@ void DebListModel::installDebs()
         return;
 
     Transaction *transaction = nullptr;
-
-    // reset package depends status
-    m_packagesManager->resetPackageDependsStatus(m_operatingStatusIndex);
 
     // check available dependencies
     const auto dependsStat = m_packagesManager->getPackageDependsStatus(m_operatingStatusIndex);


### PR DESCRIPTION
## Root Cause Analysis

When the user clicks "Install", the install entry `slotInstallPackages` runs synchronously on the GUI main thread, and several blocking operations execute before the auth dialog can appear. Two of them are redundant or unbounded:

- `installNextDeb()` (deblistmodel.cpp:1305) calls `resetPackageDependsStatus` which triggers `backend->reloadCache()` and a full dependency-tree parse via `getPackageDependsStatus`. It then calls `installDebs()` (deblistmodel.cpp:825), which repeats the exact same `resetPackageDependsStatus` call, forcing the cache reload and full dependency reparse to run a second time with an identical result — pure wasted main-thread time before auth.
- `isDpkgRunning()` (deblistmodel.cpp:60) starts `ps` and calls `waitForFinished()` with no timeout; when dpkg is already running it polls `ps` every second (:844/:883), and each poll can re-trigger the redundant reload/parse above.

The auth dialog (`signalLockForAuth`, deblistmodel.cpp:518) only appears after `backend->installFile` creates a transaction (deblistmodel.cpp:886), which is reached only after all of this pre-work completes — so all of it delays the dialog.

## Fix

- Remove the redundant `resetPackageDependsStatus(m_operatingStatusIndex)` call in `installDebs()`. It is already performed by `installNextDeb()` immediately before `installDebs()` is invoked, and `installDebs()` is only ever called from `installNextDeb()` (:1308, :1319). With the redundant reset gone, the following `getPackageDependsStatus` becomes a fast cache hit instead of a full reparse.
- Add a 3-second timeout to `isDpkgRunning()`'s `ps` `waitForFinished()`. `ps` normally completes in milliseconds; the timeout only bounds the pathological case where `ps` is slow or stuck, preventing an unbounded main-thread block.
- RC-1 (`Digital_Verify` `waitForFinished(-1)` in utils.cpp:155) is intentionally NOT changed: that unbounded wait was introduced by commit `ea7ba72e` to fix PMS #123, where large-package signature verification was being killed by a 30s timeout. Adding a timeout here would regress that fix.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The removed `resetPackageDependsStatus` call in `installDebs()` is provably redundant: `installDebs()` is only called from `installNextDeb()` (:1308, :1319), which performs the identical reset immediately beforehand, so removing the duplicate does not change the eventual dependency status — the subsequent `getPackageDependsStatus` returns the same cached result.
- The 3s `ps` timeout is a safety bound only; `ps` completes in milliseconds in normal operation, so behavior is unchanged for the common path.
- RC-1's unbounded wait is a deliberate historical fix (commit `ea7ba72e`, PMS #123) and is left untouched, so this change does not revert a prior bug fix.

### Business Impact Scope

- Affects the package install flow before the authentication dialog: installing single or multiple `.deb` packages, especially large packages such as `ddim`. The auth dialog should appear sooner after clicking "Install".
- Installing while `dpkg` is already running (the 1s poll retry path) benefits from the bounded `ps` wait and the eliminated redundant cache reload/dependency reparse.

### Verification Suggestion

- Verify the auth dialog appears noticeably sooner when installing a large package (e.g. `ddim`) after clicking "Install".
- Regression-check multi-package batch install with dependencies, and installing while `dpkg` is running, to confirm dependency status resolution and install behavior are unchanged.

---

## 根因分析

用户点击「安装」时，安装入口 `slotInstallPackages` 在 GUI 主线程同步执行，鉴权弹框出现之前会先执行若干阻塞操作，其中两项冗余或无上限：

- `installNextDeb()`（deblistmodel.cpp:1305）调用 `resetPackageDependsStatus`，触发 `backend->reloadCache()` 与经 `getPackageDependsStatus` 的全量依赖树解析；随后调用 `installDebs()`（deblistmodel.cpp:825），后者再次执行完全相同的 `resetPackageDependsStatus`，导致缓存重载与全量依赖重解析无意义地跑第二遍且结果一致——纯属鉴权弹框前浪费的主线程耗时。
- `isDpkgRunning()`（deblistmodel.cpp:60）启动 `ps` 并以无超时 `waitForFinished()` 等待；当 dpkg 正在运行时每秒轮询 `ps`（:844/:883），每轮又可能触发上述冗余的重载/解析。

鉴权弹框（`signalLockForAuth`，deblistmodel.cpp:518）仅在 `backend->installFile` 创建事务后（deblistmodel.cpp:886）出现，而这必须在所有前置工作完成后才到达，因此这些前置耗时都延迟了弹框。

## 修复方案

- 删除 `installDebs()` 中冗余的 `resetPackageDependsStatus(m_operatingStatusIndex)` 调用。该调用已在 `installNextDeb()` 调用 `installDebs()` 之前立即执行，且 `installDebs()` 仅被 `installNextDeb()`（:1308、:1319）调用。去除冗余后，随后的 `getPackageDependsStatus` 直接命中缓存而非全量重解析。
- 为 `isDpkgRunning()` 的 `ps` `waitForFinished()` 增加 3 秒超时。`ps` 正常情况下毫秒级完成，超时仅约束 `ps` 异常缓慢或卡住的病态场景，避免主线程无限阻塞。
- RC-1（utils.cpp:155 的 `Digital_Verify` `waitForFinished(-1)`）刻意不改：该无超时等待由提交 `ea7ba72e` 为修复 PMS #123（大包签名校验被 30 秒超时杀死）而引入，加超时将回归该修复。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- `installDebs()` 中删除的 `resetPackageDependsStatus` 调用可证冗余：`installDebs()` 仅被 `installNextDeb()`（:1308、:1319）调用，而后者在调用前已执行相同 reset，故删除重复项不改变最终依赖状态——随后的 `getPackageDependsStatus` 返回同样的缓存结果。
- `ps` 的 3 秒超时仅为安全上界；正常路径下 `ps` 毫秒级完成，行为不变。
- RC-1 的无超时等待是刻意保留的历史修复（提交 `ea7ba72e`，PMS #123），本次未改动，故不会回归既有缺陷修复。

### 业务影响范围

- 影响鉴权弹框前的安装流程：单包或多 `.deb` 包安装，尤其 `ddim` 等大包。点击「安装」后鉴权弹框应更快弹出。
- dpkg 运行期间安装（1 秒轮询重试路径）受益于有界的 `ps` 等待与被消除的冗余缓存重载/依赖重解析。

### 验证建议

- 验证安装大包（如 `ddim`）时点击「安装」后鉴权弹框明显更快弹出。
- 回归测试多包批量含依赖安装，以及 dpkg 运行期间安装，确认依赖状态解析与安装行为不变。

PMS: BUG-248165

## Summary by Sourcery

Bug Fixes:
- Reduce the time before the authentication dialog appears during package installation by removing redundant dependency-status work and bounding process detection waits.