### PR TITLE
fix(immutable): support reinstall when same version installed

### DIFF
--- a/src/AptInstallDepend/installDebThread.cpp
+++ b/src/AptInstallDepend/installDebThread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,6 +12,7 @@ static const QString kParamInstallConfig = "install_config";
 static const QString kParamInstallComaptible = "install_compatible";
 static const QString kParamInstallImmutable = "install_immutable";
 static const QString kParamInstallUab = "uab";
+static const QString kParamReinstall = "reinstall";
 
 static const QString kAptBin = "apt";
 static const QString kInstall = "install";
@@ -65,8 +66,9 @@ void InstallDebThread::setParam(const QStringList &arguments)
                                             {kParamInstallConfig, InstallConfig},
                                             {kParamInstallComaptible, Compatible},
                                             {kParamInstallImmutable, Immutable},
-                                            {kParamInstallUab, LinglongUab},
-                                            {kInstall, Install},
+                                             {kParamInstallUab, LinglongUab},
+                                             {kParamReinstall, Reinstall},
+                                             {kInstall, Install},
                                             {kRemove, Remove},
                                             {kCompCheck, AppCheck}};
 
@@ -367,6 +369,7 @@ void InstallDebThread::immutableProcess()
     static const QString kImmuEnvEnableWait = "DEEPIN_IMMUTABLE_CTL_WAIT_LOCK";
     static const QString kImmuYes = "-y";
     static const QString kImmuAllowDowngrades = "--allow-downgrades";
+    static const QString kImmuReinstall = "--reinstall";
 
     QStringList params;
 
@@ -391,13 +394,19 @@ void InstallDebThread::immutableProcess()
         }
 
         // Note: deepin-immutable-ctl actually use apt to install/uninstall. (params transport to deepin-immutable-ctl)
-        // e.g.: apt install [deb file] -y (--allow-downgrades)
+        // e.g.: apt install [deb file] -y (--allow-downgrades) (--reinstall)
         params << kInstall << debPath << kImmuYes;
 
         // FIXME: temporary code, check if current Immutable System need --allow-downgrades
         if (newImmutableVersion()) {
             qDebug() << "new immutable version, add --allow-downgrades";
             params << kImmuAllowDowngrades;
+        }
+
+        // apt skips when the same version is already installed, force reinstall
+        if (m_cmds.testFlag(Reinstall)) {
+            qDebug() << "flag Reinstall, add --reinstall";
+            params << kImmuReinstall;
         }
 
     } else if (m_cmds.testFlag(Remove)) {

--- a/src/AptInstallDepend/installDebThread.h
+++ b/src/AptInstallDepend/installDebThread.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -33,6 +33,7 @@ public:
         LinglongUab = 1 << 7,  // linglong app(lingyaps)
 
         AppCheck = 1 << 8,  // compatible appcheck
+        Reinstall = 1 << 9,  // reinstall same version installed package
     };
     Q_DECLARE_FLAGS(Commands, Command)
     Q_FLAG(Commands)

--- a/src/deb-installer/immutable/immutable_process_controller.cpp
+++ b/src/deb-installer/immutable/immutable_process_controller.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,6 +16,7 @@ namespace Immutable {
 static const QString kPkexecBin = "pkexec";
 static const QString kInstallProcessorBin = "deepin-deb-installer-dependsInstall";
 static const QString kParamImmutable = "--install_immutable";
+static const QString kParamReinstall = "--reinstall";
 static const QString kParamInstallConfig = "--install_config";
 static const QString kParamInstall = "--install";
 static const QString kParamRemove = "--remove";
@@ -41,7 +42,7 @@ bool ImmutableProcessController::isRunning() const
     return false;
 }
 
-bool ImmutableProcessController::install(const Deb::DebPackage::Ptr &package)
+bool ImmutableProcessController::install(const Deb::DebPackage::Ptr &package, bool reinstall)
 {
     qCDebug(appLog) << "install immutable package";
     if (!package || !package->isValid() || isRunning()) {
@@ -67,6 +68,10 @@ bool ImmutableProcessController::install(const Deb::DebPackage::Ptr &package)
     // but the first argument to pass to setProgram()
     // sa: Pty::start()
     QStringList params{kPkexecBin, kInstallProcessorBin, kParamImmutable, kParamInstall, m_currentPackage->filePath()};
+    if (reinstall) {
+        qCDebug(appLog) << "same version installed, add --reinstall";
+        params << kParamReinstall;
+    }
     if (m_currentPackage->containsTemplates()) {
         qCDebug(appLog) << "install config templates";
         params << kParamInstallConfig;

--- a/src/deb-installer/immutable/immutable_process_controller.h
+++ b/src/deb-installer/immutable/immutable_process_controller.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -26,7 +26,7 @@ public:
     [[nodiscard]] const Deb::DebPackage::Ptr &currentPackage() const;
 
     [[nodiscard]] bool isRunning() const;
-    [[nodiscard]] bool install(const Deb::DebPackage::Ptr &package);
+    [[nodiscard]] bool install(const Deb::DebPackage::Ptr &package, bool reinstall = false);
     [[nodiscard]] bool uninstall(const Deb::DebPackage::Ptr &package);
 
     [[nodiscard]] bool needTemplates() const;

--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -2245,7 +2245,12 @@ bool DebListModel::installImmutablePackage()
 
     m_currentPackage = packagePtr(m_operatingIndex);
 
-    return m_immProcessor->install(m_currentPackage);
+    // apt skips when the same version is already installed, force reinstall
+    const int installStat = m_packagesManager->packageInstallStatus(m_operatingStatusIndex);
+    const bool reinstall = (Pkg::PackageInstallStatus::InstalledSameVersion == installStat);
+    qCDebug(appLog) << "Immutable package install status:" << installStat << "reinstall:" << reinstall;
+
+    return m_immProcessor->install(m_currentPackage, reinstall);
 }
 
 bool DebListModel::uninstallImmutablePackage()


### PR DESCRIPTION
Pass --reinstall to apt when the same version package is already installed on immutable system, so apt will not skip the install.

不可变系统下同版本包已安装时 apt 会跳过安装，传递 --reinstall
参数强制重装。

Log: 不可变系统支持同版本包强制重装
PMS: BUG-374779
Influence: 不可变系统上安装同版本已安装的包时将强制重装，不再被 apt 跳过。

## Summary by Sourcery

Ensure immutable-system installs reinstall packages when the same version is already present.

Bug Fixes:
- Force reinstallation of the same-version package on immutable systems instead of allowing apt to skip it.

Enhancements:
- Propagate immutable package reinstall status through the installation flow and support the reinstall command option.