### PR TITLE
fix(model): return recorded status in lastProcessError

### DIFF
--- a/src/deb-installer/model/deblistmodel.cpp
+++ b/src/deb-installer/model/deblistmodel.cpp
@@ -650,6 +650,22 @@ QString DebListModel::lastProcessError()
         qCDebug(appLog) << "Returning error string from current transaction:" << m_currentTransaction->errorString();
         return m_currentTransaction->errorString();
     }
+
+    // The transaction is deleted right after a successful finish, before
+    // signalWorkerFinished wakes the DBus caller. Decide by the operating
+    // package's status instead of blindly reporting "failed".
+    const int operateStatus = m_packageOperateStatus.value(m_operatingPackageMd5, Pkg::PackageOperationStatus::Prepare);
+    if (Pkg::PackageOperationStatus::Success == operateStatus) {
+        qCDebug(appLog) << "Last operation succeeded, no process error.";
+        return QString();
+    }
+
+    const QString failReason = m_packageFailReason.value(m_operatingPackageMd5);
+    if (!failReason.isEmpty()) {
+        qCDebug(appLog) << "Returning recorded fail reason:" << failReason;
+        return failReason;
+    }
+
     qCDebug(appLog) << "No current transaction, returning 'failed'.";
     return "failed";
 }

--- a/tests/src/model/ut_deblistmodel.cpp
+++ b/tests/src/model/ut_deblistmodel.cpp
@@ -684,6 +684,39 @@ TEST_F(ut_DebListModel_test, deblistmodel_UT_initRowStatus)
     ASSERT_EQ(m_debListModel->m_packageOperateStatus.find("deb").value(), Pkg::PackageOperationStatus::Waiting);
 }
 
+TEST_F(ut_DebListModel_test, deblistmodel_UT_lastProcessError_no_record)
+{
+    EXPECT_EQ(QString("failed"), m_debListModel->lastProcessError());
+}
+
+TEST_F(ut_DebListModel_test, deblistmodel_UT_lastProcessError_success_without_transaction)
+{
+    const QByteArray md5("md5-lastProcessError-success");
+    m_debListModel->m_operatingPackageMd5 = md5;
+    m_debListModel->m_packageOperateStatus[md5] = Pkg::PackageOperationStatus::Success;
+
+    EXPECT_EQ(QString(), m_debListModel->lastProcessError());
+}
+
+TEST_F(ut_DebListModel_test, deblistmodel_UT_lastProcessError_failed_with_reason)
+{
+    const QByteArray md5("md5-lastProcessError-failed");
+    m_debListModel->m_operatingPackageMd5 = md5;
+    m_debListModel->m_packageOperateStatus[md5] = Pkg::PackageOperationStatus::Failed;
+    m_debListModel->m_packageFailReason[md5] = "depend not found";
+
+    EXPECT_EQ(QString("depend not found"), m_debListModel->lastProcessError());
+}
+
+TEST_F(ut_DebListModel_test, deblistmodel_UT_lastProcessError_failed_without_reason)
+{
+    const QByteArray md5("md5-lastProcessError-failed-noreason");
+    m_debListModel->m_operatingPackageMd5 = md5;
+    m_debListModel->m_packageOperateStatus[md5] = Pkg::PackageOperationStatus::Failed;
+
+    EXPECT_EQ(QString("failed"), m_debListModel->lastProcessError());
+}
+
 TEST_F(ut_DebListModel_test, deblistmodel_UT_checkSystemVersion_UosEnterprise)
 {
     stub.set(ADDR(Dtk::Core::DSysInfo, uosEditionType), model_uosEditionType_UosEnterprise);


### PR DESCRIPTION
The transaction is deleted right after a successful finish, so decide by the operating package's status instead of reporting "failed".

事务成功结束后即被删除，改为依据操作包状态判断，不再盲目返回"failed"。

Log: 修复lastProcessError在事务删除后误报failed的问题
Influence: 安装成功后DBus调用方不再误报failed，失败时返回真实失败原因。

## Summary by Sourcery

Report the recorded package operation outcome when determining the last process error.

Bug Fixes:
- Return an empty error for successful package operations and the recorded failure reason when available, avoiding false “failed” results after transactions are removed.

Tests:
- Add coverage for missing transactions, successful operations, recorded failure reasons, and failures without a recorded reason.