### PR TITLE
chore: update version to 6.5.51

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deb-installer (6.5.51) unstable; urgency=medium
+
+  * fix: update Arabic (ar) translations
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Mon, 07 Sep 2026 11:30:58 +0800
+
 deepin-deb-installer (6.5.50) unstable; urgency=medium
 
   * fix(immutable): support reinstall when same version installed


### PR DESCRIPTION
as title

Log: update version

## Summary by Sourcery

Chores:
- Update the Debian package changelog for version 6.5.51.