### PR TITLE
fix: emit signalWorkerFinished on auth cancel to prevent event loop deadlock

### DIFF
--- a/src/deb-installer/model/backend/apt_install_backend.cpp
+++ b/src/deb-installer/model/backend/apt_install_backend.cpp
@@ -582,7 +582,8 @@ void AptInstallBackend::slotTransactionErrorOccurred()
         Q_EMIT m_model->signalLockForAuth(false);
         Q_EMIT m_model->signalAuthCancel();
         Q_EMIT m_model->signalEnableCloseButton(true);
-        m_model->m_workerStatus = AbstractPackageListModel::WorkerPrepare;
+        m_model->m_workerStatus = AbstractPackageListModel::WorkerFinished;
+        Q_EMIT m_model->signalWorkerFinished();
         return;
     }
 


### PR DESCRIPTION
## Root Cause Analysis

When a user cancels authentication during a DBus-initiated deb package
installation, `AptInstallBackend::slotTransactionErrorOccurred()` handles the
`AuthError` by setting `WorkerPrepare` and returning **without** emitting
`signalWorkerFinished`. This causes `DebInstaller::startInstallPackge()`'s
`QEventLoop` to block permanently — the dbus call never returns, the process
lingers, and a second call to the same instance reports "Already Added" because
the MD5 was already registered before the loop started.

Key evidence: `apt_install_backend.cpp:585-586` (AuthError return without
signal) vs `apt_install_backend.cpp:637-638` (uninstall path correctly emits
`signalWorkerFinished`).

## Fix

Set `m_workerStatus` to `WorkerFinished` (instead of `WorkerPrepare`) and emit
`signalWorkerFinished()` before `return` in the AuthError branch, matching the
signal contract already used by the uninstall path. Change is 2 lines in a
single function.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Target code was introduced in a strategy-pattern refactor (commit `18d6f93c`,
  2026-05-12) and never emitted `signalWorkerFinished` — this is a historical
  omission, not a regression of a prior fix.
- All 5 reference sites (headers, model, UT) do not depend on the AuthError
  branch returning `WorkerPrepare`; no caller behavior changes.

### Business Impact Scope

Only affects the **DBus install path when authentication is cancelled**:
- The dbus call returns normally and the process exits cleanly.
- Normal install and uninstall flows are unaffected.
- Reinstalling the same package after auth cancel no longer triggers
  "Already Added".

### Verification Suggestion

Test via `gdbus call ... InstallerDebPackge`, cancel at the polkit dialog,
verify the command returns and the process exits; then call again for the same
package and verify no "Already Added" error.

---

## 根因分析

用户通过 DBus 调用安装 deb 包时在鉴权阶段取消，`AptInstallBackend::slotTransactionErrorOccurred()`
处理 `AuthError` 时设置 `WorkerPrepare` 后直接 return，**未发射 `signalWorkerFinished`**，
导致 `DebInstaller::startInstallPackge()` 的 `QEventLoop` 永久阻塞——dbus call 不返回、
进程残留，二次调用同一实例因 MD5 已注册而报 "Already Added"。

关键证据：`apt_install_backend.cpp:585-586`（AuthError 未发射信号）对比
`apt_install_backend.cpp:637-638`（卸载路径正确发射 `signalWorkerFinished`）。

## 修复方案

在 AuthError 分支 return 前将 `m_workerStatus` 设为 `WorkerFinished`（替代 `WorkerPrepare`）
并发射 `signalWorkerFinished()`，与卸载路径的信号契约保持一致。改动仅 2 行，单函数内。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 目标代码在策略模式重构（commit `18d6f93c`，2026-05-12）中引入，从未发射过
  `signalWorkerFinished`，属历史遗漏而非回归历史修复。
- 5 处引用点（头文件、模型、UT）均不依赖 AuthError 分支返回 `WorkerPrepare`，无调用者行为变化。

### 业务影响范围

仅影响 **DBus 安装路径鉴权取消** 场景：
- dbus call 正常返回，进程正常退出。
- 正常安装和卸载流程不受影响。
- 鉴权取消后再次安装同一包不再提示 "Already Added"。

### 验证建议

通过 `gdbus call ... InstallerDebPackge` 调用安装，在 polkit 弹窗取消，验证命令返回且进程退出；
再次调用同一包验证不提示 "Already Added"。

## Summary by Sourcery

Bug Fixes:
- Complete the DBus installation flow when authentication is cancelled so the waiting event loop terminates and subsequent installation attempts can proceed normally.