### PR TITLE
fix: exit nested event loop on auth cancel in DBus install path

### DIFF
--- a/src/deb-installer/view/pages/debinstaller.cpp
+++ b/src/deb-installer/view/pages/debinstaller.cpp
@@ -321,11 +321,16 @@ QString DebInstaller::startInstallPackge(const QString &debPath)
         // wait install finished;
         QEventLoop loop;
         connect(m_fileListModel, &AbstractPackageListModel::signalWorkerFinished, &loop, &QEventLoop::quit);
+        connect(m_fileListModel, &AbstractPackageListModel::signalAuthCancel, &loop, &QEventLoop::quit);
         loop.exec();
 
-        message = m_fileListModel->lastProcessError();
-        if (message.isEmpty())
-            message = "install succeeded";
+        if (m_fileListModel->isWorkerPrepare()) {
+            message = "authorization cancelled";
+        } else {
+            message = m_fileListModel->lastProcessError();
+            if (message.isEmpty())
+                message = "install succeeded";
+        }
     }
 
     return message;


### PR DESCRIPTION
## Root Cause Analysis

`DebInstaller::startInstallPackge()` uses a nested `QEventLoop` that only connects `signalWorkerFinished` to `loop.quit()`. The auth-cancel path (`AptInstallBackend::slotTransactionErrorOccurred()` AuthError branch) resets worker status to `WorkerPrepare` and emits `signalAuthCancel`, but never emits `signalWorkerFinished` — by design, since the GUI path needs `WorkerPrepare` to allow retry after auth cancel.

This causes `loop.exec()` to block forever: the D-Bus method `InstallerDebPackge` never returns, the `QTimer::singleShot(100, quit())` at `singleInstallerApplication.cpp:135` is never reached, and the process persists. A second D-Bus call re-enters `startInstallPackge` on the residual instance, where `checkPackageValid` runs before `reset()` and finds the MD5 still in `m_appendedPackagesMd5`, returning "The deb package Already Added".

## Fix

Connect `signalAuthCancel` to `loop.quit()` in `startInstallPackge()`, so the nested event loop exits when auth is cancelled. After `loop.exec()` returns, check `isWorkerPrepare()` to distinguish auth cancel from normal completion and return the appropriate message.

This fix only modifies the **listening side** (`debinstaller.cpp`) — the emission side (`apt_install_backend.cpp`) is unchanged, preserving the `WorkerPrepare` status needed for GUI retry.

## Change Safety Assessment

- **Risk level**: Low — only adds a `connect` and a conditional branch; no existing logic modified
- **GUI path unaffected**: `startInstallPackge()` is only used in the D-Bus call path, not the GUI install path
- **Worker status unchanged**: AuthError branch keeps `WorkerPrepare`; GUI retry still works
- **Avoids dangling pointer**: auth-cancel path returns "authorization cancelled" without calling `lastProcessError()` on a `deleteLater()`'d transaction

## Verification

1. D-Bus call → cancel auth → verify gdbus returns normally
2. D-Bus call → cancel auth → verify process exits
3. D-Bus call → cancel auth → second call → verify no "Already Added"
4. D-Bus call → complete normally → verify "install succeeded"
5. GUI install → cancel auth → verify retry works

---

## 根因分析

`DebInstaller::startInstallPackge()` 的嵌套 `QEventLoop` 只连接了 `signalWorkerFinished`。鉴权取消路径将 worker 状态重置为 `WorkerPrepare` 并发射 `signalAuthCancel`，但不发射 `signalWorkerFinished`——这是设计如此，GUI 路径需要 `WorkerPrepare` 状态以支持鉴权取消后重试。

导致 `loop.exec()` 永久阻塞：D-Bus 方法 `InstallerDebPackge` 不返回，`quit()` 定时器不执行，进程残留。二次调用重入残留实例，`checkPackageValid` 先于 `reset()` 执行，MD5 仍在列表中，返回 "Already Added"。

## 修复方案

在 `startInstallPackge()` 中将 `signalAuthCancel` 也连接到 `loop.quit()`，使鉴权取消时嵌套事件循环正常退出。退出后检查 `isWorkerPrepare()` 区分鉴权取消和正常完成。

仅修改监听端（`debinstaller.cpp`），发射端（`apt_install_backend.cpp`）不变，保留 GUI 重试所需的 `WorkerPrepare` 状态。

## 改动安全评估

- **风险等级**：低——仅新增 1 行 connect 和条件判断分支，不修改已有逻辑
- **GUI 路径不受影响**：`startInstallPackge()` 仅用于 D-Bus 调用路径
- **Worker 状态不变**：AuthError 分支保持 `WorkerPrepare`，GUI 重试功能正常
- **避免悬空指针**：鉴权取消路径返回 "authorization cancelled"，不调用 `lastProcessError()`

## Summary by Sourcery

Allow the D-Bus installation flow to exit cleanly and report cancellation when package authorization is denied or cancelled.

Bug Fixes:
- Ensure D-Bus package installation requests return normally when authorization is cancelled instead of hanging indefinitely.
- Report authorization cancellation distinctly and avoid treating cancelled installations as successful or accessing unavailable transaction errors.